### PR TITLE
[network] #109 금화미션 API 연결

### DIFF
--- a/Kiero/Kiero/Network/Base/EndPoint.swift
+++ b/Kiero/Kiero/Network/Base/EndPoint.swift
@@ -65,7 +65,7 @@ enum EndPoint {
         switch self {
         case .kakaoLogin, .kakaoAccessToken, .childSignup, .reissueAccessToken, .reissueAllTokens:
             return .none
-        case .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .purchaseCoupon, .completeMission:
+        case .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .purchaseCoupon, .completeMission, .fireLit:
             return .child
         default:
             return .parent
@@ -156,7 +156,7 @@ enum EndPoint {
         switch self {
         case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor, .fetchFeeds:
             return "GET"
-        case .updateDailyJourney, .skipJourney, .completeSchedule, .purchaseCoupon, .fireLit:
+        case .updateDailyJourney, .skipJourney, .completeSchedule, .purchaseCoupon, .fireLit, .completeMission:
             return "PATCH"
         case .deleteChildDummy:
             return "DELETE"

--- a/Kiero/Kiero/Network/Base/EndPoint.swift
+++ b/Kiero/Kiero/Network/Base/EndPoint.swift
@@ -49,16 +49,19 @@ enum EndPoint {
     case postMissionSuggestions(request: MissionSuggestionRequestDTO)
     case postBulkMissions(childId: Int, request: MissionBulkCreateRequestDTO)
     
-    //CoinMission
+    // WishWell
     case fetchChildrenInfo
     case fetchWishes
     case purchaseCoupon(couponId: Int64)
+    
+    // CoinMission
+    case completeMission(missionId: Int64)
     
     var refreshPolicy: TokenRefreshPolicy {
         switch self {
         case .kakaoLogin, .kakaoAccessToken, .childSignup, .reissueAccessToken, .reissueAllTokens:
             return .none
-        case .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .purchaseCoupon:
+        case .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .purchaseCoupon, .completeMission:
             return .child
         default:
             return .parent
@@ -109,6 +112,8 @@ enum EndPoint {
             return "/api/v1/coupons/\(couponId)"
         case .fetchDefaultColor(let childId):
             return "/api/v1/schedules/\(childId)/default"
+        case .completeMission(let missionId):
+            return "/api/v1/missions/\(missionId)/complete"
         }
     }
     
@@ -116,7 +121,7 @@ enum EndPoint {
         switch self {
         case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor:
             return "GET"
-        case .purchaseCoupon:
+        case .purchaseCoupon, .completeMission:
             return "PATCH"
         default:
             return "POST"

--- a/Kiero/Kiero/Network/CoinMission/CoinMissionDTO.swift
+++ b/Kiero/Kiero/Network/CoinMission/CoinMissionDTO.swift
@@ -1,0 +1,16 @@
+//
+//  CoinMissionService.swift
+//  Kiero
+//
+//  Created by 정윤아 on 1/22/26.
+//
+
+import Foundation
+
+struct MissionCompleteResponseDTO: Decodable {
+    let id: Int64
+    let name: String
+    let reward: Int
+    let dueAt: String       
+    let isCompleted: Bool
+}

--- a/Kiero/Kiero/Network/CoinMission/CoinMissionService.swift
+++ b/Kiero/Kiero/Network/CoinMission/CoinMissionService.swift
@@ -1,0 +1,33 @@
+//
+//  CoinMissionService.swift
+//  Kiero
+//
+//  Created by 정윤아 on 1/22/26.
+//
+
+import Combine
+import Foundation
+
+protocol CoinMissionServiceType {
+    func completeMission(missionId: Int64) -> AnyPublisher<MissionCompleteResponseDTO, NetworkError>
+}
+
+final class CoinMissionService: CoinMissionServiceType {
+    func completeMission(missionId: Int64) -> AnyPublisher<MissionCompleteResponseDTO, NetworkError> {
+        let endpoint = EndPoint.completeMission(missionId: missionId)
+        
+        return Future { promise in
+            Task {
+                do {
+                    let dto: MissionCompleteResponseDTO = try await BaseService.shared.request(endPoint: endpoint)
+                    promise(.success(dto))
+                } catch let error as NetworkError {
+                    promise(.failure(error))
+                } catch {
+                    promise(.failure(.unknownError))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Kiero/Kiero/Presentation/CoinMission/CoinMissionViewController.swift
+++ b/Kiero/Kiero/Presentation/CoinMission/CoinMissionViewController.swift
@@ -13,19 +13,21 @@ final class CoinMissionViewController: BaseViewController<CoinMissionViewModel> 
     // MARK: - Properties
     
     private let rootView = CoinMissionView()
-    private var dataSource: [DailyMissionData] = []
+    private var dataSource: [MissionGroupDTO] = []
+    
+    private let completeMissionSubject = PassthroughSubject<Int64, Never>()
+    private let viewWillAppearSubject = PassthroughSubject<Void, Never>()
     
     // MARK: - Life Cycle
     
     override func loadView() { view = rootView }
     
-    // MARK: - Setup Methods
-    
-    override func setUI() {
-        if let vm = viewModel {
-            rootView.configureUserInfo(name: vm.userName, price: vm.currentCoinCount)
-        }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewWillAppearSubject.send(())
     }
+    
+    // MARK: - Setup Methods
     
     override func setDelegate() {
         rootView.missionCollectionView.delegate = self
@@ -36,21 +38,29 @@ final class CoinMissionViewController: BaseViewController<CoinMissionViewModel> 
     
     override func bind(viewModel: CoinMissionViewModel) {
         let input = CoinMissionViewModel.Input(
-            viewDidLoad: Just(()).eraseToAnyPublisher()
+            viewDidLoad: Just(()).eraseToAnyPublisher(),
+            viewWillAppear: viewWillAppearSubject.eraseToAnyPublisher(),
+            completeMission: completeMissionSubject.eraseToAnyPublisher()
         )
         
         let output = viewModel.transform(input: input)
-        output.missionData
+        
+        output.userInfo
             .receive(on: RunLoop.main)
-            .sink { [weak self] data in
-                guard let self = self else { return }
+            .sink { [weak self] info in
+                self?.rootView.configureUserInfo(name: info.firstName, price: info.coinAmount)
+            }
+            .store(in: &cancellables)
+        
+        output.missions
+            .receive(on: RunLoop.main)
+            .sink { [weak self] groups in
+                guard let self else { return }
                 
-                self.dataSource = data
-                let isEmpty = data.isEmpty
+                self.dataSource = groups
+                let isEmpty = groups.isEmpty
                 self.rootView.updateEmptyState(isEmpty: isEmpty)
-                if !isEmpty {
-                    self.rootView.missionCollectionView.reloadData()
-                }
+                self.rootView.missionCollectionView.reloadData()
             }
             .store(in: &cancellables)
     }
@@ -69,13 +79,16 @@ extension CoinMissionViewController: UICollectionViewDataSource {
             for: indexPath
         ) as? DailyMissionCell else { return UICollectionViewCell() }
         
-        let data = dataSource[indexPath.item]
+        let group = dataSource[indexPath.item]
+        
         cell.configure(
-            date: data.date,
-            missions: data.missions
+            dueAt: group.dueAt,
+            dayOfWeek: group.dayOfWeek,
+            missions: group.missions
         )
-        cell.missionTapHandler = { [weak self] id, name in
-            self?.handleMissionTap(id: id, name: name)
+        
+        cell.missionTapHandler = { [weak self] missionId, name in
+            self?.handleMissionTap(id: missionId, name: name)
         }
         return cell
     }
@@ -98,40 +111,22 @@ private extension CoinMissionViewController {
         view.showDialog(state: dialogState) { [weak self] in
             guard let self = self else { return }
             
-            var rewardAmount = 0
-            for data in self.dataSource {
-                if let mission = data.missions.first(where: { $0.id == id }) {
-                    rewardAmount = mission.reward
-                    break
-                }
-            }
+            let rewardAmount = self.findRewardAmount(missionId: id)
             self.view.showConfirm(state: .coinMission(count: rewardAmount)) {
-                self.completeMissionDirectly(id: id, reward: rewardAmount)
+                self.completeMissionSubject.send(id)
             }
         }
     }
     
-    private func completeMissionDirectly(id: Int64, reward: Int) {
-        viewModel?.getCoin(reward: reward)
+    func findRewardAmount(missionId: Int64) -> Int {
+        let targetId = Int(missionId) // MissionItemDTO.id가 Int
         
-        for (sectionIndex, dayDate) in dataSource.enumerated() {
-            if let missionIndex = dayDate.missions.firstIndex(where: {$0.id == id}) {
-                var updatedMissions = dayDate.missions
-                updatedMissions[missionIndex].isCompleted = true
-                
-                dataSource[sectionIndex] = DailyMissionData(
-                    date: dayDate.date,
-                    missions: updatedMissions
-                )
-                break
+        for group in dataSource {
+            if let mission = group.missions.first(where: { $0.id == targetId }) {
+                return mission.reward
             }
         }
-        
-        if let vm = viewModel {
-            rootView.configureUserInfo(name: vm.userName, price: vm.currentCoinCount)
-        }
-        rootView.missionCollectionView.reloadData()
-        // TODO: 서버에게 변경된 금화, 상태 데이터 전송
+        return 0
     }
 }
 

--- a/Kiero/Kiero/Presentation/CoinMission/CoinMissionViewModel.swift
+++ b/Kiero/Kiero/Presentation/CoinMission/CoinMissionViewModel.swift
@@ -8,52 +8,132 @@
 import Foundation
 import Combine
 
-struct DailyMissionData {
-    let date: Date
-    let missions: [(id: Int64, name: String, reward: Int, isCompleted: Bool)]
-}
-
 final class CoinMissionViewModel: BaseViewModel, ViewModelType {
     
     struct Input {
         let viewDidLoad: AnyPublisher<Void, Never>
+        let viewWillAppear: AnyPublisher<Void, Never>
+        let completeMission: AnyPublisher<Int64, Never>
     }
     
     struct Output {
-        let missionData: AnyPublisher<[DailyMissionData], Never>
+        let userInfo: AnyPublisher<ChildrenInfo,Never>
+        let missions: AnyPublisher<[MissionGroupDTO], Never>
     }
     
-    let userName: String = "윤아"
-    var currentCoinCount: Int = 350
+    private let wishWellService: WishWellServiceType
+    private let missionService: MissionServiceType
+    private let coinMissionService: CoinMissionServiceType
     
-    private let missionDataSubject = CurrentValueSubject<[DailyMissionData], Never>([
-        DailyMissionData(date: Date(), missions: [
-            (1, "설거지하기", 50, false),
-            (2, "동생 숙제 도와주기", 50, false),
-            (3, "강아지 하리 산책시키기", 50, true)
-        ]),
-        DailyMissionData(date: Calendar.current.date(byAdding: .day, value: 1, to: Date())!, missions: [
-            (4, "방 청소하기", 30, false),
-            (5, "일기 쓰기", 20, false)
-        ]),
-        DailyMissionData(date: Calendar.current.date(byAdding: .day, value: 3, to: Date())!, missions: [
-            (6, "방 청소하기", 30, false),
-            (7, "일기 쓰기", 20, false)
-        ]),
-    ])
+    private let userInfoSubject =
+    CurrentValueSubject<ChildrenInfo, Never>(
+        .init(firstName: "", coinAmount: 0, today: "")
+    )
+    private let missionsSubject =
+    CurrentValueSubject<[MissionGroupDTO], Never>([])
+    
+    init(
+        wishWellService: WishWellServiceType = WishWellService(),
+        missionService: MissionServiceType = MissionService(),
+        coinMissionService: CoinMissionServiceType = CoinMissionService()
+    ) {
+        self.wishWellService = wishWellService
+        self.missionService = missionService
+        self.coinMissionService = coinMissionService
+        super.init()
+    }
     
     func transform(input: Input) -> Output {
         input.viewDidLoad
             .sink { [weak self] _ in
-                guard let self = self else { return }
-                self.missionDataSubject.send(self.missionDataSubject.value)
+                self?.fetchUserInfo()
+                self?.fetchMissions()
             }
             .store(in: &cancellables)
-            
-        return Output(missionData: missionDataSubject.eraseToAnyPublisher())
+        
+        input.viewWillAppear
+            .sink { [weak self] _ in
+                self?.fetchUserInfo()
+                self?.fetchMissions()
+            }
+            .store(in: &cancellables)
+        
+        input.completeMission
+            .flatMap { [weak self] missionId -> AnyPublisher<MissionCompleteResponseDTO, Never> in
+                guard let self else { return Empty().eraseToAnyPublisher() }
+                return self.coinMissionService.completeMission(missionId: missionId)
+                    .catch { error in
+                        print("❌ 미션 완료 실패:", error)
+                        return Empty<MissionCompleteResponseDTO, Never>()
+                    }
+                    .eraseToAnyPublisher()
+            }
+            .sink { [weak self] dto in
+                self?.applyComplete(dto)
+            }
+            .store(in: &cancellables)
+        
+        return Output (
+            userInfo: userInfoSubject.eraseToAnyPublisher(),
+            missions: missionsSubject.eraseToAnyPublisher()
+        )
     }
     
-    func getCoin(reward: Int) {
-        self.currentCoinCount += reward
+    private func fetchUserInfo() {
+        wishWellService.fetchMyInfo()
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { [weak self] info in
+                self?.userInfoSubject.send(info)
+            })
+            .store(in: &cancellables)
+    }
+    
+    private func fetchMissions() {
+        missionService.fetchMissions(childId: nil)
+            .sink(receiveCompletion: { _ in },
+                  receiveValue: { [weak self] dto in
+                self?.missionsSubject.send(dto.missionsByDate)
+            })
+            .store(in: &cancellables)
+    }
+    
+    private func applyComplete(_ dto: MissionCompleteResponseDTO) {
+        var current = missionsSubject.value
+        
+        let completedId = Int(dto.id)
+        
+        for groupIdx in current.indices {
+            if let missionIdx = current[groupIdx].missions.firstIndex(where: { $0.id == completedId }) {
+                
+                var updatedMissions = current[groupIdx].missions
+                let old = updatedMissions[missionIdx]
+                
+                updatedMissions[missionIdx] = MissionItemDTO(
+                    id: old.id,
+                    name: old.name,
+                    reward: old.reward,
+                    isCompleted: true
+                )
+                
+                let oldGroup = current[groupIdx]
+                current[groupIdx] = MissionGroupDTO(
+                    dueAt: oldGroup.dueAt,
+                    dayOfWeek: oldGroup.dayOfWeek,
+                    missions: updatedMissions
+                )
+                
+                break
+            }
+        }
+        
+        missionsSubject.send(current)
+        
+        var user = userInfoSubject.value
+        user = ChildrenInfo(
+            firstName: user.firstName,
+            coinAmount: user.coinAmount + dto.reward,
+            today: user.today
+        )
+        userInfoSubject.send(user)
     }
 }

--- a/Kiero/Kiero/Presentation/CoinMission/DailyMissionCell.swift
+++ b/Kiero/Kiero/Presentation/CoinMission/DailyMissionCell.swift
@@ -64,9 +64,9 @@ class DailyMissionCell: UICollectionViewCell {
     
     // MARK: - Configuration
     
-    func configure(date: Date, missions: [(id: Int64, name: String, reward: Int, isCompleted: Bool)]) {
-        dateLabel.setTypo(.body4_12_R, text: date.toMissionDateString())
-        missionStack.arrangedSubviews.forEach { $0.removeFromSuperview()}
+    func configure(dueAt: String, dayOfWeek: String, missions: [MissionItemDTO]) {
+        dateLabel.setTypo(.body4_12_R, text: dueAt.toMissionDateString(dayOfWeek: dayOfWeek))
+        missionStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
         
         for mission in missions {
             let missionView = createMissionView(from: mission)
@@ -74,13 +74,13 @@ class DailyMissionCell: UICollectionViewCell {
         }
     }
     
-    private func createMissionView(from mission: (id: Int64, name: String, reward: Int, isCompleted: Bool)) -> MissionBoxChild {
+    private func createMissionView(from mission: MissionItemDTO) -> MissionBoxChild {
         let missionView = MissionBoxChild()
         let state: MissionBoxChild.State = mission.isCompleted ? .completed : .inProgress
         
         missionView.configure(name: mission.name, reward: mission.reward, state: state)
         missionView.onTap = { [weak self] in
-            self?.missionTapHandler?(mission.id, mission.name)
+            self?.missionTapHandler?(Int64(mission.id), mission.name)
         }
         return missionView
     }
@@ -91,16 +91,35 @@ class DailyMissionCell: UICollectionViewCell {
     }
 }
 
-extension Date {
-    func toMissionDateString() -> String {
-        let calendar = Calendar.current
-        if calendar.isDateInToday(self) { return "오늘까지"}
-        else if calendar.isDateInTomorrow(self) { return "내일까지" }
-        else {
+extension String {
+    
+    func toMissionDateString(dayOfWeek: String) -> String {
+        let parsed = self.toDateFlexible()
+        
+        if let date = parsed {
+            let calendar = Calendar.current
+            if calendar.isDateInToday(date) { return "오늘까지" }
+            if calendar.isDateInTomorrow(date) { return "내일까지" }
+            
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "ko_KR")
-            formatter.dateFormat = "M월 d일 E요일까지"
-            return formatter.string(from: self)
+            formatter.dateFormat = "M월 d일 \(dayOfWeek)까지"
+            return formatter.string(from: date)
         }
+        
+        return "\(self) \(dayOfWeek)까지"
+    }
+    
+    private func toDateFlexible() -> Date? {
+        let fmts = ["yyyy.MM.dd", "yyyy-MM-dd", "yyyy/MM/dd"]
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ko_KR")
+        f.timeZone = TimeZone(identifier: "Asia/Seoul")
+        
+        for fmt in fmts {
+            f.dateFormat = fmt
+            if let d = f.date(from: self) { return d }
+        }
+        return nil
     }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #109
<br>

## 🍎 작업 내용
금화 미션 뷰의 API를 연결하였습니다. 
- 상단의 아이 이름과 금화 정보 조회
- 미션 리스트 조회
- 미션 리스트 날짜별 매핑
- 미션 성공시 완료 API 서버에 전달 
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 기능1 |![Simulator Screen Recording - iPhone 17 - 2026-01-22 at 09 56 03](https://github.com/user-attachments/assets/90c716f7-f994-4b2a-a86e-302c7813de0a)|
<br>

## 💬 리뷰 코멘트
진짜 밤새면서 작업해서..... 이상한 부분 있으면 알려주세요
