### PR TITLE
[feat] #74 불조각 획득 뷰 구현

### DIFF
--- a/Kiero/Kiero.xcodeproj/project.pbxproj
+++ b/Kiero/Kiero.xcodeproj/project.pbxproj
@@ -188,8 +188,10 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Kiero/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "카메라를 허용하시겠습니까?";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
@@ -84,9 +84,9 @@ final class SpeechField: UIView {
         }
         
         contentStackView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(24)
+            $0.top.equalToSuperview().offset(14)
             $0.leading.trailing.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview().inset(27)
+            $0.bottom.equalToSuperview().inset(14)
         }
     }
     

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
@@ -13,7 +13,7 @@ import SnapKit
 import Then
 
 final class DailyJourneyView: BaseUIView {
-        
+    
     // MARK: - UI Components
     
     private let backgroundImageView = UIImageView().then {

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
@@ -6,13 +6,14 @@
 //
 
 import UIKit
+import Combine
 
 import Kingfisher
 import SnapKit
 import Then
 
 final class DailyJourneyView: BaseUIView {
-    
+        
     // MARK: - UI Components
     
     private let backgroundImageView = UIImageView().then {

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import Combine
 
-final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel>, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel> {
     
     // MARK: - Properties
     
@@ -87,13 +87,11 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
     }
     
     private func showNextJourneyDialog() {
-        self.view.showDialog(state: .nextJourney) { 
+        self.view.showDialog(state: .nextJourney) {
             print("유저가 다음 여정으로 넘어가기를 확정")
             // TODO: ViewModel의 다음 여정 로직 연결
         }
     }
-    
-    // MARK: - Camera Logic
     
     private func openCamera() {
         guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
@@ -110,6 +108,17 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
         self.present(picker, animated: true)
     }
     
+    private func moveToMissionCompleteView(with image: UIImage) {
+        let completeViewModel = MissionCompleteViewModel()
+        let completeVC = MissionCompleteViewController(viewModel: completeViewModel)
+        
+        completeVC.initialImage = image
+        
+        self.navigationController?.pushViewController(completeVC, animated: true)
+    }
+}
+
+extension DailyJourneyViewController: UINavigationControllerDelegate, UIImagePickerControllerDelegate {
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         
         guard let capturedImage = info[.originalImage] as? UIImage else {
@@ -124,14 +133,5 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
     
     func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
         picker.dismiss(animated: true)
-    }
-    
-    private func moveToMissionCompleteView(with image: UIImage) {
-        let completeViewModel = MissionCompleteViewModel()
-        let completeVC = MissionCompleteViewController(viewModel: completeViewModel)
-        
-        completeVC.initialImage = image
-        
-        self.navigationController?.pushViewController(completeVC, animated: true)
     }
 }

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import Combine
 
-final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel> {
+final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel>, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
     
     // MARK: - Properties
     
@@ -74,13 +74,57 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
     private func didTapVerifyButton() {
         verifyButtonTapSubject.send(())
     }
-    
+        
     private func handleRoute(_ route: DailyJourneyRoute) {
         switch route {
         case .showNextJourneyDialogBox:
-            print("LOG: 다음 여정 팝업 띄우기")
+            print("다음 여정 다이어로그")
+            
         case .showCamera:
-            print("LOG: 인증 카메라 화면으로 이동")
+            openCamera()
         }
+    }
+    
+    // MARK: - Camera Logic
+    
+    private func openCamera() {
+        guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
+            print("카메라를 사용할 수 없습니다.")
+            return
+        }
+        
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.cameraCaptureMode = .photo
+        picker.delegate = self
+        picker.modalPresentationStyle = .fullScreen
+        
+        self.present(picker, animated: true)
+    }
+        
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        
+        guard let capturedImage = info[.originalImage] as? UIImage else {
+            picker.dismiss(animated: true)
+            return
+        }
+        
+        picker.dismiss(animated: false) { [weak self] in
+            self?.moveToMissionCompleteView(with: capturedImage)
+        }
+    }
+    
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        picker.dismiss(animated: true)
+    }
+        
+    private func moveToMissionCompleteView(with image: UIImage) {
+        let completeViewModel = MissionCompleteViewModel()
+        
+        let completeVC = MissionCompleteViewController(viewModel: completeViewModel)
+        
+        completeVC.initialImage = image
+        
+        self.navigationController?.pushViewController(completeVC, animated: true)
     }
 }

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
@@ -74,14 +74,22 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
     private func didTapVerifyButton() {
         verifyButtonTapSubject.send(())
     }
-        
+    
     private func handleRoute(_ route: DailyJourneyRoute) {
         switch route {
         case .showNextJourneyDialogBox:
+            showNextJourneyDialog()
             print("다음 여정 다이어로그")
             
         case .showCamera:
             openCamera()
+        }
+    }
+    
+    private func showNextJourneyDialog() {
+        self.view.showDialog(state: .nextJourney) { 
+            print("유저가 다음 여정으로 넘어가기를 확정")
+            // TODO: ViewModel의 다음 여정 로직 연결
         }
     }
     
@@ -101,7 +109,7 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
         
         self.present(picker, animated: true)
     }
