### PR TITLE
[fix] #122 SnapKit 레이아웃 충돌 해결

### DIFF
--- a/Kiero/Kiero/Presentation/CoinMission/DailyMissionCell.swift
+++ b/Kiero/Kiero/Presentation/CoinMission/DailyMissionCell.swift
@@ -58,7 +58,7 @@ class DailyMissionCell: UICollectionViewCell {
         missionStack.snp.makeConstraints {
             $0.top.equalTo(dateLabel.snp.bottom).offset(18)
             $0.horizontalEdges.equalToSuperview().inset(15.5)
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalToSuperview().priority(.low)
         }
     }
     

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/ConfirmBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/ConfirmBox.swift
@@ -107,8 +107,7 @@ final class ConfirmBox: UIView {
     
     private func setLayout() {
         container.snp.makeConstraints {
-            $0.edges.equalToSuperview()
-            $0.width.equalTo(343)
+            $0.edges.equalToSuperview().inset(16)
             $0.height.equalTo(248)
         }
         
@@ -118,7 +117,7 @@ final class ConfirmBox: UIView {
         }
         
         actionButton.snp.makeConstraints {
-            $0.width.equalTo(311)
+            $0.horizontalEdges.equalToSuperview().inset(16)
             $0.height.equalTo(49)
         }
     }

--- a/Kiero/Kiero/Presentation/Common/Components/MissionBox/MissionBoxChild.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/MissionBox/MissionBoxChild.swift
@@ -121,7 +121,7 @@ final class MissionBoxChild: UIView {
         missionBox.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(13)
             $0.verticalEdges.equalToSuperview().inset(13.5)
-            $0.width.equalTo(343)
+            $0.width.equalTo(343).priority(.low)
         }
         
         completeButton.snp.makeConstraints {


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #122 
<br>

## 🍎 작업 내용
ConfirmBox, MissionBoxChild에 있는 SnapKit 제약조건 충돌을 해결하였습니다. 
inset 여백을 주고 width를 설정하여서 충돌이 났었고, width가 꼭 필요한 부분은 priority를 low로 설정하여 충돌을 없앴습니다. 
<br>

## 💬 리뷰 코멘트
로그 알려주신 치욱님께 감사드립니다. 
