### PR TITLE
[network] #118 로그아웃 API 구현

### DIFF
--- a/Kiero/Kiero/Network/Base/BaseService.swift
+++ b/Kiero/Kiero/Network/Base/BaseService.swift
@@ -105,10 +105,18 @@ final class BaseService {
             throw NetworkError.unknownError
         }
         
+        // Empty Body 대응
+        if data.isEmpty {
+            if Response.self == EmptyResponse.self {
+                return EmptyResponse() as! Response
+            } else {
+                throw NetworkError.noData
+            }
+        }
+
         // 디코딩
         do {
             if Response.self == EmptyResponse.self {
-                _ = try JSONDecoder().decode(BaseResponse<EmptyResponse>.self, from: data)
                 return EmptyResponse() as! Response
             }
             
@@ -116,16 +124,16 @@ final class BaseService {
             
             if let data = decoded.data {
                 return data
-            } else if let emptyResponse = EmptyResponse() as? Response {
-                return emptyResponse
+            } else if Response.self == EmptyResponse.self {
+                return EmptyResponse() as! Response
             } else {
                 throw NetworkError.noData
             }
             
-        } catch let error as NetworkError {
-            throw error
         } catch {
-            print("❌ Decoding Error 상세: \(error)")
+            if Response.self == EmptyResponse.self {
+                return EmptyResponse() as! Response
+            }
             throw NetworkError.responseDecodingError
         }
     }

