### PR TITLE
[feat] #26 dialog 컴포넌트 구현

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/ConfirmBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/ConfirmBox.swift
@@ -45,7 +45,7 @@ final class ConfirmBox: UIView {
     // MARK: - UI Component
     
     private let characterImage = UIImageView().then {
-        $0.image = UIImage(named: "img_goblin_smile")
+        $0.image = UIImage(resource: .imgGoblinSmile)
         $0.contentMode = .scaleAspectFit
     }
     
@@ -144,5 +144,4 @@ final class ConfirmBox: UIView {
     private func didTapButton() {
         onTapButton?()
     }
-    
 }

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/ConfirmBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/ConfirmBox.swift
@@ -1,0 +1,140 @@
+//
+//  ConfirmBox.swift
+//  Kiero
+//
+//  Created by 정윤아 on 1/10/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ConfirmBox: UIView {
+    
+    // MARK: - State
+    
+    enum State {
+        case coinMission(count: Int)
+        
+        case wishWell(wish: String)
+        
+        var message: String {
+            switch self {
+            case .coinMission(let count):
+                return "금나와라 뚝딱!\n금화 \(count)개를 만들었어!"
+            case .wishWell(let wish):
+                return wish + "를\n획득했어요!"
+            }
+        }
+        
+        var buttonTitle: String {
+            switch self {
+            case . coinMission:
+                return "받기"
+            case .wishWell:
+                return "확인"
+            }
+        }
+    }
+    
+    // MARK: - Properties
+    
+    var onTapButton: (() -> Void)?
+    
+    // MARK: - Set UI
+    
+    private let characterImage = UIImageView().then {
+        $0.image = UIImage(named: "img_goblin_smile")
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    private let messageLabel = UILabel().then {
+        $0.textAlignment = .center
+        $0.numberOfLines = 2
+        $0.textColor = .gray100
+        $0.setTypo(.body3_14_R)
+    }
+    
+    private let actionButton = UIButton().then {
+        $0.titleLabel?.font = .title3_16_SB
+        $0.setTitleColor(.kBlack, for: .normal)
+        $0.backgroundColor = .main
+        $0.layer.cornerRadius = 10
+        $0.clipsToBounds = true
+    }
+    
+    private let titleStack = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .center
+        $0.spacing = 3
+    }
+    
+    private let container = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .center
+        $0.spacing = 24
+        
+        $0.isLayoutMarginsRelativeArrangement = true
+        $0.layoutMargins = UIEdgeInsets(top: 44, left: 16, bottom: 16, right: 16)
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+        setStyle()
+        setLayout()
+        bind()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setUI() {
+        addSubviews(container)
+        titleStack.addArrangedSubviews(characterImage, messageLabel)
+        container.addArrangedSubviews(titleStack, actionButton)
+    }
+    
+    private func setStyle() {
+        backgroundColor = .gray900
+        layer.cornerRadius = 16
+    }
+    
+    private func setLayout() {
+        container.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalTo(343)
+            $0.height.equalTo(248)
+        }
+        
+        characterImage.snp.makeConstraints {
+            $0.width.equalTo(63)
+            $0.height.equalTo(71)
+        }
+        
+        actionButton.snp.makeConstraints {
+            $0.width.equalTo(311)
+            $0.height.equalTo(49)
+        }
+    }
+    
+    func configure(state: State) {
+        messageLabel.text = state.message
+        actionButton.setTitle(state.buttonTitle, for: .normal)
+    }
+    
+    private func bind() {
+        actionButton.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
+    }
+    
+    @objc
+    private func didTapButton() {
+        onTapButton?()
+    }
+    
+    
+    
+    
+}

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/ConfirmBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/ConfirmBox.swift
@@ -42,7 +42,7 @@ final class ConfirmBox: UIView {
     
     var onTapButton: (() -> Void)?
     
-    // MARK: - Set UI
+    // MARK: - UI Component
     
     private let characterImage = UIImageView().then {
         $0.image = UIImage(named: "img_goblin_smile")
@@ -79,10 +79,13 @@ final class ConfirmBox: UIView {
         $0.layoutMargins = UIEdgeInsets(top: 44, left: 16, bottom: 16, right: 16)
     }
     
+    // MARK: Life Cycle
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setUI()
+        
         setStyle()
+        setUI()
         setLayout()
         bind()
     }
@@ -91,15 +94,17 @@ final class ConfirmBox: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func setUI() {
-        addSubviews(container)
-        titleStack.addArrangedSubviews(characterImage, messageLabel)
-        container.addArrangedSubviews(titleStack, actionButton)
-    }
+    // MARK: Setup Methods
     
     private func setStyle() {
         backgroundColor = .gray900
         layer.cornerRadius = 16
+    }
+    
+    private func setUI() {
+        addSubviews(container)
+        titleStack.addArrangedSubviews(characterImage, messageLabel)
+        container.addArrangedSubviews(titleStack, actionButton)
     }
     
     private func setLayout() {
@@ -120,21 +125,24 @@ final class ConfirmBox: UIView {
         }
     }
     
+    // MARK: Configure
+    
     func configure(state: State) {
         messageLabel.text = state.message
         actionButton.setTitle(state.buttonTitle, for: .normal)
     }
     
+    // MARK: Bind
+    
     private func bind() {
         actionButton.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
     }
+    
+    // MARK: Action
     
     @objc
     private func didTapButton() {
         onTapButton?()
     }
-    
-    
-    
     
 }

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -61,7 +61,6 @@ final class DialogBox: UIView {
         
         var cancelButtonTitle: String { "취소" }
         var confirmButtonTitle: String { "확인" }
-        
     }
     
     // MARK: - Properties
