### PR TITLE
[feat] #28 SpeechField 컴포넌트 구현

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
@@ -1,0 +1,120 @@
+//
+//  SpeechField.swift
+//  Kiero
+//
+//  Created by Hyunseo Han on 1/9/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class SpeechField: UIView {
+    
+    // MARK: - UI Components
+    
+    private let nameContainerView = UIView()
+    
+    private let containerView = UIView()
+    
+    private let nameLabel = UILabel().then {
+        $0.textAlignment = .center
+    }
+    
+    private let contentStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 10
+        $0.alignment = .leading
+        $0.distribution = .fill
+    }
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setStyle()
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    private func setStyle() {
+        nameContainerView.backgroundColor = .main
+        nameContainerView.layer.cornerRadius = 4
+        nameContainerView.clipsToBounds = true
+        
+        containerView.backgroundColor = .gray900
+        containerView.layer.cornerRadius = 15
+        containerView.clipsToBounds = true
+        
+        nameLabel.textColor = .kBlack
+        nameLabel.font = .body5_10_R
+        
+        contentStackView.backgroundColor = .clear
+    }
+    
+    private func setUI() {
+        addSubviews(containerView, nameContainerView)
+        nameContainerView.addSubview(nameLabel)
+        containerView.addSubview(contentStackView)
+    }
+    
+    private func setLayout() {
+        nameContainerView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.height.equalTo(21)
+            $0.width.greaterThanOrEqualTo(43)
+            $0.leading.equalTo(containerView.snp.leading).offset(18)
+        }
+        
+        nameLabel.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 2, left: 10, bottom: 2, right: 10))
+        }
+        
+        containerView.snp.makeConstraints {
+            $0.top.equalTo(nameContainerView.snp.bottom).offset(-2)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview()
+        }
+        
+        contentStackView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(24)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(27)
+        }
+    }
+    
+    // MARK: - Configuration
+    
+    func configure(name: String, lines: [String], highlightKeywords: [String] = []) {
+        nameLabel.text = name
+        contentStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        
+        for line in lines {
+            let label = UILabel().then {
+                $0.numberOfLines = 0
+                $0.textColor = .gray300
+            }
+            
+            label.setTypo(.body3_14_R, text: line)
+            
+            if let currentAttr = label.attributedText{
+                let mutableString = NSMutableAttributedString(attributedString: currentAttr)
+                for keyword in highlightKeywords {
+                    let range = (line as NSString).range(of: keyword)
+                    if range.location != NSNotFound {
+                        mutableString.addAttribute(.foregroundColor, value: UIColor.main, range: range)
+                    }
+                }
+                label.attributedText = mutableString
+            }
+            contentStackView.addArrangedSubview(label)
+        }
+    }
+}

--- a/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
@@ -29,7 +29,7 @@ final class SpeechField: UIView {
         $0.distribution = .fill
     }
     
-    // MARK: - Init
+    // MARK: - Life Cycle
     
     override init(frame: CGRect) {
         super.init(frame: .zero)
@@ -42,7 +42,7 @@ final class SpeechField: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - Setup
+    // MARK: - Setup Methods
     
     private func setStyle() {
         nameContainerView.backgroundColor = .main


### PR DESCRIPTION
## 📟 연결된 이슈
closed #28 
<br>

## 🍎 작업 내용
- SpeechField 컴포넌트 구현: 꾸비의 대사를 보여주는 말풍선 UI를 제작했습니다.
- configure 메서드에서 키워드의 색상을 변경하는 로직을 구현했습니다.
- UILabel+의 setTypo를 통해 자간/행간을 먼저 적용한 뒤, NSMutableAttributedString으로 색상 속성만 덧입혀 디자인 시스템이 깨지지 않도록 구현했습니다.
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 기능1 | <img width="250" alt="image" src="https://github.com/user-attachments/assets/9e6d2c6d-eafd-4149-af21-bfd8a821ccb4" /> | 
<br>

## 💬 리뷰 코멘트
configure 메서드를 잘 만들었는지 모르겟어요.. 리뷰 부탁드립니당