### PR TITLE
[feat] #138 login logic 구현 및 자동로그인

### DIFF
--- a/Kiero/Kiero/Network/Login/TokenManager.swift
+++ b/Kiero/Kiero/Network/Login/TokenManager.swift
@@ -77,5 +77,7 @@ final class TokenManager {
         clearUserInfo()
     }
 
-    var isLoggedIn: Bool { getAccessToken() != nil }
+    var isLoggedIn: Bool {
+        getAccessToken() != nil && getRefreshToken() != nil
+    }
 }

--- a/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewController.swift
+++ b/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewController.swift
@@ -1,0 +1,66 @@
+//
+//  AuthGateViewController.swift
+//  Kiero
+//
+//  Created by 안치욱 on 1/21/26.
+//
+
+import Combine
+import UIKit
+
+final class AuthGateViewController: UIViewController {
+
+    private let viewModel: AuthGateViewModel
+    private var cancellables = Set<AnyCancellable>()
+
+    init(viewModel: AuthGateViewModel = AuthGateViewModel()) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+
+        bind()
+        viewModel.decideRoute()
+    }
+
+    private func bind() {
+        viewModel.route
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] route in
+                self?.handle(route)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func handle(_ route: AuthGateRoute) {
+        switch route {
+        case .pickRole:
+            let pickRoleVC = AppDIContainer.shared.makePickRoleViewController()
+            let nav = UINavigationController(rootViewController: pickRoleVC)
+            changeRoot(nav)
+
+        case .parentTab:
+            let nav = UINavigationController(
+                rootViewController: TabBarViewController(factory: AppDIContainer.shared, isParent: true)
+            )
+            changeRoot(nav)
+
+        case .childTab:
+            let nav = UINavigationController(
+                rootViewController: TabBarViewController(factory: AppDIContainer.shared, isParent: false)
+            )
+            changeRoot(nav)
+        }
+    }
+
+    private func changeRoot(_ vc: UIViewController) {
+        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+            sceneDelegate.changeRootViewController(vc)
+        }
+    }
+}

--- a/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewController.swift
+++ b/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewController.swift
@@ -22,7 +22,6 @@ final class AuthGateViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .black
 
         bind()
         viewModel.decideRoute()

--- a/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewModel.swift
+++ b/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewModel.swift
@@ -1,0 +1,39 @@
+//
+//  AuthGateViewModel.swift
+//  Kiero
+//
+//  Created by 안치욱 on 1/21/26.
+//
+
+import Combine
+import Foundation
+
+enum AuthGateRoute {
+    case pickRole
+    case parentTab
+    case childTab
+}
+
+final class AuthGateViewModel {
+
+    private let routeSubject = PassthroughSubject<AuthGateRoute, Never>()
+    var route: AnyPublisher<AuthGateRoute, Never> { routeSubject.eraseToAnyPublisher() }
+
+    func decideRoute() {
+
+        guard TokenManager.shared.getAccessToken() != nil else {
+            routeSubject.send(.pickRole)
+            return
+        }
+
+        let role = (TokenManager.shared.getUserRole() ?? "").lowercased()
+
+        if role.contains("parent") {
+            routeSubject.send(.parentTab)
+        } else if role.contains("child") {
+            routeSubject.send(.childTab)
+        } else {
+            routeSubject.send(.pickRole)
+        }
+    }
+}

--- a/Kiero/Kiero/Presentation/Common/Splash/SplashViewController.swift
+++ b/Kiero/Kiero/Presentation/Common/Splash/SplashViewController.swift
@@ -163,12 +163,18 @@ class SplashViewController: UIViewController {
     }
     
     private func transitionToMain() {
-        let pickRoleVC = AppDIContainer.shared.makePickRoleViewController()
-        let nav = UINavigationController(rootViewController: pickRoleVC)
+        let authVC = AuthGateViewController()
         if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
-            sceneDelegate.changeRootViewController(nav)
+            sceneDelegate.changeRootViewController(authVC)
         }
     }
+//    private func transitionToMain() {
+//        let pickRoleVC = AppDIContainer.shared.makePickRoleViewController()
+//        let nav = UINavigationController(rootViewController: pickRoleVC)
+//        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
+//            sceneDelegate.changeRootViewController(nav)
+//        }
+//    }
 }
 
 #Preview {

--- a/Kiero/Kiero/Presentation/Common/Splash/SplashViewController.swift
+++ b/Kiero/Kiero/Presentation/Common/Splash/SplashViewController.swift
@@ -168,13 +168,6 @@ class SplashViewController: UIViewController {
             sceneDelegate.changeRootViewController(authVC)
         }
     }
-//    private func transitionToMain() {
-//        let pickRoleVC = AppDIContainer.shared.makePickRoleViewController()
-//        let nav = UINavigationController(rootViewController: pickRoleVC)
-//        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
-//            sceneDelegate.changeRootViewController(nav)
-//        }
-//    }
 }
 
 #Preview {

--- a/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
+++ b/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
@@ -57,6 +57,7 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
 
                 TokenManager.shared.saveAccessToken(loginData.accessToken)
                 TokenManager.shared.saveRefreshToken(loginData.refreshToken)
+                TokenManager.shared.saveUserRole(loginData.role)
 
                 await MainActor.run {
                     self.stateSubject.send(.idle)


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #138 
<br>

## 🍎 작업 내용
메인 기능

로그인 시 Userdefault에 role을 저장하게끔 구현해 놓았는데
스플래쉬 뷰가 끝난 뒤 Auth 뷰컨에서 token이 있으면 Userdefault.role을 확인하고 각 역할 탭바로 이동하게끔 구현했습니다.

```swift 
func decideRoute() {

        guard TokenManager.shared.getAccessToken() != nil else {
            routeSubject.send(.pickRole)
            return
        }

        let role = (TokenManager.shared.getUserRole() ?? "").lowercased()

        if role.contains("parent") {
            routeSubject.send(.parentTab)
        } else if role.contains("child") {
            routeSubject.send(.childTab)
        } else {
            routeSubject.send(.pickRole)
        }
    }
```
<br>


## 💬 리뷰 코멘트
리뷰어가 신경써서 봐줄 부분을 알려주세요.
