### PR TITLE
[network] #91 자녀 목록 조회 API 구현

### DIFF
--- a/Kiero/Kiero/Network/Schedule/ScheduleDTO.swift
+++ b/Kiero/Kiero/Network/Schedule/ScheduleDTO.swift
@@ -29,6 +29,12 @@ struct NormalScheduleDTO: Decodable {
     let date: String
 }
 
+struct ChildResponseDTO: Decodable {
+    let childId: Int
+    let childLastName: String
+    let childFirstName: String
+}
+
 extension ScheduleResponseDTO {
     func toEntity() -> [Schedule] {
         let recurring = recurringSchedules.map {

--- a/Kiero/Kiero/Network/Schedule/ScheduleService.swift
+++ b/Kiero/Kiero/Network/Schedule/ScheduleService.swift
@@ -9,10 +9,28 @@ import Foundation
 import Combine
 
 protocol ScheduleServiceType {
+    func fetchChildren() -> AnyPublisher<[ChildResponseDTO], NetworkError>
     func fetchSchedules(childId: Int, startDate: Date, endDate: Date) -> AnyPublisher<[Schedule], NetworkError>
 }
 
 final class ScheduleService: ScheduleServiceType {
+    func fetchChildren() -> AnyPublisher<[ChildResponseDTO], NetworkError> {
+        let endPoint = EndPoint.fetchChildren
+        
+        return Future<[ChildResponseDTO], NetworkError> { promise in
+            Task {
+                do {
+                    let response: [ChildResponseDTO] = try await BaseService.shared.request(endPoint: endPoint)
+                    promise(.success(response))
+                } catch let error as NetworkError {
+                    promise(.failure(error))
+                } catch {
+                    promise(.failure(.unknownError))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
     func fetchSchedules(childId: Int, startDate: Date, endDate: Date) -> AnyPublisher<[Schedule], NetworkError> {
         let startStr = startDate.toString(format: "yyyy-MM-dd")
         let endStr = endDate.toString(format: "yyyy-MM-dd")

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewModel.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewModel.swift
@@ -13,7 +13,7 @@ final class ScheduleViewModel: BaseViewModel, ViewModelType {
     // MARK: - Properties
     
     private let service: ScheduleServiceType
-    private let childId: Int = 5 // MARK: 임시 Id
+    private let childId = CurrentValueSubject<Int, Never>(0)
     
     private(set) var scheduleList = CurrentValueSubject<[Schedule], Never>([])
     let currentReferenceDate = CurrentValueSubject<Date, Never>(Date())
@@ -36,15 +36,26 @@ final class ScheduleViewModel: BaseViewModel, ViewModelType {
     
     init(service: ScheduleServiceType, childId: Int) {
         self.service = service
-//        self.childId = childId
         super.init()
+        
+        fetchInitialChildId()
     }
     
-    // MARK: - Transform
+    private func fetchInitialChildId() {
+        service.fetchChildren()
+            .sink { _ in } receiveValue: { [weak self] children in
+                // 첫 번째 자녀의 ID를 사용합니다.
+                if let firstChildId = children.first?.childId {
+                    self?.childId.send(firstChildId)
+                }
+            }
+            .store(in: &cancellables)
+    }
     
     func transform(input: Input) -> Output {
-        currentReferenceDate
-            .flatMap { [weak self] date -> AnyPublisher<[Schedule], Never> in
+        Publishers.CombineLatest(childId, currentReferenceDate)
+            .filter { id, _ in id != 0 }
+            .flatMap { [weak self] (id, date) -> AnyPublisher<[Schedule], Never> in
                 guard let self = self else { return Just([]).eraseToAnyPublisher() }
                 
                 let days = date.daysOfWeek
@@ -52,7 +63,7 @@ final class ScheduleViewModel: BaseViewModel, ViewModelType {
                     return Just([]).eraseToAnyPublisher()
                 }
                 
-                return self.service.fetchSchedules(childId: self.childId, startDate: startDate, endDate: endDate)
+                return self.service.fetchSchedules(childId: id, startDate: startDate, endDate: endDate)
                     .replaceError(with: [])
                     .eraseToAnyPublisher()
             }

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewModel.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewModel.swift
@@ -44,7 +44,6 @@ final class ScheduleViewModel: BaseViewModel, ViewModelType {
     private func fetchInitialChildId() {
         service.fetchChildren()
             .sink { _ in } receiveValue: { [weak self] children in
-                // 첫 번째 자녀의 ID를 사용합니다.
                 if let firstChildId = children.first?.childId {
                     self?.childId.send(firstChildId)
                 }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #91 
<br>

## 🍎 작업 내용
- 일정 탭 조회에 필요한 자녀 id를 불러오기 위한 자녀 목록 조회 API를 구현했습니다.
```
Response
Status Code: 200
Headers: [AnyHashable("X-XSS-Protection"): 0, AnyHashable("Server"): nginx/1.24.0 (Ubuntu), AnyHashable("X-Frame-Options"): DENY, AnyHashable("X-Content-Type-Options"): nosniff, AnyHashable("Connection"): keep-alive, AnyHashable("Date"): Tue, 20 Jan 2026 15:19:42 GMT, AnyHashable("Expires"): 0, AnyHashable("Pragma"): no-cache, AnyHashable("Cache-Control"): no-cache, no-store, max-age=0, must-revalidate, AnyHashable("Content-Type"): application/json, AnyHashable("Vary"): Origin, Access-Control-Request-Method, Access-Control-Request-Headers, AnyHashable("Transfer-Encoding"): Identity]
Body: {"status":200,"message":"자녀 목록 조회에 성공하였습니다.","data":[]}
===========================
```
<br>

## 💬 리뷰 코멘트
현재는 로그인한 부모 계정에 연결된 자녀가 아직 한 명도 없어서 앞단에서 API 구현이 되어야 최종적으로 확인해볼 수 있으며, 자녀 ID를 찾아야 다음 단계인 일정 조회로 넘어갈 수 있습니다. 
