### PR TITLE
[feat] #81 logout UI 구현

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -182,6 +182,7 @@ final class DialogBox: UIView {
     private func setLayout() {
         container.snp.makeConstraints {
             $0.edges.equalToSuperview()
+            $0.height.equalTo(container.snp.width).multipliedBy(194.0 / 343.0)
         }
         
         closeButton.snp.makeConstraints {
@@ -196,6 +197,7 @@ final class DialogBox: UIView {
         
         cancelButton.snp.makeConstraints {
             $0.height.equalTo(49)
+            $0.height.equalTo(cancelButton.snp.width).multipliedBy(49.0 / 147.5)
         }
         
         confirmButton.snp.makeConstraints {

--- a/Kiero/Kiero/Presentation/Common/Extensions/UIViewController+Dialog.swift
+++ b/Kiero/Kiero/Presentation/Common/Extensions/UIViewController+Dialog.swift
@@ -1,0 +1,55 @@
+//
+//  UIViewController+Dialog.swift
+//  Kiero
+//
+//  Created by 정윤아 on 1/16/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+extension UIViewController {
+    func showLogoutDialog(oncConfirm: @escaping () -> Void) {
+        let dimmedView = UIView().then {
+            $0.backgroundColor = UIColor.kBlack.withAlphaComponent(0.75)
+            $0.alpha = 1
+        }
+        
+        let dialogBox = DialogBox().then {
+            $0.configure(state: .logout)
+            $0.alpha = 1
+        }
+        
+        view.addSubviews(dimmedView, dialogBox)
+        
+        dimmedView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        dialogBox.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(16)
+        }
+        
+        dialogBox.onTapCancel = {
+            self.dismissDialog(dimmedView, dialogBox)
+        }
+        
+        dialogBox.onTapConfirm = { [weak self] in
+            self?.dismissDialog(dimmedView, dialogBox)
+            self?.performLogout()
+        }
+    }
+    
+    func performLogout() {
+        // TODO: 로그아웃시 역할 선택 화면으로 이동
+        print("로그아웃 눌림")
+    }
+    
+    func dismissDialog(_ dimmed: UIView, _ dialog: UIView) {
+        dimmed.removeFromSuperview()
+        dialog.removeFromSuperview()
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #81 
<br>

## 🍎 작업 내용
logout UI 구현하였습니다. 
- extension으로 구현하여 profilBox가 있는 뷰에서 모두 사용 가능합니다. 
- 프로필 부분을 누르면 dim 처리된 배경과 함께 로그아웃 dialogBox가 나타납니다. 
- 로그아웃 박스에서 닫기를 누르면 이전 뷰로 돌아가고, 확인을 누르면 역할 선택 뷰로 넘어가야하지만 아직 뷰가 머지되지 않아서 TODO로 넣어두었습니다. 
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 기능1 |![Simulator Screen Recording - iPhone 17 Pro - 2026-01-16 at 21 50 45](https://github.com/user-attachments/assets/894ebddb-6c1a-4aaa-8e1b-41b3a9004af6)| 
<br>
test로 만든 뷰컨은 베이스 뷰컨으로 하지 않아서 위에 여백이 생기네용.....

## 💬 리뷰 코멘트
사용 방법은 profileBox가 있는 viewController에서 다음과 같이 선언해주면 됩니다. 
```swift
profileBox.onTap = { [weak self] in
    self?.showLogoutDialog() // 이제 뒤에 아무것도 안 붙여도 됨!
}
```
