### PR TITLE
[chore] #93 bottom layout 수정

### DIFF
--- a/Kiero/Kiero/Presentation/CoinMission/CoinMissionView.swift
+++ b/Kiero/Kiero/Presentation/CoinMission/CoinMissionView.swift
@@ -113,7 +113,7 @@ final class CoinMissionView: BaseUIView {
         
         missionCollectionView.snp.makeConstraints {
             $0.top.equalTo(missionLabel.snp.bottom)
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(10)
             $0.horizontalEdges.equalToSuperview()
         }
         

--- a/Kiero/Kiero/Presentation/CoinMission/CoinMissionView.swift
+++ b/Kiero/Kiero/Presentation/CoinMission/CoinMissionView.swift
@@ -113,7 +113,7 @@ final class CoinMissionView: BaseUIView {
         
         missionCollectionView.snp.makeConstraints {
             $0.top.equalTo(missionLabel.snp.bottom)
-            $0.bottom.equalToSuperview().inset(10)
+            $0.bottom.equalToSuperview().inset(100)
             $0.horizontalEdges.equalToSuperview()
         }
         

--- a/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedView.swift
+++ b/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedView.swift
@@ -42,7 +42,7 @@ final class NotificationFeedView: BaseUIView {
         tableView.snp.makeConstraints {
             $0.top.equalTo(profileView.snp.bottom).offset(25)
             $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(100)
         }
     }
 }

--- a/Kiero/Kiero/Presentation/WishWell/WishWellView.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellView.swift
@@ -128,7 +128,7 @@ final class WishWellView: BaseUIView {
         wishCollectionView.snp.makeConstraints {
             $0.top.equalTo(line.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(10)
+            $0.bottom.equalToSuperview().inset(100)
         }
     }
     

--- a/Kiero/Kiero/Presentation/WishWell/WishWellView.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellView.swift
@@ -128,7 +128,7 @@ final class WishWellView: BaseUIView {
         wishCollectionView.snp.makeConstraints {
             $0.top.equalTo(line.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().inset(10)
         }
     }
     


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #93
<br>

## 🍎 작업 내용
금화미션, 소원의 우물, 알림 피드에 사용되는 collectionView, TableView의 bottom layout을 tabBar 위로 변경하였습니다. 
<br>

## 💬 리뷰 코멘트
리뷰어가 신경써서 봐줄 부분을 알려주세요.
