### PR TITLE
[feat] #25 소원의 우물 wishBox 컴포넌트 구현

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/WishWell/WishBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/WishWell/WishBox.swift
@@ -1,0 +1,102 @@
+//
+//  WishBox.swift
+//  Kiero
+//
+//  Created by 정윤아 on 1/9/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class WishBox: UIView {
+    
+    // MARK: - Properties
+    
+    var onTap: (() -> Void)?
+    
+    // MARK: - UI Components
+    
+    private let titleLabel = UILabel().then {
+        $0.textColor = .white
+        $0.numberOfLines = 1
+    }
+    
+    private let rewardLabel = UILabel().then {
+        $0.textColor = .gray400
+        $0.numberOfLines = 1
+    }
+    
+    private let titleStack = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .leading
+        $0.spacing = 4
+    }
+    
+    private let completeButton = UIButton().then {
+        $0.titleLabel?.font = .title4_14_SB
+        $0.setTitle("소원빌기", for: .normal)
+        $0.setTitleColor(.kBlack, for: .normal)
+        $0.layer.cornerRadius = 8
+        $0.backgroundColor = .white
+    }
+    
+    private let wishBox = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .fill
+        $0.spacing = 14
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setStyle()
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    private func setStyle() {
+        layer.cornerRadius = 10
+        layer.masksToBounds = true
+        backgroundColor = .gray900
+    }
+    
+    private func setUI() {
+        addSubview(wishBox)
+        titleStack.addArrangedSubviews(rewardLabel, titleLabel)
+        wishBox.addArrangedSubviews(titleStack, completeButton)
+        
+        completeButton.addTarget(self, action: #selector(didTapComplete), for: .touchUpInside)
+    }
+    
+    private func setLayout() {
+        wishBox.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(12)
+            $0.verticalEdges.equalToSuperview().inset(13)
+        }
+        
+        completeButton.snp.makeConstraints {
+            $0.height.equalTo(40)
+            $0.width.equalTo(139)
+        }
+    }
+    
+    // MARK: - Action
+    
+    @objc private func didTapComplete() {
+        onTap?()
+    }
+    
+    // MARK: - Configuration
+    
+    func configure(name: String, price: Int) {
+        titleLabel.setTypo(.body3_14_R, text: name)
+        rewardLabel.setTypo(.body4_12_R, text: "금화 \(price) 개")
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
closed #25
<br>

## 🍎 작업 내용
소원의 우물 뷰에 사용되는 wishBox 컴포넌트를 구현하였습니다. 
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 화면 | <img width="250" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-09 at 22 15 54" src="https://github.com/user-attachments/assets/eff8dfb7-f3af-4980-a3aa-135b61d4143a" />|
<br>

## 💬 리뷰 코멘트
🧩 사용 예시
1️⃣ 생성 및 설정
```swift
let wishBox = WishBox()
wishBox.configure(
    name: "매일 물 2L 마시기",
    price: 50
)

wishBox.onTap = {
    print("WishBox complete button tapped")
}
```
2️⃣ 레이아웃 설정
WishBox 내부에서는 패딩과 버튼 레이아웃만 관리하며,카드 전체 크기는 ViewController 또는 Cell에서 설정합니다.
```swift
view.addSubview(wishBox)

wishBox.snp.makeConstraints {
    $0.width.equalTo(165)
    $0.height.equalTo(119)
    $0.center.equalToSuperview()
}
```