--- a/Kiero/Kiero/Network/Base/EndPoint.swift
+++ b/Kiero/Kiero/Network/Base/EndPoint.swift
@@ -28,6 +28,7 @@ enum EndPoint {
     case logout
     case reissueAccessToken
     case reissueAllTokens
+    case deleteChildDummy
     
     // Child
     case fetchChildren
@@ -49,7 +50,7 @@ enum EndPoint {
     case postMissionSuggestions(request: MissionSuggestionRequestDTO)
     case postBulkMissions(childId: Int, request: MissionBulkCreateRequestDTO)
     
-    //CoinMission
+    // CoinMission
     case fetchChildrenInfo
     case fetchWishes
     case purchaseCoupon(couponId: Int64)
@@ -109,6 +110,8 @@ enum EndPoint {
             return "/api/v1/coupons/\(couponId)"
         case .fetchDefaultColor(let childId):
             return "/api/v1/schedules/\(childId)/default"
+        case .deleteChildDummy:
+            return "/api/v1/dummy"
         }
     }
     
@@ -118,6 +121,8 @@ enum EndPoint {
             return "GET"
         case .purchaseCoupon:
             return "PATCH"
+        case .deleteChildDummy:
+            return "DELETE"
         default:
             return "POST"
         }

--- a/Kiero/Kiero/Network/Schedule/Schedule/ScheduleService.swift
+++ b/Kiero/Kiero/Network/Schedule/Schedule/ScheduleService.swift
@@ -11,12 +11,13 @@ import Combine
 protocol ScheduleServiceType {
     func fetchChildren() -> AnyPublisher<[ChildResponseDTO], NetworkError>
     func fetchSchedules(childId: Int, startDate: Date, endDate: Date) -> AnyPublisher<[Schedule], NetworkError>
+    func deleteChildDummyData() -> AnyPublisher<Void, NetworkError>
+    func logout() -> AnyPublisher<Void, NetworkError>
 }
 
 final class ScheduleService: ScheduleServiceType {
     func fetchChildren() -> AnyPublisher<[ChildResponseDTO], NetworkError> {
         let endPoint = EndPoint.fetchChildren
-        
         return Future<[ChildResponseDTO], NetworkError> { promise in
             Task {
                 do {
@@ -34,7 +35,6 @@ final class ScheduleService: ScheduleServiceType {
     func fetchSchedules(childId: Int, startDate: Date, endDate: Date) -> AnyPublisher<[Schedule], NetworkError> {
         let startStr = startDate.toString(format: "yyyy-MM-dd")
         let endStr = endDate.toString(format: "yyyy-MM-dd")
-        
         let endPoint = EndPoint.fetchSchedules(childId: childId, startDate: startStr, endDate: endStr)
         
         return Future<[Schedule], NetworkError> { promise in
@@ -48,7 +48,32 @@ final class ScheduleService: ScheduleServiceType {
                     promise(.failure(.unknownError))
                 }
             }
-        }
-        .eraseToAnyPublisher()
+        }.eraseToAnyPublisher()
+    }
+    
+    func deleteChildDummyData() -> AnyPublisher<Void, NetworkError> {
+        return Future<Void, NetworkError> { promise in
+            Task {
+                do {
+                    let _: EmptyResponse = try await BaseService.shared.request(endPoint: .deleteChildDummy)
+                    promise(.success(()))
+                } catch {
+                    promise(.failure(error as? NetworkError ?? .unknownError))
+                }
+            }
+        }.eraseToAnyPublisher()
+    }
+    
+    func logout() -> AnyPublisher<Void, NetworkError> {
+        return Future<Void, NetworkError> { promise in
+            Task {
+                do {
+                    let _: EmptyResponse = try await BaseService.shared.request(endPoint: .logout)
+                    promise(.success(()))
+                } catch {
+                    promise(.failure(error as? NetworkError ?? .unknownError))
+                }
+            }
+        }.eraseToAnyPublisher()
     }
 }

--- a/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewController.swift
+++ b/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewController.swift
@@ -44,16 +44,12 @@ final class AuthGateViewController: UIViewController {
             changeRoot(nav)
 
         case .parentTab:
-            let nav = UINavigationController(
-                rootViewController: TabBarViewController(factory: AppDIContainer.shared, isParent: true)
-            )
-            changeRoot(nav)
+            let tab = TabBarViewController(factory: AppDIContainer.shared, isParent: true)
+            changeRoot(tab)
 
         case .childTab:
-            let nav = UINavigationController(
-                rootViewController: TabBarViewController(factory: AppDIContainer.shared, isParent: false)
-            )
-            changeRoot(nav)
+            let tab = TabBarViewController(factory: AppDIContainer.shared, isParent: false)
+            changeRoot(tab)
         }
     }
 

--- a/Kiero/Kiero/Presentation/Common/Extensions/UIViewController+Dialog.swift
+++ b/Kiero/Kiero/Presentation/Common/Extensions/UIViewController+Dialog.swift
@@ -35,7 +35,7 @@ extension UIViewController {
         }
     }
     
-    func performLogout() {
+    func navigateToPickRole() {
         let roleSelectionVC = PickRoleViewController(viewModel: PickRoleViewModel(), diContainer: AppDIContainer.shared)
         let nav = UINavigationController(rootViewController: roleSelectionVC)
         

--- a/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
+++ b/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
@@ -57,6 +57,8 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
 
                 TokenManager.shared.saveAccessToken(loginData.accessToken)
                 TokenManager.shared.saveRefreshToken(loginData.refreshToken)
+                TokenManager.shared.saveProfile(loginData.image)
+                TokenManager.shared.saveUserName(loginData.name)
                 TokenManager.shared.saveUserRole(loginData.role)
 
                 await MainActor.run {

--- a/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewController.swift
+++ b/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewController.swift
@@ -165,6 +165,19 @@ final class AIMissionViewController: BaseViewController<AIMissionViewModel> {
                 self?.dismiss(animated: true)
             }
             .store(in: &cancellables)
+        
+        viewModel.errorMessage
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] message in
+                guard let self = self else { return }
+                
+                if let presented = self.presentedViewController as? LoadingViewController {
+                    presented.dismiss(animated: false)
+                }
+                
+                Toast.show(message: message, bottomInset: 40)
+            }
+            .store(in: &cancellables)
     }
     
     @objc

--- a/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewModel.swift
+++ b/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewModel.swift
@@ -14,6 +14,7 @@ final class AIMissionViewModel: BaseViewModel {
     let suggestionResult = PassthroughSubject<[SuggestedMissionDTO], Never>()
     let isLoading = CurrentValueSubject<Bool, Never>(false)
     let bulkCreateSuccess = PassthroughSubject<Void, Never>()
+    let errorMessage = PassthroughSubject<String, Never>()
 
     init(service: AIMissionServiceType) {
         self.service = service
@@ -24,13 +25,21 @@ final class AIMissionViewModel: BaseViewModel {
         isLoading.send(true)
         
         service.postMissionSuggestions(text: text)
+            .timeout(.seconds(15), scheduler: DispatchQueue.main, customError: {
+                return NetworkError.unknownError
+            })
             .sink { [weak self] completion in
                 self?.isLoading.send(false)
                 if case .failure(let error) = completion {
                     print("❌ 알림장 분석 에러: \(error)")
+                    self?.errorMessage.send("알림장 내용을 분석하지 못했어요.")
                 }
             } receiveValue: { [weak self] missions in
-                self?.suggestionResult.send(missions)
+                if missions.isEmpty {
+                    self?.errorMessage.send("알림장 내용을 분석하지 못했어요.")
+                } else {
+                    self?.suggestionResult.send(missions)
+                }
             }
             .store(in: &cancellables)
     }

--- a/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewController.swift
+++ b/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewController.swift
@@ -33,7 +33,8 @@ final class NotificationFeedViewController: BaseViewController<NotificationFeedV
         
         contentView.onProfileTapped = { [weak self] in
             self?.showLogoutDialog {
-                self?.performLogout()
+                // TODO: 알림 API 합친 뒤 로그아웃 로직 추가
+//                self?.viewModel?.performLogout()
             }
         }
         

--- a/Kiero/Kiero/Presentation/Onboarding/View/ChildrenOnboardingViewController.swift
+++ b/Kiero/Kiero/Presentation/Onboarding/View/ChildrenOnboardingViewController.swift
@@ -156,9 +156,9 @@ final class ChildrenOnboardingViewController: BaseViewController<ChildrenOnboard
     }
     
     private func navigateToChildrenTap() {
-        let nav = UINavigationController(rootViewController: TabBarViewController(factory: AppDIContainer.shared, isParent: false))
+        let tab = TabBarViewController(factory: AppDIContainer.shared, isParent: false)
         if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
-            sceneDelegate.changeRootViewController(nav)
+            sceneDelegate.changeRootViewController(tab)
         }
     }
     

--- a/Kiero/Kiero/Presentation/Onboarding/View/ParentInviteViewController.swift
+++ b/Kiero/Kiero/Presentation/Onboarding/View/ParentInviteViewController.swift
@@ -103,11 +103,9 @@ final class ParentInviteViewController: BaseViewController<ParentInviteViewModel
     }
 
     private func navigateToParentTap() {
-        let nav = UINavigationController(
-            rootViewController: TabBarViewController(factory: AppDIContainer.shared, isParent: true)
-        )
+        let tab = TabBarViewController(factory: AppDIContainer.shared, isParent: true)
         if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
-            sceneDelegate.changeRootViewController(nav)
+            sceneDelegate.changeRootViewController(tab)
         }
     }
 }

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewController.swift
@@ -32,8 +32,8 @@ class ScheduleViewController: BaseViewController<ScheduleViewModel> {
     // MARK: - UI Components
     
     private lazy var profileBox = ProfileBox(
-        name: "신키로",
-        profileURL: "",
+        name: TokenManager.shared.getUserName() ?? "신키로",
+        profileURL: TokenManager.shared.getProfile() ?? "",
         backgroundColor: .clear
     ).then {
         $0.onTap = {[weak self] in

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewController.swift
@@ -38,7 +38,7 @@ class ScheduleViewController: BaseViewController<ScheduleViewModel> {
     ).then {
         $0.onTap = {[weak self] in
             self?.showLogoutDialog {
-                self?.performLogout()
+                self?.viewModel?.performLogout()
             }
         }
     }
@@ -239,6 +239,12 @@ class ScheduleViewController: BaseViewController<ScheduleViewModel> {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] dates in
                 self?.scheduleChildVC.updateWeeklyDates(dates)
+            }.store(in: &cancellables)
+        
+        viewModel.logoutSuccess
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.navigateToPickRole()
             }.store(in: &cancellables)
     }
 }

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewModel.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewModel.swift
@@ -17,6 +17,7 @@ final class ScheduleViewModel: BaseViewModel, ViewModelType {
     
     private(set) var scheduleList = CurrentValueSubject<[Schedule], Never>([])
     let currentReferenceDate = CurrentValueSubject<Date, Never>(Date())
+    let logoutSuccess = PassthroughSubject<Void, Never>()
     
     // MARK: - Input / Output
     
@@ -178,5 +179,31 @@ final class ScheduleViewModel: BaseViewModel, ViewModelType {
         var current = scheduleList.value
         current.append(schedule)
         scheduleList.send(current)
+    }
+    
+    func performLogout() {
+        service.deleteChildDummyData()
+            .handleEvents(receiveSubscription: { _ in
+                print("📡 [1단계] 아이 데이터 삭제 API 구독 시작")
+            })
+            .catch { error in
+                print("⚠️ [1단계 에러] 삭제 실패(무시하고 진행): \(error)")
+                return Just(())
+            }
+            .flatMap { [weak self] _ -> AnyPublisher<Void, NetworkError> in
+                print("🚀 [2단계] 부모 로그아웃 API 요청 전송")
+                guard let self = self else { return Fail(error: .unknownError).eraseToAnyPublisher() }
+                return self.service.logout()
+            }
+            .sink { completion in
+                if case .failure(let error) = completion {
+                    print("❌ 최종 로그아웃 실패: \(error)")
+                }
+            } receiveValue: { [weak self] _ in
+                print("✅ 서버 로그아웃 응답 성공")
+                TokenManager.shared.clearAll()
+                self?.logoutSuccess.send(())
+            }
+            .store(in: &cancellables)
     }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #118 
<br>

## 🍎 작업 내용
- 아이 데이터 삭제 API를 구현했습니다.
- 로그아웃 API를 구현했습니다.
- 스케줄 관리 > 일정에서의 ProfileBox 데이터 주입 로직을 구현했습니다.
- UINavigationcontroller와 TabBar의 위계가 거꾸로 되어 TabBarViewController의 상단에 네비게이션 바 영역이 잡히는 문제를 해결했습니다.
- Empty Body를 대응하기 위한 코드를 추가했습니다.
<br>

## 📸 로그
로그아웃이 성공적으로 실행된 로그입니다.
<img src="https://github.com/user-attachments/assets/6ff2c354-a38b-467f-8714-385d4074db9f" width="500">
<br>

## 💬 리뷰 코멘트
빠르게 확인 후 어푸 부탁드립니다 ! 머지 후에는 꼭 Pull 받아서 본인이 구현한 API 로직과 충돌나는 부분은 없는지 확인해주세요 💬