### PR TITLE
[refactor] #153 소원의 우물 토스트 위치 수정

### DIFF
--- a/Kiero/Kiero/Presentation/WishWell/WishWellViewController.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellViewController.swift
@@ -106,7 +106,7 @@ private extension WishWellViewController {
         let data = vm.coupons[indexPath.item]
         
         if vm.currentCoinCount < data.price {
-            Toast.show(message: "금화가 부족해! 미션을 더 하고 오자!")
+            Toast.show(message: "금화가 부족해! 미션을 더 하고 오자!", bottomInset: 117)
             return
         }
         let dialogState = DialogBox.State.wishWell(title: data.name, coin: "\(data.price)")


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #153 
<br>

## 🍎 작업 내용
소원의 우물 뷰에서 금화 부족시 나타나는 토스트 메세지의 위치를 수정했습니다. 
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 기능1 |<img width="250" alt="Simulator Screenshot - iPhone 17 - 2026-01-23 at 00 46 54" src="https://github.com/user-attachments/assets/21241d0a-52b8-4127-a04e-266a4662293e" />|
<br>

## 💬 리뷰 코멘트
자녀 이름 입력하다가 말고 다른 시뮬 켜고 자식 뷰로 들어갔더니 자식 연동이 안되네요. 토스트 위치만 확인 부탁드립니다. 
