### PR TITLE
[feat] #29 ChipItem 컴포넌트 구현

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/ChipItem.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/ChipItem.swift
@@ -1,0 +1,159 @@
+//
+//  ChipItem.swift
+//  Kiero
+//
+//  Created by Hyunseo Han on 1/10/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ChipItem: UIView {
+    
+    // MARK: State
+    
+    enum ChipStyle {
+        case currentCoinChip
+        case usedCoinChip
+        case inProgressChip
+        case highlightChip
+        case completedChip
+        
+        var height: CGFloat {
+            switch self {
+            case .usedCoinChip:
+                return 24
+            default:
+                return 28
+            }
+        }
+        
+        var iconSize: CGSize {
+            switch self {
+            case .usedCoinChip:
+                return CGSize(width: 16, height: 16)
+                
+            case .currentCoinChip:
+                return CGSize(width: 20, height: 20)
+                
+            case .inProgressChip, .highlightChip, .completedChip:
+                return CGSize(width: 19, height: 23)
+            }
+        }
+        
+        var font: UIFont {
+            switch self {
+            case .usedCoinChip:
+                return .body5_10_R
+            default:
+                return .body3_14_R
+            }
+        }
+    }
+    
+    // MARK: - UI Components
+    
+    private let containerView = UIView()
+    
+    private let contentStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 6
+        $0.alignment = .center
+        $0.distribution = .fill
+    }
+    
+    private let iconImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    private let textLabel = UILabel().then {
+        $0.textAlignment = .center
+    }
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    
+    private func setStyle (_ style: ChipStyle) {
+        containerView.layer.borderWidth = 1
+        containerView.layer.shadowOpacity = 0
+        containerView.backgroundColor = UIColor.gray900
+        
+        switch style {
+        case .usedCoinChip:
+            containerView.layer.borderColor = UIColor.gray500.cgColor
+            containerView.backgroundColor = .gray900
+            textLabel.textColor = .gray500
+            iconImageView.alpha = 0.5
+            
+        case .highlightChip:
+            containerView.layer.borderColor = UIColor.main.cgColor
+            textLabel.textColor = UIColor.main
+            iconImageView.alpha = 1.0
+            containerView.layer.shadowColor = UIColor.main.cgColor
+            containerView.layer.shadowOffset = .zero
+            containerView.layer.shadowRadius = 4
+            containerView.layer.shadowOpacity = 1
+            containerView.clipsToBounds = false
+            
+        default:
+            containerView.layer.borderColor = UIColor.gray100.cgColor
+            textLabel.textColor = .gray100
+            iconImageView.alpha = 1.0
+        }
+    }
+    
+    private func setUI() {
+        addSubview(containerView)
+        containerView.addSubview(contentStackView)
+        contentStackView.addArrangedSubviews(iconImageView, textLabel)
+    }
+    
+    private func setLayout() {
+        containerView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        contentStackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(12)
+        }
+        
+        iconImageView.snp.makeConstraints {
+            $0.size.equalTo(20)
+        }
+    }
+    
+    func configure(style: ChipStyle, icon: UIImage, text: String) {
+        textLabel.text = text
+        textLabel.font = style.font
+        
+        iconImageView.image = icon
+        iconImageView.isHidden = false
+        
+        iconImageView.snp.remakeConstraints {
+            $0.size.equalTo(style.iconSize)
+        }
+        
+        setStyle(style)
+        
+        containerView.layer.cornerRadius = style.height / 2
+        
+        containerView.snp.remakeConstraints {
+            $0.edges.equalToSuperview()
+            $0.height.equalTo(style.height)
+        }
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
closed #29 
<br>

## 🍎 작업 내용
- 앱 전반에서 사용되는 ChipItem 컴포넌트를 제작했습니다.
- 자녀 - 오늘의 레시피 - 불피우기 완료 후 뷰에 들어가는 chip까지 고려하여, ChipStyle Enum을 통해 5가지 상태를 관리합니다. 
    - currentCoin: 현재 보유 코인
    - usedCoin: 사용된 코인
    - inProgress: 오늘의 조각을 모으는 중인 상태
    - highlight: 오늘의 조각을 모두 모은 활성화 상태 
    - completed: 불조각 건네준 후 완료 상태
- 동적 레이아웃 처리: 상태에 따라 높이, 아이콘 크기, 폰트가 자동으로 변경되도록 구현했습니다.
<br>

## 📸 스크린샷
| ChipItem 컴포넌트 |
|:---------:|
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/0eab6fef-0643-4937-a321-1808f089225f" /> | 
<br>

## 💬 리뷰 코멘트
usedCoinChip 상태만 크기와 아이콘 사이즈가 달라서 컴포넌트를 분리할지 고민했는데요..! 
결국 아이콘+텍스트가 나란히 있는 구조는 동일하다고 판단하여 파일을 분리하지 않고 remakeConstraints로 제약조건을 재설정하는 방식으로 구현했습니다. 이 방식이 효율적인지 확인 부탁드립니다!
<br>

## 💡사용 방법
```swift
// 1. 컴포넌트 선언
private let chipView = ChipItem()

// 2. 이미지 준비
let coinImg = UIImage(resource: .ic3DCoin)
let fireImg = UIImage(resource: .ic3DBluestone)

// 3 서버 데이터 바인딩
let current = 1
let total = 7
chipView.configure(style: .inProgressChip, icon: fireImg, text: "\(current) / \(total) 개")