-        
+    
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
         
         guard let capturedImage = info[.originalImage] as? UIImage else {
@@ -117,7 +125,7 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
     func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
         picker.dismiss(animated: true)
     }
-        
+    
     private func moveToMissionCompleteView(with image: UIImage) {
         let completeViewModel = MissionCompleteViewModel()
         let completeVC = MissionCompleteViewController(viewModel: completeViewModel)

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
@@ -120,7 +120,6 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
         
     private func moveToMissionCompleteView(with image: UIImage) {
         let completeViewModel = MissionCompleteViewModel()
-        
         let completeVC = MissionCompleteViewController(viewModel: completeViewModel)
         
         completeVC.initialImage = image

--- a/Kiero/Kiero/Presentation/MissionComplete/MissioinCompleteModel.swift
+++ b/Kiero/Kiero/Presentation/MissionComplete/MissioinCompleteModel.swift
@@ -1,0 +1,43 @@
+//
+//  MissioinCompleteModel.swift
+//  Kiero
+//
+//  Created by Hyunseo Han on 1/16/26.
+//
+
+import UIKit
+
+enum MissioinCompleteModel: Int, CaseIterable {
+    case courage = 0
+    case patience
+    case wisdom
+    
+    static func from(scheduleDetailId: Int) -> MissioinCompleteModel {
+        let index = (scheduleDetailId - 1) % 3
+        return MissioinCompleteModel(rawValue: index) ?? .courage
+    }
+    
+    var name: String {
+        switch self {
+        case .courage: return "용기"
+        case .patience: return "인내"
+        case .wisdom: return "지혜"
+        }
+    }
+    
+    var image: UIImage {
+        switch self {
+        case .courage: return UIImage(resource: .ic3DBluestone)
+        case .patience: return UIImage(resource: .ic3DRedstone)
+        case .wisdom: return UIImage(resource: .ic3DGreenstone)
+        }
+    }
+    
+    var message: String {
+        return "우와! \(self.name)의 불조각 을 손에 넣었어!"
+    }
+    
+    var highlightKeyword: String {
+        return "\(self.name)의 불조각"
+    }
+}

--- a/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteView.swift
+++ b/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Combine
+
 import SnapKit
 import Then
 
@@ -58,12 +59,12 @@ final class MissionCompleteView: BaseUIView {
         fireStoneImageView.snp.makeConstraints {
             $0.bottom.equalTo(kkubiImageView.snp.top).offset(19)
             $0.centerX.equalToSuperview()
-            $0.width.height.equalTo(140)
+            $0.size.equalTo(140)
         }
         
         speechField.snp.makeConstraints {
             $0.top.equalTo(safeAreaLayoutGuide).offset(131)
-            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.horizontalEdges.equalToSuperview().inset(16)
         }
     }
     

--- a/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteView.swift
+++ b/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteView.swift
@@ -1,0 +1,100 @@
+//
+//  MissionCompleteView.swift
+//  Kiero
+//
+//  Created by Hyunseo Han on 1/15/26.
+//
+
+import UIKit
+import Combine
+import SnapKit
+import Then
+
+final class MissionCompleteView: BaseUIView {
+    
+    // MARK: - UI Components
+    
+    let backgroundImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.clipsToBounds = true
+    }
+    
+    let blackOverlayView = UIView().then {
+        $0.backgroundColor = UIColor.kBlack.withAlphaComponent(0.6)
+    }
+    
+    let speechField = SpeechField().then {
+        $0.isHidden = false
+    }
+    
+    let fireStoneImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFit
+        $0.layer.shadowColor = UIColor.white.cgColor
+        $0.layer.shadowOpacity = 0.5
+        $0.layer.shadowRadius = 10
+        $0.layer.shadowOffset = .zero
+    }
+    
+    let kkubiImageView = UIImageView().then {
+        $0.image = UIImage(resource: .imgGoblinSmile)
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    override func setUI() {
+        addSubviews(backgroundImageView, blackOverlayView, kkubiImageView, fireStoneImageView, speechField)
+    }
+    
+    override func setLayout() {
+        backgroundImageView.snp.makeConstraints { $0.edges.equalToSuperview() }
+        blackOverlayView.snp.makeConstraints { $0.edges.equalToSuperview() }
+        
+        kkubiImageView.snp.makeConstraints {
+            $0.bottom.equalToSuperview()
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(252)
+            $0.height.equalTo(286)
+        }
+        
+        fireStoneImageView.snp.makeConstraints {
+            $0.bottom.equalTo(kkubiImageView.snp.top).offset(19)
+            $0.centerX.equalToSuperview()
+            $0.width.height.equalTo(140)
+        }
+        
+        speechField.snp.makeConstraints {
+            $0.top.equalTo(safeAreaLayoutGuide).offset(131)
+            $0.leading.trailing.equalToSuperview().inset(16)
+        }
+    }
+    
+    func configure(capturedImage: UIImage?, rewardImage: UIImage, message: String, keyword: String) {
+        self.backgroundImageView.image = capturedImage
+        self.fireStoneImageView.image = rewardImage
+        
+        speechField.configure(
+            name: "꾸비",
+            lines: [message],
+            highlightKeywords: [keyword]
+        )
+    }
+    
+    func startFloatingAnimation(completion: @escaping () -> Void) {
+        CATransaction.begin()
+        CATransaction.setCompletionBlock {
+            completion()
+        }
+        
+        let animation = CABasicAnimation(keyPath: "transform.translation.y")
+        animation.duration = 1.0
+        animation.autoreverses = true
+        animation.repeatCount = 2
+        animation.fromValue = 0
+        animation.toValue = -16
+        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        animation.isRemovedOnCompletion = true
+        
+        fireStoneImageView.layer.add(animation, forKey: "missionSuccess")
+        
+        CATransaction.commit()
+    }
+}

--- a/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteViewController.swift
+++ b/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteViewController.swift
@@ -70,7 +70,7 @@ final class MissionCompleteViewController: BaseViewController<MissionCompleteVie
         self.navigationController?.popViewController(animated: true)
     }
     
