### PR TITLE
[feat] #36 Toast 컴포넌트 구현

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/Toast.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Toast.swift
@@ -1,0 +1,113 @@
+//
+//  Toast.swift
+//  Kiero
+//
+//  Created by Hyunseo Han on 1/11/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class Toast {
+        
+    static func show(message: String) {
+        let windowScene: UIWindowScene? = UIApplication.shared.connectedScenes.first as? UIWindowScene
+        
+        guard let window: UIWindow = windowScene?.windows.first(where: { $0.isKeyWindow }) else {
+            return
+        }
+        
+        let toastView: ToastView = ToastView()
+        
+        toastView.configure(message: message)
+        
+        window.addSubview(toastView)
+        
+        toastView.snp.makeConstraints {
+            $0.bottom.equalTo(window.safeAreaLayoutGuide).inset(31)
+            $0.leading.trailing.equalToSuperview().inset(16)
+        }
+        
+        self.animate(view: toastView)
+    }
+        
+    private static func animate(view: UIView) {
+        UIView.animate(
+            withDuration: 0.2,
+            delay: 0.0,
+            options: .curveEaseIn,
+            animations: {
+                view.alpha = 1.0
+            },
+            completion: { _ in
+                UIView.animate(
+                    withDuration: 0.2,
+                    delay: 2.0,
+                    options: .curveEaseOut,
+                    animations: {
+                        view.alpha = 0.0
+                    },
+                    completion: { _ in
+                        view.removeFromSuperview()
+                    }
+                )
+            }
+        )
+    }
+}
+
+private final class ToastView: UIView {
+    
+    // MARK: - UI Components
+    
+    private let messageLabel: UILabel = UILabel().then {
+        $0.textColor = .schedule1
+        $0.textAlignment = .center
+        $0.font = .body4_12_R
+        $0.numberOfLines = 1
+    }
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setStyle()
+        self.setUI()
+        self.setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup Methods
+    
+    private func setStyle() {
+        self.backgroundColor = .gray900
+        self.layer.cornerRadius = 12
+        self.clipsToBounds = true
+        self.alpha = 0.0
+    }
+    
+    private func setUI() {
+        self.addSubview(self.messageLabel)
+    }
+    
+    private func setLayout() {
+        self.messageLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(16)
+            $0.trailing.equalToSuperview().inset(16)
+            $0.centerY.equalToSuperview()
+        }
+        
+        self.snp.makeConstraints {
+            $0.height.equalTo(49)
+        }
+    }
+        
+    func configure(message: String) {
+        self.messageLabel.text = message
+    }
+}

--- a/Kiero/Kiero/Presentation/Common/Components/Toast.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Toast.swift
@@ -11,7 +11,6 @@ import SnapKit
 import Then
 
 final class Toast {
-        
     static func show(message: String) {
         let windowScene: UIWindowScene? = UIApplication.shared.connectedScenes.first as? UIWindowScene
         
@@ -32,7 +31,7 @@ final class Toast {
         
         self.animate(view: toastView)
     }
-        
+    
     private static func animate(view: UIView) {
         UIView.animate(
             withDuration: 0.2,
@@ -92,21 +91,21 @@ private final class ToastView: UIView {
     }
     
     private func setUI() {
-        self.addSubview(self.messageLabel)
+        addSubview(self.messageLabel)
     }
     
     private func setLayout() {
-        self.messageLabel.snp.makeConstraints {
+        messageLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(16)
             $0.trailing.equalToSuperview().inset(16)
             $0.centerY.equalToSuperview()
         }
         
-        self.snp.makeConstraints {
+        snp.makeConstraints {
             $0.height.equalTo(49)
         }
     }
-        
+    
     func configure(message: String) {
         self.messageLabel.text = message
     }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #36 
<br>

## 🍎 작업 내용
- Global Toast Manager (`Toast`) 구현
  - UIWindow를 탐색하여 뷰 계층 최상단에 토스트 추가
  - Fade In/Out 및 2초 대기 애니메이션 로직 구현
- UI 컴포넌트 (`ToastView`) 구현
  - 외부에서 직접 접근하지 못하도록 private으로 캡슐화
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 토스트 | ![Simulator Screen Recording - iPhone 17 Pro - 2026-01-11 at 12 35 51](https://github.com/user-attachments/assets/e68017ce-6814-4e9b-b422-3d9b357eef71) | 
<br>

## 💬 리뷰 코멘트
- UIWindowScene을 고려하여 keyWindow를 찾는 방식이 맞는지 확인 부탁드립니다!
<br>

## 💡사용 방법
```swift
Toast.show(message: "일정이 최대 글자수 10자를 초과하였습니다")
```