@@ -73,7 +72,7 @@ final class DialogBox: UIView {
     // MARK: - UI Conponents
     
     private let closeButton = UIButton().then {
-        $0.setImage(UIImage(named: "ic_close"), for: .normal)
+        $0.setImage(UIImage(resource: .icClose), for: .normal)
     }
     
     private let titleLabel = UILabel().then {
@@ -89,7 +88,7 @@ final class DialogBox: UIView {
     }
     
     private let coinIcon = UIImageView().then {
-        $0.image = UIImage(named: "ic_3d_coin")
+        $0.image = UIImage(resource: .ic3DCoin)
         $0.contentMode = .scaleAspectFit
     }
     
@@ -163,15 +162,15 @@ final class DialogBox: UIView {
         contentStack.addArrangedSubviews(titleLabel, coinStack, messageLabel)
         buttonStack.addArrangedSubviews(cancelButton, confirmButton)
         container.addArrangedSubviews(contentStack, buttonStack)
+        
+        container.isLayoutMarginsRelativeArrangement = true
+        container.layoutMargins = UIEdgeInsets(top: 44, left: 16, bottom: 16, right: 16)
     }
     
     private func setStyle() {
         backgroundColor = .gray900
         layer.cornerRadius = 16
         clipsToBounds = true
-        
-        container.isLayoutMarginsRelativeArrangement = true
-        container.layoutMargins = UIEdgeInsets(top: 44, left: 16, bottom: 16, right: 16)
     }
     
     private func setLayout() {
@@ -243,5 +242,4 @@ final class DialogBox: UIView {
     private func didTapCancel() { onTapCancel?() }
     @objc
     private func didTapConfirm() { onTapConfirm?() }
-    
 }

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -1,0 +1,15 @@
+//
+//  DialogBox.swift
+//  Kiero
+//
+//  Created by 정윤아 on 1/9/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class DialogBox: UIView {
+    //TODO: 구현하기
+}

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -11,5 +11,226 @@ import SnapKit
 import Then
 
 final class DialogBox: UIView {
-    //TODO: 구현하기
+    
+    // MARK: - State
+    
+    enum State {
+        case missionComplete(title: String)
+        case logout
+        case wishWell(title: String, coin: String)
+        
+        var title: String {
+            switch self {
+            case .missionComplete(let title):
+                return "["+title+"]"
+            case .logout:
+                return "로그아웃"
+            case .wishWell(let title, _):
+                return title
+            }
+        }
+        
+        var message: String {
+            switch self {
+            case .missionComplete:
+                return "미션을 완료했다면\n아래 버튼을 눌러줘"
+            case .logout:
+                return "로그아웃 하시겠습니까?"
+            case .wishWell:
+                return "금화를 사용해 소원을 빌까?"
+            }
+        }
+        
+        var coinText: String? {
+            switch self {
+            case .wishWell(_, let coin):
+                return "\(coin)개"
+            default:
+                return nil
+            }
+        }
+        
+        var cancelButtonTitle: String { "취소" }
+        var confirmButtonTitle: String { "확인" }
+        
+    }
+    
+    // MARK: - Properties
+    
+    var onTapClose: (() -> Void)?
+    var onTapCancel: (() -> Void)?
+    var onTapConfirm: (() -> Void)?
+    
+    // MARK: - UI Conponents
+    
+    private let closeButton = UIButton().then {
+        $0.setImage(UIImage(named: "ic_close"), for: .normal)
+    }
+    
+    private let titleLabel = UILabel().then {
+        $0.textAlignment = .center
+        $0.textColor = .white
+    }
+    
+    private let coinStack = UIStackView().then {
+        $0.axis = .horizontal
+        $0.alignment = .center
+        $0.spacing = 10
+        $0.isHidden = true
+    }
+    
+    private let coinIcon = UIImageView().then {
+        $0.image = UIImage(named: "ic_3d_coin")
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    private let coinLabel = UILabel().then {
+        $0.textAlignment = .center
+        $0.textColor = .main
+    }
+    
+    private let messageLabel = UILabel().then {
+        $0.textAlignment = .center
+        $0.textColor = .white
+        $0.numberOfLines = 2
+    }
+    
+    private let contentStack = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .center
+        $0.spacing = 0
+    }
+    
+    private let cancelButton = UIButton().then {
+        $0.titleLabel?.font = .title3_16_SB
+        $0.setTitleColor(.white, for: .normal)
+        $0.backgroundColor = .gray800
+        $0.layer.cornerRadius = 8
+        $0.clipsToBounds = true
+    }
+    
+    private let confirmButton = UIButton().then {
+        $0.titleLabel?.font = .title3_16_SB
+        $0.setTitleColor(.kBlack, for: .normal)
+        $0.backgroundColor = .main
+        $0.layer.cornerRadius = 8
+        $0.clipsToBounds = true
+    }
+    
+    private let buttonStack = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 16
+        $0.distribution = .fillEqually
+        $0.alignment = .fill
+    }
+    
+    private let container = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .fill
+        $0.spacing = 24
+    }
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setUI()
+        setStyle()
+        setLayout()
+        bind()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup Method
+    
+    private func setUI() {
+        addSubviews(container, closeButton)
+        
+        coinStack.addArrangedSubviews(coinIcon, coinLabel)
+        contentStack.addArrangedSubviews(titleLabel, coinStack, messageLabel)
+        buttonStack.addArrangedSubviews(cancelButton, confirmButton)
+        container.addArrangedSubviews(contentStack, buttonStack)
+    }
+    
+    private func setStyle() {
+        backgroundColor = .gray900
+        layer.cornerRadius = 16
+        clipsToBounds = true
+        
+        container.isLayoutMarginsRelativeArrangement = true
+        container.layoutMargins = UIEdgeInsets(top: 44, left: 16, bottom: 16, right: 16)
+    }
+    
+    private func setLayout() {
+        container.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        closeButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(16)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.size.equalTo(24)
+        }
+        
+        coinIcon.snp.makeConstraints {
+            $0.size.equalTo(18)
+        }
+        
+        cancelButton.snp.makeConstraints {
+            $0.height.equalTo(49)
+        }
+        
+        confirmButton.snp.makeConstraints {
+            $0.height.equalTo(49)
+        }
+        
+        messageLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+        messageLabel.setContentHuggingPriority(.required, for: .vertical)
+    }
+    
+    // MARK: - Bind
+    
+    private func bind() {
+        closeButton.addTarget(self, action: #selector(didTapClose), for: .touchUpInside)
+        cancelButton.addTarget(self, action: #selector(didTapCancel), for: .touchUpInside)
+        confirmButton.addTarget(self, action: #selector(didTapConfirm), for: .touchUpInside)
+    }
+    
+    // MARK: - Configure
+    
+    func configure(state: State) {
+        titleLabel.setTypo(.title2_20_SB, text: state.title)
+        messageLabel.setTypo(.body3_14_R, text: state.message)
+        coinLabel.setTypo(.title4_14_SB, text: state.coinText)
+        
+        cancelButton.setTitle(state.cancelButtonTitle, for: .normal)
+        confirmButton.setTitle(state.confirmButtonTitle, for: .normal)
+        
+        if let coin = state.coinText {
+            coinStack.isHidden = false
+            coinLabel.text = coin
+            
+            contentStack.setCustomSpacing(4, after: titleLabel)
+            contentStack.setCustomSpacing(15, after: coinStack)
+        } else {
+            coinStack.isHidden = true
+            coinLabel.text = nil
+            
+            contentStack.setCustomSpacing(15, after: titleLabel)
+        }
+    }
+    
+    // MARK: - Actions
+    
+    @objc
+    private func didTapClose() { onTapClose?() }
+    @objc
+    private func didTapCancel() { onTapCancel?() }
+    @objc
+    private func didTapConfirm() { onTapConfirm?() }
+    
 }

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -50,6 +50,15 @@ final class DialogBox: UIView {
             }
         }
         
+        var isCloseButtonHidden: Bool {
+            switch self {
+            case .logout:
+                return true
+            default:
+                return false
+            }
+        }
+        
         var cancelButtonTitle: String { "취소" }
         var confirmButtonTitle: String { "확인" }
         
@@ -209,6 +218,8 @@ final class DialogBox: UIView {
         
         cancelButton.setTitle(state.cancelButtonTitle, for: .normal)
         confirmButton.setTitle(state.confirmButtonTitle, for: .normal)
+        
+        closeButton.isHidden = state.isCloseButtonHidden
         
         if let coin = state.coinText {
             coinStack.isHidden = false


### PR DESCRIPTION
## 📟 연결된 이슈
closed #26
<br>

## 🍎 작업 내용
dialog 컴포넌트를 구현하였습니다. 
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 화면2 |
|:---------:|:-------------:|:-------------:|
| 화면 | <img width="250" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-10 at 01 51 47" src="https://github.com/user-attachments/assets/f58552d5-5419-434d-9b08-46ae99bb4d88" /> |<img width="250" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-11 at 04 00 16" src="https://github.com/user-attachments/assets/20e2a8e7-ed6c-4e5c-b866-db59e76e5dbd" />|
<br>

## 💬 리뷰 코멘트
- 사용 방법
✅ 컴포넌트 생성 및 설정
상황에 맞는 state를 주입하여 뷰를 구성합니다.
```swift
let dialogBox = DialogBox()
dialogBox.configure(state: .missionComplete(title: "설거지하기"))
dialogBox.configure(state: .logout)
dialogBox.configure(state: .wishWell(title: "게임 30분 추가", coin: "150"))
```
✅ 액션 처리
클로저를 통해 각 버튼이 눌렸을 때의 동작을 정의합니다.
```swift
dialogBox.onTapConfirm = {print("확인 버튼이 눌렸습니다.")}
dialogBox.onTapCancel = {print("취소 버튼이 눌렸습니다.")}
dialogBox.onTapClose = {print("닫기(X) 버튼이 눌렸습니다.")}
```
✅ 레이아웃 배치
너비(width)를 지정하면 내부 컨텐츠 양에 따라 높이가 자동으로 결정됩니다.
```swift
view.addSubview(dialogBox)
dialogBox.snp.makeConstraints {
    $0.center.equalToSuperview()
    $0.width.equalTo(327) // 디자인 가이드에 따른 너비 고정
}
```

- 고민한 점 
1. 
```swift
container.isLayoutMarginsRelativeArrangement = true
container.layoutMargins = UIEdgeInsets(top: 44, left: 16, bottom: 16, right: 16)
```
컨테이너 내부의 여백을 직접 설정하는 코드인데 이 친구를 setStyle에 넣어야할지 setLayout에 넣어야 할지 모르겠습니당......
2. 
디자인 팀으로 부터 닫는 버튼에 대한 답을 듣지는 못했는데요 로그아웃 창에는 또 버튼이 없더라고요 근데 만약 있으면 다 필요할 것 같아서 일단 일괄적으로 넣어두었습니당

- 어려웠던 점
stackView는 원하는 요소들을 묶어서 다룰 수 있다는 점이 정말 좋은데 자꾸 지맘대로 배열되고 막 space 생기고 해서 너무 어려워요.......