### PR TITLE
[refactor] #103 gif 렌더링 이슈 수정

### DIFF
--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Combine
+import ImageIO
 
 import Kingfisher
 import SnapKit
@@ -38,7 +39,7 @@ final class DailyJourneyView: BaseUIView {
     
     private let journeyTimeView = DailyJourneyTimeView()
     
-    private let kkubiCharacterImageView = UIImageView().then {
+    private let kkubiCharacterImageView = AnimatedImageView().then {
         $0.contentMode = .scaleAspectFit
     }
     
@@ -108,6 +109,7 @@ final class DailyJourneyView: BaseUIView {
             $0.top.equalTo(journeyTimeView.snp.bottom).offset(20)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(343)
+            $0.height.equalTo(343)
         }
     }
     
@@ -127,19 +129,14 @@ final class DailyJourneyView: BaseUIView {
             time: data.journeyTimeText
         )
         
+        kkubiCharacterImageView.stopAnimating()
+        kkubiCharacterImageView.image = nil
+        
         if let url = Bundle.main.url(forResource: data.kkubiImageName, withExtension: "gif") {
-            let resource = LocalFileImageDataProvider(fileURL: url)
-            kkubiCharacterImageView.kf.setImage(
-                with: resource,
-                options: [
-                    .scaleFactor(UIScreen.main.scale),
-                    .cacheOriginalImage,
-                    .transition(.fade(0.2))
-                ]
-            )
+            kkubiCharacterImageView.kf.setImage(with: url)
         } else {
             kkubiCharacterImageView.image = UIImage(resource: .imgGoblinKid)
-            print("gif 경로 못 찾음")
+            print("gif 경로 못 찾음: \(data.kkubiImageName)")
         }
         
         let lines = data.bubbleText.components(separatedBy: "\n")


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #103
<br>

## 🍎 작업 내용
- DailyJourneyView의 캐릭터 GIF 렌더링 이슈를 수정했습니다.
- Kingfisher의 AnimatedImageView와 LocalFileImageDataProvider를 사용하여 프레임 드랍 없이 부드럽게 재생되도록 개선했습니다.
- GIF 미노출 해결: AnimatedImageView 사용 시 intrinsicContentSize가 잡히지 않아 화면에 나오지 않던 문제를 height 제약조건을 명시하여 해결했습니다.
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 
|:---------:|:-------------:|
| gif 렌더링 | <img src="https://github.com/user-attachments/assets/c74f5ecd-d3ef-4008-b5e2-42be5d9f2e73" width="250"> |

<br>

## 💬 리뷰 코멘트
리뷰어가 신경써서 봐줄 부분을 알려주세요.
