### PR TITLE
[network] #145 알림 내 로그아웃 API 구현

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
+++ b/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
@@ -10,6 +10,10 @@ import UIKit
 import SnapKit
 import Then
 
+protocol ScrollToTopAvailable {
+    func scrollToTop()
+}
+
 public final class TabBarViewController: UITabBarController {
     
     private let factory: ViewControllerFactory
@@ -141,10 +145,6 @@ extension TabBarViewController: UITabBarControllerDelegate {
             findScrollViewAndScrollToTop(in: subview)
         }
     }
-}
-
-protocol ScrollToTopAvailable {
-    func scrollToTop()
 }
 
 extension TabBarViewController: UINavigationControllerDelegate {

--- a/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewController.swift
+++ b/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewController.swift
@@ -43,8 +43,7 @@ final class NotificationFeedViewController: BaseViewController<NotificationFeedV
         
         contentView.onProfileTapped = { [weak self] in
             self?.showLogoutDialog {
-                // TODO: 알림 API 합친 뒤 로그아웃 로직 추가
-//                self?.viewModel?.performLogout()
+                self?.viewModel?.performLogout()
             }
         }
         
@@ -64,6 +63,13 @@ final class NotificationFeedViewController: BaseViewController<NotificationFeedV
             .store(in: &cancellables)
         
         viewDidLoadSubject.send(())
+        
+        viewModel.logoutSuccess
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.navigateToPickRole()
+            }
+            .store(in: &cancellables)
     }
 }
 

--- a/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewController.swift
+++ b/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewController.swift
@@ -25,7 +25,7 @@ final class NotificationFeedViewController: BaseViewController<NotificationFeedV
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+        self.tabBarController?.delegate = self
         contentView.updateProfile()
         refreshSubject.send(())
     }
@@ -139,7 +139,20 @@ extension NotificationFeedViewController: UITableViewDelegate {
 extension NotificationFeedViewController: ScrollToTopAvailable {
     func scrollToTop() {
         if viewModel?.sections.isEmpty == false {
-            contentView.tableView.setContentOffset(.zero, animated: false)
+            contentView.tableView.setContentOffset(.zero, animated: true)
         }
+    }
+}
+
+extension NotificationFeedViewController: UITabBarControllerDelegate {
+    func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        let targetVC = (viewController as? UINavigationController)?.viewControllers.first ?? viewController
+        
+        if targetVC === self {
+            if tabBarController.selectedViewController === viewController {
+                self.scrollToTop()
+            }
+        }
+        return true
     }
 }

--- a/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
+++ b/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
@@ -23,6 +23,7 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
     private let isLoadingSubject = CurrentValueSubject<Bool, Never>(false)
     private let isLoadingMoreSubject = CurrentValueSubject<Bool, Never>(false)
     private let sectionsSubject = CurrentValueSubject<[FeedSection], Never>([])
+    let logoutSuccess = PassthroughSubject<Void, Never>()
     
     private(set) var sections: [FeedSection] = []
     private var nextCursor: String? = nil
@@ -141,6 +142,32 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
             isLoading: isLoadingSubject.eraseToAnyPublisher(),
             isLoadingMore: isLoadingMoreSubject.eraseToAnyPublisher()
         )
+    }
+    
+    func performLogout() {
+        scheduleService.deleteChildDummyData()
+            .handleEvents(receiveSubscription: { _ in
+                print("📡 [1단계] 아이 데이터 삭제 API 구독 시작")
+            })
+            .catch { error in
+                print("⚠️ [1단계 에러] 삭제 실패(무시하고 진행): \(error)")
+                return Just(())
+            }
+            .flatMap { [weak self] _ -> AnyPublisher<Void, NetworkError> in
+                print("🚀 [2단계] 부모 로그아웃 API 요청 전송")
+                guard let self = self else { return Fail(error: .unknownError).eraseToAnyPublisher() }
+                return self.scheduleService.logout()
+            }
+            .sink { completion in
+                if case .failure(let error) = completion {
+                    print("❌ 최종 로그아웃 실패: \(error)")
+                }
+            } receiveValue: { [weak self] _ in
+                print("✅ 서버 로그아웃 응답 성공")
+                TokenManager.shared.clearAll()
+                self?.logoutSuccess.send(())
+            }
+            .store(in: &cancellables)
     }
     
     // MARK: - Helpers

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleChildViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleChildViewController.swift
@@ -112,3 +112,11 @@ final class ScheduleChildViewController: BaseViewController<ScheduleViewModel> {
         scheduleView.timeTableView.updateDaysDates(dates)
     }
 }
+
+extension ScheduleChildViewController: ScrollToTopAvailable {
+    func scrollToTop() {
+        DispatchQueue.main.async { [weak self] in
+            self?.scheduleView.timeTableView.scrollToTop()
+        }
+    }
+}

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewController.swift
@@ -68,7 +68,7 @@ class ScheduleViewController: BaseViewController<ScheduleViewModel> {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+        self.tabBarController?.delegate = self
         viewModel?.refreshSchedules()
     }
     
@@ -113,6 +113,16 @@ class ScheduleViewController: BaseViewController<ScheduleViewModel> {
                 self.presentAddSchedule()
             } else {
                 self.presentAddMission()
+            }
+        }
+    }
+    
+    private func scrollToTopCurrentTab() {
+        if currentTabIndex == 0 {
+            scheduleChildVC.scrollToTop()
+        } else {
+            if let missionVC = missionVC as? ScrollToTopAvailable {
+                missionVC.scrollToTop()
             }
         }
     }
@@ -249,11 +259,17 @@ class ScheduleViewController: BaseViewController<ScheduleViewModel> {
     }
 }
 
-extension ScheduleChildViewController: ScrollToTopAvailable {
-    func scrollToTop() {
-        DispatchQueue.main.async { [weak self] in
-            self?.scheduleView.timeTableView.scrollToTop()
+extension ScheduleViewController: UITabBarControllerDelegate {
+    
+    func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
+        let targetVC = (viewController as? UINavigationController)?.topViewController ?? viewController
+        
+        if targetVC === self {
+            if tabBarController.selectedViewController === viewController {
+                scrollToTopCurrentTab()
+            }
         }
+        return true
     }
 }
 

--- a/Kiero/Kiero/Presentation/Schedule/WeeklyTimeTable/WeeklyTimeTableView.swift
+++ b/Kiero/Kiero/Presentation/Schedule/WeeklyTimeTable/WeeklyTimeTableView.swift
@@ -172,7 +172,7 @@ final class WeeklyTimeTableView: BaseUIView {
     }
     
     func scrollToTop() {
-        scrollView.setContentOffset(CGPoint.zero, animated: false)
+        scrollView.setContentOffset(CGPoint.zero, animated: true)
     }
     
     func updateEmptyState(isEmpty: Bool) {


### PR DESCRIPTION
## 📟 연결된 이슈
closed #145 
<br>

## 🍎 작업 내용
- 스케줄 관리 > 알림 내 로그아웃 API를 구현했습니다.
- 탭 바 재클릭 시 상단으로 초기화 되도록 하였습니다.
<br>

## 📸 스크린샷
| 기능/화면 | 로그아웃 API |
|:---------:|:-------------:|
| 로그 | <img src="https://github.com/user-attachments/assets/a8c50d92-0787-4345-bddf-e92e86d48a24" width="500"> |
<br>

## 💬 리뷰 코멘트
빠른 어푸 부탁탁구리
