### PR TITLE
[feat] #71 dialog 종류 추가

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/ConfirmBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/ConfirmBox.swift
@@ -53,7 +53,6 @@ final class ConfirmBox: UIView {
         $0.textAlignment = .center
         $0.numberOfLines = 2
         $0.textColor = .gray100
-        $0.setTypo(.body3_14_R)
     }
     
     private let actionButton = UIButton().then {
@@ -128,7 +127,8 @@ final class ConfirmBox: UIView {
     // MARK: Configure
     
     func configure(state: State) {
-        messageLabel.text = state.message
+        messageLabel.setTypo(.body3_14_R, text: state.message)
+        messageLabel.textAlignment = .center
         actionButton.setTitle(state.buttonTitle, for: .normal)
     }
     

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -18,6 +18,7 @@ final class DialogBox: UIView {
         case missionComplete(title: String)
         case logout
         case wishWell(title: String, coin: String)
+        case nextJourney
         
         var title: String {
             switch self {
@@ -27,6 +28,8 @@ final class DialogBox: UIView {
                 return "로그아웃"
             case .wishWell(let title, _):
                 return title
+            case .nextJourney:
+                return "다음여정으로 갈까요?"
             }
         }
         
@@ -38,6 +41,8 @@ final class DialogBox: UIView {
                 return "로그아웃 하시겠습니까?"
             case .wishWell:
                 return "금화를 사용해 소원을 빌까?"
+            case .nextJourney:
+                return "한번 다음 여정으로 넘어가면\n다시 지금 여정으로 돌아올 수 없어요!"
             }
         }
         
@@ -101,6 +106,7 @@ final class DialogBox: UIView {
         $0.textAlignment = .center
         $0.textColor = .white
         $0.numberOfLines = 2
+        $0.font = .body3_14_R
     }
     
     private let contentStack = UIStackView().then {
@@ -213,6 +219,7 @@ final class DialogBox: UIView {
     func configure(state: State) {
         titleLabel.setTypo(.title2_20_SB, text: state.title)
         messageLabel.setTypo(.body3_14_R, text: state.message)
+        messageLabel.textAlignment = .center
         coinLabel.setTypo(.title4_14_SB, text: state.coinText)
         
         cancelButton.setTitle(state.cancelButtonTitle, for: .normal)

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -29,7 +29,7 @@ final class DialogBox: UIView {
             case .wishWell(let title, _):
                 return title
             case .nextJourney:
-                return "다음여정으로 갈까요?"
+                return "다음 여정으로 갈거야?"
             }
         }
         
@@ -42,7 +42,7 @@ final class DialogBox: UIView {
             case .wishWell:
                 return "금화를 사용해 소원을 빌까?"
             case .nextJourney:
-                return "한번 다음 여정으로 넘어가면\n다시 지금 여정으로 돌아올 수 없어요!"
+                return "한번 다음 여정으로 넘어가면\n다시 지금 여정으로 돌아올 수 없어!"
             }
         }
         


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #71 
<br>

## 🍎 작업 내용
dialog에 nextJorney에 사용되는 컴포넌트 종류를 추가했습니다. 
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 화면 |<img width="250" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-15 at 03 43 01" src="https://github.com/user-attachments/assets/311df779-9705-4547-8dda-520b150f8c0d" />|
<br>

## 💬 리뷰 코멘트
none
