### PR TITLE
[feat] #16 버튼 컴포넌트 구현

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+
 import SnapKit
 import Then
 

--- a/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
@@ -37,7 +37,7 @@ final class CTAButton: UIButton {
         $0.spacing = 10
         $0.alignment = .center
         $0.distribution = .fill
-        $0.isUserInteractionEnabled = false 
+        $0.isUserInteractionEnabled = false
     }
     
     private let iconImageView = UIImageView().then {
@@ -53,6 +53,7 @@ final class CTAButton: UIButton {
         self.style = style
         super.init(frame: .zero)
         setUI()
+        setLayout()
         setStyle()
     }
     
@@ -66,7 +67,9 @@ final class CTAButton: UIButton {
         
         addSubviews(contentStackView)
         contentStackView.addArrangedSubviews(iconImageView, mainLabel)
-        
+    }
+    
+    private func setLayout() {
         self.snp.makeConstraints {
             $0.height.equalTo(50)
         }

--- a/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
@@ -64,8 +64,7 @@ final class CTAButton: UIButton {
         self.clipsToBounds = true
         
         addSubviews(contentStackView)
-        contentStackView.addArrangedSubview(iconImageView)
-        contentStackView.addArrangedSubview(mainLabel)
+        contentStackView.addArrangedSubviews(iconImageView, mainLabel)
         
         self.snp.makeConstraints {
             $0.height.equalTo(50)

--- a/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
@@ -72,6 +72,7 @@ final class CTAButton: UIButton {
     private func setLayout() {
         self.snp.makeConstraints {
             $0.height.equalTo(50)
+            $0.leading.trailing.equalToSuperview().inset(16)
         }
         
         contentStackView.snp.makeConstraints {

--- a/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
@@ -1,0 +1,109 @@
+//
+//  KieroButton.swift
+//  Kiero
+//
+//  Created by Hyunseo Han on 1/8/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class KieroButton: UIButton {
+    private let type: KieroButtonType
+    private let color: KieroButtonColor
+    
+    private let contentStackView = UIStackView().then {
+        $0.isUserInteractionEnabled = false
+        $0.alignment = .center
+        $0.distribution = .fill
+    }
+    
+    private let mainLabel = UILabel().then {
+        $0.setTypo(.title3_16_SB)
+        $0.textAlignment = .center
+    }
+    
+    //large용
+    private let subLabel = UILabel().then {
+        $0.setTypo(.body2_16_R)
+        $0.textAlignment = .center
+        $0.isHidden = true // 이걸 쓰는 이유?
+    }
+    
+    // medium용
+    private let iconImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+        $0.isHidden = true
+    }
+    
+    // MARK: - init
+    
+    init(type: KieroButtonType, color: KieroButtonColor){
+        self.type = type
+        self.color = color
+        super.init(frame: .zero)
+        setupUI()
+        applyStyle()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("에러입니다")
+    }
+    
+    private func setupUI() {
+        self.layer.cornerRadius = 8
+        self.clipsToBounds = true
+        
+        addSubviews(contentStackView)
+        
+        switch type {
+        case .medium:
+            contentStackView.axis = .horizontal
+            contentStackView.spacing = 10 // ?
+            contentStackView.addArrangedSubview(iconImageView)
+            contentStackView.addArrangedSubview(mainLabel)
+            
+            iconImageView.snp.makeConstraints {
+                $0.size.equalTo(16)
+            }
+            
+        case .large:
+            contentStackView.axis = .vertical
+            contentStackView.spacing = 10 // ?
+            contentStackView.addArrangedSubview(subLabel)
+            contentStackView.addArrangedSubview(mainLabel)
+        }
+        
+        // SnapKit Layout
+        self.snp.makeConstraints {
+            $0.height.equalTo(type.height) // Enum에 정의된 높이 사용
+        }
+        
+        contentStackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        
+    }
+    
+    private func applyStyle() {
+        self.backgroundColor = color.backgroundColor
+        self.mainLabel.textColor = color.titleColor
+    }
+    
+    // 여기는 왜 private 안 붙임?: ViewController가 써야 하니까
+    func configure(title: String, subTitle: String? = nil, icon: UIImage? = nil) {
+        mainLabel.text = title
+        
+        if let subTitle = subTitle {
+            subLabel.text = subTitle
+            subLabel.isHidden = false
+        }
+        
+        if let icon = icon {
+            iconImageView.image = icon
+            iconImageView.isHidden = false
+        }
+    }
+}

--- a/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
@@ -1,5 +1,5 @@
 //
-//  KieroButton.swift
+//  CTAButton.swift
 //  Kiero
 //
 //  Created by Hyunseo Han on 1/8/26.
@@ -9,46 +9,54 @@ import UIKit
 import SnapKit
 import Then
 
-final class KieroButton: UIButton {
-    private let type: KieroButtonType
-    private let color: KieroButtonColor
+final class CTAButton: UIButton {
+    enum Style {
+        case main
+        case gray
+        
+        var backgroundColor: UIColor {
+            switch self {
+            case .main: return .main
+            case .gray: return .gray900
+            }
+        }
+        
+        var titleColor: UIColor {
+            switch self {
+            case .main: return .kBlack
+            case .gray: return .white
+            }
+        }
+    }
+    
+    private let style: Style
     
     private let contentStackView = UIStackView().then {
-        $0.isUserInteractionEnabled = false
+        $0.axis = .horizontal
+        $0.spacing = 10
         $0.alignment = .center
         $0.distribution = .fill
+        $0.isUserInteractionEnabled = false 
     }
     
-    private let mainLabel = UILabel().then {
-        $0.setTypo(.title3_16_SB)
-        $0.textAlignment = .center
-    }
-    
-    //large용
-    private let subLabel = UILabel().then {
-        $0.setTypo(.body2_16_R)
-        $0.textAlignment = .center
-        $0.isHidden = true // 이걸 쓰는 이유?
-    }
-    
-    // medium용
     private let iconImageView = UIImageView().then {
         $0.contentMode = .scaleAspectFit
         $0.isHidden = true
     }
     
-    // MARK: - init
+    private let mainLabel = UILabel().then {
+        $0.textAlignment = .center
+    }
     
-    init(type: KieroButtonType, color: KieroButtonColor){
-        self.type = type
-        self.color = color
+    init(style: Style) {
+        self.style = style
         super.init(frame: .zero)
         setupUI()
         applyStyle()
     }
     
     required init?(coder: NSCoder) {
-        fatalError("에러입니다")
+        fatalError("init(coder:) has not been implemented")
     }
     
     private func setupUI() {
@@ -56,54 +64,38 @@ final class KieroButton: UIButton {
         self.clipsToBounds = true
         
         addSubviews(contentStackView)
+        contentStackView.addArrangedSubview(iconImageView)
+        contentStackView.addArrangedSubview(mainLabel)
         
-        switch type {
-        case .medium:
-            contentStackView.axis = .horizontal
-            contentStackView.spacing = 10 // ?
-            contentStackView.addArrangedSubview(iconImageView)
-            contentStackView.addArrangedSubview(mainLabel)
-            
-            iconImageView.snp.makeConstraints {
-                $0.size.equalTo(16)
-            }
-            
-        case .large:
-            contentStackView.axis = .vertical
-            contentStackView.spacing = 10 // ?
-            contentStackView.addArrangedSubview(subLabel)
-            contentStackView.addArrangedSubview(mainLabel)
-        }
-        
-        // SnapKit Layout
         self.snp.makeConstraints {
-            $0.height.equalTo(type.height) // Enum에 정의된 높이 사용
+            $0.height.equalTo(50)
         }
         
         contentStackView.snp.makeConstraints {
             $0.center.equalToSuperview()
         }
         
-        
+        iconImageView.snp.makeConstraints {
+            $0.size.equalTo(24)
+        }
     }
     
     private func applyStyle() {
-        self.backgroundColor = color.backgroundColor
-        self.mainLabel.textColor = color.titleColor
+        self.backgroundColor = style.backgroundColor
+        self.mainLabel.textColor = style.titleColor
+        self.iconImageView.tintColor = style.titleColor
     }
     
-    // 여기는 왜 private 안 붙임?: ViewController가 써야 하니까
-    func configure(title: String, subTitle: String? = nil, icon: UIImage? = nil) {
-        mainLabel.text = title
-        
-        if let subTitle = subTitle {
-            subLabel.text = subTitle
-            subLabel.isHidden = false
-        }
+    // MARK: - Configuration
+    
+    func configure(title: String, icon: UIImage? = nil) {
+        mainLabel.setTypo(.title3_16_SB, text: title)
         
         if let icon = icon {
             iconImageView.image = icon
             iconImageView.isHidden = false
+        } else {
+            iconImageView.isHidden = true
         }
     }
 }

--- a/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
@@ -53,7 +53,7 @@ final class CTAButton: UIButton {
         self.style = style
         super.init(frame: .zero)
         setUI()
-        applyStyle()
+        setStyle()
     }
     
     required init?(coder: NSCoder) {
@@ -80,7 +80,7 @@ final class CTAButton: UIButton {
         }
     }
     
-    private func applyStyle() {
+    private func setStyle() {
         self.backgroundColor = style.backgroundColor
         self.mainLabel.textColor = style.titleColor
         self.iconImageView.tintColor = style.titleColor

--- a/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/CTAButton.swift
@@ -51,7 +51,7 @@ final class CTAButton: UIButton {
     init(style: Style) {
         self.style = style
         super.init(frame: .zero)
-        setupUI()
+        setUI()
         applyStyle()
     }
     
@@ -59,7 +59,7 @@ final class CTAButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func setupUI() {
+    private func setUI() {
         self.layer.cornerRadius = 8
         self.clipsToBounds = true
         

--- a/Kiero/Kiero/Presentation/Common/Components/FireButton.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/FireButton.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+
 import SnapKit
 import Then
 

--- a/Kiero/Kiero/Presentation/Common/Components/FireButton.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/FireButton.swift
@@ -47,16 +47,16 @@ final class FireButton: UIButton {
     
     init() {
         super.init(frame: .zero)
-        setupUI()
+        setUI()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - Setup
+    // MARK: - Set
     
-    private func setupUI() {
+    private func setUI() {
         self.backgroundColor = .gray900
         self.layer.cornerRadius = 8
         self.clipsToBounds = true

--- a/Kiero/Kiero/Presentation/Common/Components/FireButton.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/FireButton.swift
@@ -1,0 +1,91 @@
+//
+//  FireButton.swift
+//  Kiero
+//
+//  Created by Hyunseo Han on 1/9/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class FireButton: UIButton {
+    
+    // MARK: - UI Components
+    
+    private let mainStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 10
+        $0.alignment = .center
+        $0.distribution = .fill
+        $0.isUserInteractionEnabled = false
+    }
+    
+    private let topInfoStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 10
+        $0.alignment = .center
+    }
+    
+    private let fireIconImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+        $0.image = UIImage(named: "ic_fire")?.withRenderingMode(.alwaysTemplate)
+        $0.tintColor = .main
+    }
+    
+    private let countLabel = UILabel().then {
+        $0.textColor = .gray500
+        $0.textAlignment = .center
+    }
+    
+    private let mainLabel = UILabel().then {
+        $0.textColor = .white
+        $0.textAlignment = .center
+    }
+    
+    // MARK: - Init
+    
+    init() {
+        super.init(frame: .zero)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    private func setupUI() {
+        self.backgroundColor = .gray900
+        self.layer.cornerRadius = 8
+        self.clipsToBounds = true
+        
+        addSubview(mainStackView)
+        
+        topInfoStackView.addArrangedSubviews(fireIconImageView, countLabel)
+        mainStackView.addArrangedSubviews(topInfoStackView, mainLabel)
+        
+        self.snp.makeConstraints {
+            $0.height.equalTo(81)
+        }
+        
+        mainStackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
+        fireIconImageView.snp.makeConstraints {
+            $0.size.equalTo(20)
+        }
+    }
+    
+    // MARK: - Configuration
+    
+    func configure(title: String, count: Int) {
+        mainLabel.setTypo(.title3_16_SB, text: title)
+        mainLabel.textColor = .white
+        
+        countLabel.setTypo(.body2_16_R, text: "\(count) 개")
+        countLabel.textColor = .gray500
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
closed #16 
<br>

## 🍎 작업 내용
- 프로젝트 전역에서 쓰일 CTA버튼 컴포넌트를 제작하였습니다.
- 오늘의 여정에서 사용되는 불조각 버튼 컴포넌트를 제작하였습니다. 
<br>

## 📸 스크린샷
| 기능/화면 | CTAButton 컴포넌트 | FireButton 컴포넌트 |
|:---------:|:-------------:|:-------------:|
| 화면 | <img width="250" alt="image" src="https://github.com/user-attachments/assets/4a0c515d-e1cd-4e36-9cf4-f47e19bc0c24" /> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/9d648a25-5790-4fd3-b1c6-c1d6df4ff799" /> | 
<br>

## 💬 리뷰 코멘트
### ✨스타일링 및 데이터 바인딩 로직
- **폰트 스타일 (`setTypo`) 적용**
  - `UILabel`의 `text` 프로퍼티에 직접 값을 대입할 경우 자간/행간 등 `TypoStyle`이 초기화됩니다.
  - 이를 방지하기 위해 반드시 **`configure` 메서드 내부에서 `setTypo(..., text: ...)`를 호출**하여 스타일과 텍스트를 동시에 적용하도록 구현했습니다.
  
- **색상(Color) 재적용**
  - `setTypo` 호출 시 내부적으로 `NSAttributedString`이 덮어씌워지며 기존 `textColor` 설정이 풀리는 현상이 있습니다.
  - 따라서 `configure` 내부에서 텍스트 설정 후 **`.textColor`를 명시적으로 다시 지정**해주는 로직을 추가했습니다.

- **레이아웃 확장성**
  - **CTAButton**: `icon` 파라미터가 `nil`일 경우 이미지뷰를 `isHidden = true` 처리하여, 텍스트가 자동으로 **중앙 정렬**되도록 구현했습니다.
  - **FireButton**: `count` 값에 따라 상단 스택(아이콘+개수)의 노출 여부를 제어하며, 추후 개수에 따른 아이콘 색상 변경 로직 확장이 가능하도록 설계했습니다.

### 💡사용 방법
```swift
// 1. 메인 스타일 (텍스트)
let confirmButton = CTAButton(style: .main).then {
    $0.configure(title: "확인")
}

// 2. 그레이 스타일 (아이콘 + 텍스트)
let cameraButton = CTAButton(style: .gray).then {
    $0.configure(title: "사진 찍기", icon: UIImage(named: "ic_camera"))
}
```

```swift
// 불 조각 버튼
let fireButton = FireButton().then {
    $0.configure(title: "불 조각 건네주기", count: 7)
}
```