### PR TITLE
[feat] #22 PagingHeader 구현

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/PagingHeader.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/PagingHeader.swift
@@ -1,0 +1,97 @@
+//
+//  PagingHeader.swift
+//  Kiero
+//
+//  Created by 신혜연 on 1/10/26.
+//
+
+import UIKit
+import SnapKit
+
+import Then
+
+final class PagingHeader: UIView {
+    
+    // MARK: - Properties
+    
+    var onLeftButtonTapped: (() -> Void)?
+    var onRightButtonTapped: (() -> Void)?
+    
+    // MARK: - UI Components
+    
+    private let titleLabel = UILabel().then {
+        $0.font = .title4_14_SB
+        $0.textColor = .white
+        $0.textAlignment = .center
+    }
+    
+    private lazy var leftButton = UIButton().then {
+        $0.setImage(UIImage(resource: .icLeft), for: .normal)
+        $0.tintColor = .white
+        $0.addTarget(self, action: #selector(leftTapped), for: .touchUpInside)
+    }
+    
+    private lazy var rightButton = UIButton().then {
+        $0.setImage(UIImage(resource: .icRight), for: .normal)
+        $0.tintColor = .white
+        $0.addTarget(self, action: #selector(rightTapped), for: .touchUpInside)
+    }
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setStyle()
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) { nil }
+    
+    // MARK: - Setup Methods
+    
+    private func setStyle() {
+        self.backgroundColor = .clear
+    }
+    
+    private func setUI() {
+        addSubviews(leftButton, titleLabel, rightButton)
+    }
+    
+    private func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.lessThanOrEqualTo(200)
+        }
+        
+        leftButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.centerX.equalToSuperview().offset(-84)
+            $0.size.equalTo(24)
+        }
+        
+        rightButton.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.centerX.equalToSuperview().offset(84)
+            $0.size.equalTo(24)
+        }
+    }
+    
+    // MARK: - Public Methods
+    
+    func configure(title: String, isLeftEnabled: Bool, isRightEnabled: Bool) {
+        titleLabel.text = title
+        
+        leftButton.isEnabled = isLeftEnabled
+        leftButton.alpha = isLeftEnabled ? 1.0 : 0.2
+        leftButton.tintColor = .white
+        
+        rightButton.isEnabled = isRightEnabled
+        rightButton.alpha = isRightEnabled ? 1.0 : 0.2
+        rightButton.tintColor = .white
+    }
+    
+    @objc private func leftTapped() { onLeftButtonTapped?() }
+    @objc private func rightTapped() { onRightButtonTapped?() }
+}

--- a/Kiero/Kiero/Presentation/Common/Components/PagingHeader.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/PagingHeader.swift
@@ -6,8 +6,8 @@
 //
 
 import UIKit
-import SnapKit
 
+import SnapKit
 import Then
 
 final class PagingHeader: UIView {


### PR DESCRIPTION
## 📟 연결된 이슈
closed #22 
<br>

## 🍎 작업 내용
- 스케줄 관리(주차 이동) 및 미션(단계 이동) 등 다양한 화면에서 공용으로 사용할 수 있는 PagingHeader를 구현했습니다. 중앙 라벨의 텍스트 길이에 관계없이 좌우 화살표 버튼의 위치가 고정되도록 centerX 기반의 오토레이아웃을 적용했습니다.
- configure 메서드를 통해 좌우 버튼의 활성화/비활성화 상태를 주입받고 있습니다.
- 클로저(`onLeftButtonTapped`, `onRightButtonTapped`)를 통해 액션을 지정할 수 있습니다.

pagingHeader를 선언 후 configure 메서드로 활성화 상태 로직을 세팅하여 사용합니다.
```
pagingHeader.configure(
    title: "12.8(월) - 12.14(일)", 
    isLeftEnabled: true, 
    isRightEnabled: true
)
```
<br>

## 📸 스크린샷
| 기능/화면 | PagingHeader |
|:---------:|:-------------:|
| 기능 | <img src="https://github.com/user-attachments/assets/459d36cf-2f34-4d3d-aaaf-3ee6c5bb7394" width="250"> |
<br>

## 💬 리뷰 코멘트
궁금한 점이 있다면 코멘트 남겨주세요 !
