### PR TITLE
[chore] #4 .gitkeep Target Membership 해제

### DIFF
--- a/Kiero/Kiero.xcodeproj/project.pbxproj
+++ b/Kiero/Kiero.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Application/Info.plist,
+				Network/.gitkeep,
+				Presentation/Common/Components/.gitkeep,
 			);
 			target = 24DF50CA2F0A5173007146AC /* Kiero */;
 		};
@@ -159,7 +161,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = Kiero/Info.plist;
+				INFOPLIST_FILE = Kiero/Application/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -189,7 +191,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = Kiero/Info.plist;
+				INFOPLIST_FILE = Kiero/Application/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";


### PR DESCRIPTION
## 📟 연결된 이슈
closed #4 
<br>

## 🍎 작업 내용
- `.gitkeep`파일을 제거하지 않고 Target Membership 해제해 빌드가 되지 않는 문제를 해결했습니다.
- `Info.plist`의 위치를 수정하였습니다.
<br>

## 💬 리뷰 코멘트
`.gitkeep` 파일 추가 시, 여러 폴더에 적용하려면 Target Membership 설정을 OFF로 설정해주어야 합니다. 