### PR TITLE
[feat] #49 TextField 컴포넌트 구현

### DIFF
--- a/Kiero/Kiero.xcodeproj/project.pbxproj
+++ b/Kiero/Kiero.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		249C641A2F0FA1F50016D6B7 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 249C64192F0FA1F50016D6B7 /* Moya */; };
 		24DF523F2F0A6487007146AC /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 24DF523E2F0A6487007146AC /* SnapKit */; };
 		24DF52422F0A64A0007146AC /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 24DF52412F0A64A0007146AC /* Then */; };
+		F6B015D62F123F0D007B1EE4 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = F6B015D52F123F0D007B1EE4 /* KakaoSDK */; };
+		F6B015D82F123F0D007B1EE4 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = F6B015D72F123F0D007B1EE4 /* KakaoSDKAuth */; };
+		F6B015DA2F123F0D007B1EE4 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = F6B015D92F123F0D007B1EE4 /* KakaoSDKUser */; };
+		F6B018522F136542007B1EE4 /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = F6B018512F136542007B1EE4 /* CombineMoya */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -20,6 +24,7 @@
 		24DF50DD2F0A5174007146AC /* Exceptions for "Kiero" folder in "Kiero" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Config.xcconfig,
 				Info.plist,
 			);
 			target = 24DF50CA2F0A5173007146AC /* Kiero */;
@@ -43,8 +48,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				24DF523F2F0A6487007146AC /* SnapKit in Frameworks */,
+				F6B015D62F123F0D007B1EE4 /* KakaoSDK in Frameworks */,
+				F6B015DA2F123F0D007B1EE4 /* KakaoSDKUser in Frameworks */,
+				F6B018522F136542007B1EE4 /* CombineMoya in Frameworks */,
 				24DF52422F0A64A0007146AC /* Then in Frameworks */,
 				249C641A2F0FA1F50016D6B7 /* Moya in Frameworks */,
+				F6B015D82F123F0D007B1EE4 /* KakaoSDKAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -55,6 +64,7 @@
 			isa = PBXGroup;
 			children = (
 				24DF50CD2F0A5173007146AC /* Kiero */,
+				F6B018502F136542007B1EE4 /* Frameworks */,
 				24DF50CC2F0A5173007146AC /* Products */,
 			);
 			sourceTree = "<group>";
@@ -65,6 +75,13 @@
 				24DF50CB2F0A5173007146AC /* Kiero.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		F6B018502F136542007B1EE4 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -90,6 +107,10 @@
 				24DF523E2F0A6487007146AC /* SnapKit */,
 				24DF52412F0A64A0007146AC /* Then */,
 				249C64192F0FA1F50016D6B7 /* Moya */,
+				F6B015D52F123F0D007B1EE4 /* KakaoSDK */,
+				F6B015D72F123F0D007B1EE4 /* KakaoSDKAuth */,
+				F6B015D92F123F0D007B1EE4 /* KakaoSDKUser */,
+				F6B018512F136542007B1EE4 /* CombineMoya */,
 			);
 			productName = Kiero;
 			productReference = 24DF50CB2F0A5173007146AC /* Kiero.app */;
@@ -103,7 +124,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1640;
-				LastUpgradeCheck = 1640;
+				LastUpgradeCheck = 2620;
 				TargetAttributes = {
 					24DF50CA2F0A5173007146AC = {
 						CreatedOnToolsVersion = 16.4;
@@ -123,6 +144,7 @@
 				24DF523D2F0A6487007146AC /* XCRemoteSwiftPackageReference "SnapKit" */,
 				24DF52402F0A64A0007146AC /* XCRemoteSwiftPackageReference "Then" */,
 				249C64182F0FA1F50016D6B7 /* XCRemoteSwiftPackageReference "Moya" */,
+				F6B015D42F123F0D007B1EE4 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 24DF50CC2F0A5173007146AC /* Products */;
@@ -275,6 +297,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -333,6 +356,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -386,6 +410,14 @@
 				minimumVersion = 3.0.0;
 			};
 		};
+		F6B015D42F123F0D007B1EE4 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.27.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -403,6 +435,26 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 24DF52402F0A64A0007146AC /* XCRemoteSwiftPackageReference "Then" */;
 			productName = Then;