-    // MARK: - Binding
+    // MARK: - Bind
     
     override func bind(viewModel: MissionCompleteViewModel) {
         super.bind(viewModel: viewModel)

--- a/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteViewController.swift
+++ b/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteViewController.swift
@@ -1,0 +1,98 @@
+//
+//  MissionCompleteViewController.swift
+//  Kiero
+//
+//  Created by Hyunseo Han on 1/15/26.
+//
+
+import UIKit
+import Combine
+
+import SnapKit
+import Then
+
+final class MissionCompleteViewController: BaseViewController<MissionCompleteViewModel> {
+    
+    // MARK: - UI Components
+    
+    private let mainView = MissionCompleteView()
+    
+    // MARK: - Properties
+    
+    var initialImage: UIImage?
+    var scheduleDetailId: Int = 1
+    
+    private let viewDidAppearSubject = PassthroughSubject<Void, Never>()
+    
+    // MARK: - Initializer
+    
+    init(viewModel: MissionCompleteViewModel) {
+        super.init(viewModel: viewModel, diContainer: AppDIContainer.shared)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Life Cycle
+    
+    override func loadView() {
+        self.view = mainView
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        if let image = initialImage {
+            mainView.backgroundImageView.image = image
+            print("[DEBUG] viewDidLoad에서 이미지 즉시 설정 완료")
+        } else {
+            print("[DEBUG] initialImage가 nil. DailyJourneyVC 확인")
+        }
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        viewDidAppearSubject.send(())
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            guard let self = self else { return }
+            self.mainView.startFloatingAnimation {
+                self.moveToPreviousScreen()
+            }
+        }
+    }
+    
+    // MARK: - Navigation
+    
+    private func moveToPreviousScreen() {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    // MARK: - Binding
+    
+    override func bind(viewModel: MissionCompleteViewModel) {
+        super.bind(viewModel: viewModel)
+        
+        viewModel.scheduleDetailId = self.scheduleDetailId
+        
+        let input = MissionCompleteViewModel.Input(
+            viewDidAppear: viewDidAppearSubject.eraseToAnyPublisher()
+        )
+        
+        let output = viewModel.transform(input: input)
+        
+        output.missionData
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] data in
+                self?.mainView.configure(
+                    capturedImage: self?.initialImage,
+                    rewardImage: data.stoneImage,
+                    message: data.message,
+                    keyword: data.highlightKeyword
+                )
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteViewModel.swift
+++ b/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteViewModel.swift
@@ -1,0 +1,55 @@
+//
+//  MissionCompleteViewModel.swift
+//  Kiero
+//
+//  Created by Hyunseo Han on 1/15/26.
+//
+
+import UIKit
+import Combine
+
+struct MissionCompleteViewData {
+    let capturedImage: UIImage?
+    let stoneImage: UIImage
+    let message: String
+    let highlightKeyword: String
+}
+
+final class MissionCompleteViewModel: BaseViewModel, ViewModelType {
+    
+    var capturedImage: UIImage?
+    var scheduleDetailId: Int = 2
+    
+    // MARK: - Input & Output
+    
+    struct Input {
+        let viewDidAppear: AnyPublisher<Void, Never>
+    }
+    
+    struct Output {
+        let missionData: AnyPublisher<MissionCompleteViewData, Never>
+    }
+    
+    // MARK: - Transform
+    
+    func transform(input: Input) -> Output {
+        let missionDataPublisher = input.viewDidAppear
+            .map { [weak self] _ -> MissionCompleteViewData in
+                guard let self = self else {
+                    return MissionCompleteViewData(capturedImage: nil, stoneImage: UIImage(), message: "", highlightKeyword: "")
+                }
+                
+                let completeModel = MissioinCompleteModel.from(scheduleDetailId: self.scheduleDetailId)
+                
+                return MissionCompleteViewData(
+                    capturedImage: self.capturedImage,
+                    stoneImage: completeModel.image,
+                    message: completeModel.message,
+                    highlightKeyword: completeModel.highlightKeyword
+                )
+            }
+            .eraseToAnyPublisher()
+        
+        return Output(missionData: missionDataPublisher)
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #74 
<br>

## 🍎 작업 내용
- 카메라 연동 (DailyJourneyVC)
    - UIImagePickerController를 사용하여 카메라 기능을 구현했습니다.
    - 촬영된 이미지를 MissionCompleteViewController로 전달합니다.

- 미션 완료 화면 (MissionCompleteVC)
    - 전달받은 이미지를 배경으로 설정하고, 캐릭터(꾸비)와 불조각 UI를 구성했습니다.
    - 애니메이션: 불조각이 둥둥 떠다니는 애니메이션(Floating)을 구현했습니다.
    - 자동 이동: 애니메이션(약 4초)이 종료되면 자동으로 이전 화면으로 복귀합니다.

- 로직 분리
    - MissionCompleteViewModel을 통해 뷰에 필요한 데이터를 가공합니다.
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:| 
| 아이폰16 | ![compressed-video-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/0cb1c066-4499-4668-84a9-7d5b803165b2) |
<br>

## 💬 리뷰 코멘트
- `SpeechField` 컴포넌트 간격 수정 되었습니다! 참고해주세요
- INFOPLIST_KEY_NSCameraUsageDescription이거 설정해야 하는데 커밋을 어케 올릴지... -> 해결
<img width="642" height="192" alt="image" src="https://github.com/user-attachments/assets/184d54ae-689c-4e52-a0a8-e12385c13d00" />

- 다음 여정으로 버튼 누르면 다이어로그 뜨는거 까지 수정했습니다!