+		};
+		F6B015D52F123F0D007B1EE4 /* KakaoSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F6B015D42F123F0D007B1EE4 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDK;
+		};
+		F6B015D72F123F0D007B1EE4 /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F6B015D42F123F0D007B1EE4 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
+		F6B015D92F123F0D007B1EE4 /* KakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F6B015D42F123F0D007B1EE4 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKUser;
+		};
+		F6B018512F136542007B1EE4 /* CombineMoya */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 249C64182F0FA1F50016D6B7 /* XCRemoteSwiftPackageReference "Moya" */;
+			productName = CombineMoya;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Kiero/Kiero.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kiero/Kiero.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fc8f8614896aa5ec8688d98e70bf3791328287c9bb560963e7f53aaaf1a62dca",
+  "originHash" : "038fc281c921b410bdeab49776a27abccbd8a65614df2d1393549308d5b9275d",
   "pins" : [
     {
       "identity" : "alamofire",

--- a/Kiero/Kiero.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kiero/Kiero.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "038fc281c921b410bdeab49776a27abccbd8a65614df2d1393549308d5b9275d",
+  "originHash" : "a50783ddf0b26316b9c615f2293218418be62762661536720f566e0794bdfac9",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "7be73f6c2b5cd90e40798b06ebd5da8f9f79cf88",
         "version" : "5.11.0"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "1a2b530921ab9d1f4385ced84109b7a86d42cff8",
+        "version" : "2.27.1"
       }
     },
     {

--- a/Kiero/Kiero/Presentation/Common/Components/TextField.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/TextField.swift
@@ -7,12 +7,22 @@
 
 import UIKit
 
+import SnapKit
+
 enum UserRole {
     case parent(ParentField)
     case child(ChildField)
 
-    enum ParentField { case lastName, firstName }
-    enum ChildField { case lastName, firstName, inviteCode }
+    enum ParentField {
+        case lastName
+        case firstName
+        case totalName
+    }
+    enum ChildField {
+        case lastName
+        case firstName
+        case inviteCode
+    }
 }
 
 extension UserRole {
@@ -20,6 +30,7 @@ extension UserRole {
         switch self {
         case .parent(.lastName): return "아이의 성을 입력해주세요."
         case .parent(.firstName): return "아이의 이름을 입력해주세요."
+        case .parent(.totalName): return ""
         case .child(.lastName): return "성"
         case .child(.firstName): return "이름"
         case .child(.inviteCode): return "초대 코드"
@@ -30,35 +41,182 @@ extension UserRole {
         switch self {
         case .parent(.lastName): return "성"
         case .parent(.firstName): return "이름"
+        case .parent(.totalName): return ""
         case .child(.lastName): return "성을 입력해줘!"
         case .child(.firstName): return "이름을 입력해줘!"
-        case .child(.inviteCode): return "부모님께 받은 비밀 암호 6자리를 입력해줘!"
+        case .child(.inviteCode): return "부모님께 받은 비밀 암호를 입력해줘!"
         }
     }
 
-    var regex: String {
+    var regex: String? {
         switch self {
-        case .parent(.lastName), .child(.lastName):
-            return "^[가-힣]{1,2}$"
-        case .parent(.firstName), .child(.firstName):
-            return "^[가-힣]{1,5}$"
+        case .parent(.lastName), .child(.lastName), .parent(.firstName), .parent(.totalName), .child(.firstName):
+            return "^[가-힣]{0,5}$"
         case .child(.inviteCode):
-            return "^[A-Za-z0-9]{6,10}$"
+            return nil
         }
     }
 
-    var errorMessage: String {
+    var errorAppear: Bool {
         switch self {
-        case .parent(.lastName), .child(.lastName):
-            return "특수문자, 이모지, 공백을 포함하지 않은 이름을 입력해주세요"
-        case .parent(.firstName), .child(.firstName):
-            return "이름은 한글로 입력해주세요."
-        case .child(.inviteCode):
-            return "초대코드는 영문/숫자 6~10자입니다."
+        case .parent(.lastName), .child(.lastName), .parent(.firstName), .child(.firstName):
+            return true
+        case .parent(.totalName), .child(.inviteCode):
+            return false
         }
     }
 }
 
 final class TextField: UIView {
     
+    // MARK: - Properties
+    
+    private let type: UserRole
+    
+    private var hasInteracted: Bool = false
+    
+    // MARK: - UI Components
+    
+    private let titleLabel = UILabel().then {
+        $0.textColor = .gray400
+        $0.setTypo(.body3_14_R)
+    }
+    
+    private let textField = UITextField().then {
+        $0.defaultTextAttributes = [
+            .kern: -0.005,
+            .font: UIFont.body4_12_R,
+            .foregroundColor: UIColor.white
+        ]
+        $0.addLeftPadding(13)
+        $0.backgroundColor = .gray900
+        $0.layer.cornerRadius = 15
+        
+    }
+    
+    private let errorImage = UIImageView().then {
+        $0.image = .icInfo
+            .withTintColor(.point)
+            .resized(to: CGSize(width: 11, height: 11))
+        $0.alpha = 0
+    }
+    
+    private let errorLabel = UILabel().then {
+        $0.textColor = .point
+        $0.alpha = 0
+    }
+    
+    // MARK: - Life Cycle
+    
+    init(type: UserRole) {
+        self.type = type
+        super.init(frame: .zero)
+        setUI()
+        setLayout()
+        setDelegate()
+        configure(type: type)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setting Methods
+    
+    private func setUI() {
+        addSubviews(
+            titleLabel,
+            textField,
+            errorImage,
+            errorLabel
+        )
+    }
+    
+    private func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(30)
+            $0.leading.equalToSuperview().inset(16)
+        }
+        
+        textField.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(6)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(45)
+        }
+        
+        errorLabel.snp.makeConstraints {
+            $0.top.equalTo(textField.snp.bottom).offset(6)
+            $0.trailing.equalToSuperview().inset(16)
+        }
+        
+        errorImage.snp.makeConstraints {
+            $0.centerY.equalTo(errorLabel.snp.centerY)
+            $0.trailing.equalTo(errorLabel.snp.leading).offset(-4)
+        }
+    }
+    
+    private func setDelegate() {
+        textField.delegate = self
+    }
+    
+    private func configure(type: UserRole) {
+        titleLabel.text = type.title
+        titleLabel.isHidden = type.title.isEmpty
+        textField.attributedPlaceholder = NSAttributedString(
+                string: type.placeholder,
+                attributes: [
+                    .kern: -0.005,
+                    .font: UIFont.body4_12_R,
+                    .foregroundColor: UIColor.gray700
+                ]
+            )
+    }
+    
+    private func validate() {
+        textField.layer.borderWidth = 0
+        textField.layer.borderColor = UIColor.clear.cgColor
+        
+        guard type.errorAppear else { return }
+        guard let regex = type.regex else { return }
+        
+        let text = (textField.text ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        guard hasInteracted else { return }
+        guard !text.isEmpty else { return }
+        
+        let isValid = NSPredicate(
+            format: "SELF MATCHES %@",
+            regex
+        ).evaluate(with: text)
+        
+        updateErrorUI(isValid: isValid)
+    }
+    
+    private func updateErrorUI(isValid: Bool) {
+        if isValid {
+            textField.layer.borderWidth = 0
+            textField.layer.borderColor = UIColor.clear.cgColor
+            return
+        }
+        
+        errorLabel.setTypo(.body5_10_R, text: "특수문자, 이모지, 공백을 포함하지 않은 이름을 입력해주세요")
+        errorLabel.alpha = 1
+        errorImage.alpha = 1
+        
+        textField.layer.borderWidth = 0.5
+        textField.layer.borderColor = UIColor.point.cgColor
+    }
+}
+
+extension TextField: UITextFieldDelegate {
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        hasInteracted = true
+        textField.layer.borderColor = UIColor.gray100.cgColor
+        textField.layer.borderWidth = 0.5
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        validate()
+    }
 }

--- a/Kiero/Kiero/Presentation/Common/Components/TextField.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/TextField.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import SnapKit
+import Then
 
 enum UserRole {
     case parent(ParentField)

--- a/Kiero/Kiero/Presentation/Common/Components/TextField.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/TextField.swift
@@ -1,0 +1,64 @@
+//
+//  TextField.swift
+//  Kiero
+//
+//  Created by 안치욱 on 1/12/26.
+//
+
+import UIKit
+
+enum UserRole {
+    case parent(ParentField)
+    case child(ChildField)
+
+    enum ParentField { case lastName, firstName }
+    enum ChildField { case lastName, firstName, inviteCode }
+}
+
+extension UserRole {
+    var title: String {
+        switch self {
+        case .parent(.lastName): return "아이의 성을 입력해주세요."
+        case .parent(.firstName): return "아이의 이름을 입력해주세요."
+        case .child(.lastName): return "성"
+        case .child(.firstName): return "이름"
+        case .child(.inviteCode): return "초대 코드"
+        }
+    }
+
+    var placeholder: String {
+        switch self {
+        case .parent(.lastName): return "성"
+        case .parent(.firstName): return "이름"
+        case .child(.lastName): return "성을 입력해줘!"
+        case .child(.firstName): return "이름을 입력해줘!"
+        case .child(.inviteCode): return "부모님께 받은 비밀 암호 6자리를 입력해줘!"
+        }
+    }
+
+    var regex: String {
+        switch self {
+        case .parent(.lastName), .child(.lastName):
+            return "^[가-힣]{1,2}$"
+        case .parent(.firstName), .child(.firstName):
+            return "^[가-힣]{1,5}$"
+        case .child(.inviteCode):
+            return "^[A-Za-z0-9]{6,10}$"
+        }
+    }
+
+    var errorMessage: String {
+        switch self {
+        case .parent(.lastName), .child(.lastName):
+            return "특수문자, 이모지, 공백을 포함하지 않은 이름을 입력해주세요"
+        case .parent(.firstName), .child(.firstName):
+            return "이름은 한글로 입력해주세요."
+        case .child(.inviteCode):
+            return "초대코드는 영문/숫자 6~10자입니다."
+        }
+    }
+}
+
+final class TextField: UIView {
+    
+}

--- a/Kiero/Kiero/Presentation/Common/Extensions/UIImage+.swift
+++ b/Kiero/Kiero/Presentation/Common/Extensions/UIImage+.swift
@@ -1,0 +1,20 @@
+//
+//  UIImage+.swift
+//  Kiero
+//
+//  Created by 안치욱 on 1/13/26.
+//
+
+import UIKit
+
+extension UIImage {
+    func resized(to size: CGSize, scale: CGFloat = UIScreen.main.scale) -> UIImage {
+        let rendererFormat = UIGraphicsImageRendererFormat.default()
+        rendererFormat.scale = scale
+
+        let renderer = UIGraphicsImageRenderer(size: size, format: rendererFormat)
+        return renderer.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: size))
+        }
+    }
+}

--- a/Kiero/Kiero/Presentation/Common/Extensions/UITextField+.swift
+++ b/Kiero/Kiero/Presentation/Common/Extensions/UITextField+.swift
@@ -5,7 +5,6 @@
 //  Created by 안치욱 on 1/13/26.
 //
 
-
 import UIKit
 
 extension UITextField {

--- a/Kiero/Kiero/Presentation/Common/Extensions/UITextField+.swift
+++ b/Kiero/Kiero/Presentation/Common/Extensions/UITextField+.swift
@@ -1,0 +1,28 @@
+//
+//  UITextField+.swift
+//  Kiero
+//
+//  Created by 안치욱 on 1/13/26.
+//
+
+
+import UIKit
+
+extension UITextField {
+    func addLeftPadding(_ width: CGFloat = 10) {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: width, height: self.frame.height))
+        self.leftView = paddingView
+        self.leftViewMode = ViewMode.always
+    }
+    
+    func addRightPadding(_ width: CGFloat = 10) {
+        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: width, height: self.frame.height))
+        self.rightView = paddingView
+        self.rightViewMode = ViewMode.always
+    }
+    
+    func addPadding(leftAmount: CGFloat = 10, rightAmount: CGFloat = 10) {
+        addLeftPadding(leftAmount)
+        addRightPadding(rightAmount)
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #49 
<br>

## 🍎 작업 내용
메인 기능

```swift
private let p1 = TextField(type: .parent(.lastName))
private let p2 = TextField(type: .parent(.firstName))
private let p3 = TextField(type: .parent(.totalName))
private let c1 = TextField(type: .child(.lastName))
private let c2 = TextField(type: .child(.firstName))
private let c3 = TextField(type: .child(.inviteCode))
```
이렇게 총 6가지 경우로 나누어서 제작하였습니다.
그냥 TextField가 사용하고 싶으시면 `.parent(.totalName)`으로 사용하시면 문제 없을 듯 합니다.
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 화면2 |
|:---------:|:-------------:|:-------------:|
| 기능1 | <img src="https://github.com/user-attachments/assets/84ad7696-6d5f-4d72-9442-3b2d32e348ce" width="250"> | <img src="https://github.com/user-attachments/assets/2606e70e-4f51-49be-a0e6-7406e0cbda6b" width="250"> |
<br>


## 💬 리뷰 코멘트
