### PR TITLE
[refactor] #151 오늘의 여정 로직 수정

### DIFF
--- a/Kiero/Kiero/Network/DailyJourney/DailyJourneyService.swift
+++ b/Kiero/Kiero/Network/DailyJourney/DailyJourneyService.swift
@@ -53,7 +53,6 @@ final class DailyJourneyService {
             Task {
                 do {
                     guard let imageData = image.jpegData(compressionQuality: 0.8) else {
-                        print("❌ 이미지 인코딩 실패")
                         promise(.failure(.unknownError))
                         return
                     }
@@ -70,7 +69,7 @@ final class DailyJourneyService {
                     )
                     
                     let s3UrlString = presignedData.presignedUrl
-                    let finalFileName = presignedData.fileName
+                    let cleanImageUrl = s3UrlString.components(separatedBy: "?").first ?? s3UrlString
                     
                     guard let s3Url = URL(string: s3UrlString) else {
                         promise(.failure(.invalidURL))
@@ -82,7 +81,6 @@ final class DailyJourneyService {
                     s3Request.setValue("image/jpeg", forHTTPHeaderField: "Content-Type")
                     
                     print("📤 S3 업로딩 시작")
-                    
                     let (data, response) = try await URLSession.shared.upload(for: s3Request, from: imageData)
                     
                     guard let s3HttpRes = response as? HTTPURLResponse else {
@@ -92,30 +90,23 @@ final class DailyJourneyService {
                     
                     NetworkLogger.shared.responseLog(s3HttpRes, data: data)
                     
-                    switch s3HttpRes.statusCode {
-                    case 200...299:
-                        break
-                    case 400...499:
+                    if !(200...299).contains(s3HttpRes.statusCode) {
                         throw NetworkError.clientError(statusCode: s3HttpRes.statusCode)
-                    case 500...599:
-                        throw NetworkError.internalServerError
-                    default:
-                        throw NetworkError.unknownError
                     }
                     
-                    let requestBody = JourneyVerificationDTO.CompleteRequest(imageUrl: finalFileName)
+                    let requestBody = JourneyVerificationDTO.CompleteRequest(imageUrl: cleanImageUrl)
+                    
                     let _: String? = try await BaseService.shared.request(
                         endPoint: .completeSchedule(scheduleDetailId: scheduleDetailId),
                         body: requestBody
                     )
                     
-                    print("✅ 모든 과정 성공")
+                    print("✅ 모든 과정 성공 (DB 저장 URL: \(cleanImageUrl))")
                     promise(.success(()))
                     
                 } catch let error as NetworkError {
                     promise(.failure(error))
                 } catch {
-                    print("❌ [Verify] Unexpected Error: \(error)")
                     promise(.failure(.unknownError))
                 }
             }

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyHeaderView.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyHeaderView.swift
@@ -74,7 +74,14 @@ final class DailyJourneyHeaderView: BaseUIView {
     
     // MARK: - Configure
     
-    func configure(kidName: String, date: String, coinCount: Int, fireStoneCount: Int, maxFireStoneCount: Int) {
+    func configure(
+        kidName: String,
+        date: String,
+        coinCount: Int,
+        fireStoneCount: Int,
+        maxFireStoneCount: Int,
+        chipType: ChipItem.ChipStyle
+    ) {
         nameLabel.setTypo(.title3_16_SB, text: kidName)
         dateLabel.setTypo(.body3_14_R, text: date)
         
@@ -82,6 +89,6 @@ final class DailyJourneyHeaderView: BaseUIView {
         let stoneImg = UIImage(resource: .ic3DBluestone)
         
         coinChip.configure(style: .currentCoinChip, icon: coinImg, text: "\(coinCount) 개")
-        fireStoneChip.configure(style: .inProgressChip, icon: stoneImg, text: "\(fireStoneCount) / \(maxFireStoneCount) 개")
+        fireStoneChip.configure(style: chipType, icon: stoneImg, text: "\(fireStoneCount) / \(maxFireStoneCount) 개")
     }
 }

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
@@ -130,7 +130,8 @@ final class DailyJourneyView: BaseUIView {
             date: data.dateText,
             coinCount: data.coinCount,
             fireStoneCount: data.fireStoneCount,
-            maxFireStoneCount: data.maxFireStoneCount
+            maxFireStoneCount: data.maxFireStoneCount,
+            chipType: data.chipItemType
         )
         
         journeyTimeView.isHidden = !data.isTimeViewActive
@@ -162,7 +163,7 @@ final class DailyJourneyView: BaseUIView {
         case .lightFire:
             verifyPhotoButton.isHidden = false
             verifyPhotoButton.configure(
-                title: "마음의 불꽃 피우기",
+                title: "마음의 불꽃 피워주기",
                 icon: nil
             )
             

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -149,11 +149,9 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         if isScheduleActive && !schedule.isNowScheduleVerified {
             buttonType = .verify
         }
-        
         else if schedule.scheduleStatus == .fireNotLit && (schedule.earnedStones ?? 0) > 0 {
             buttonType = .lightFire
         }
-        
         else {
             buttonType = .hidden
         }
@@ -173,6 +171,8 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 bubbleText = "다음은 \(scheduleName)의 시간이야!\n다음 여정을 진행하면 \(stoneTypeName)의 불조각을 줄게."
             }
             
+            let isLastJourney = (schedule.scheduleOrder == schedule.totalSchedule)
+            
             return DailyJourneyModel(
                 bubbleText: bubbleText,
                 highlightKeywords: [scheduleName, stoneTypeName],
@@ -185,7 +185,7 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 maxFireStoneCount: schedule.totalSchedule,
                 scheduleOrder: schedule.scheduleOrder,
                 scheduleOrderText: orderText,
-                speechFieldType: .gray,
+                speechFieldType: isLastJourney ? .no : .gray,
                 chipItemType: .inProgressChip,
                 isTimeViewActive: isTimeViewActive,
                 actionButtonType: buttonType

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -92,7 +92,6 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         } receiveValue: { [weak self] (scheduleDTO, childInfo) in
             guard let self = self else { return }
             
-            // ✨ 로그 분석 결과에 따라, totalSchedule이 1 이상인 데이터를 한 번이라도 받으면 true로 고정
             if scheduleDTO.totalSchedule > 0 {
                 self.hasHadScheduleToday = true
             }
@@ -136,7 +135,6 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
     
     private func convertDTOToModel(schedule: DailyJourneyDTO, child: ChildrenInfo) -> DailyJourneyModel {
         
-        // 🔍 디버깅을 위한 프린트문 (선택 사항)
         print("--- 🏁 여정 진행도 체크 ---")
         print("현재 여정 순서 (scheduleOrder): \(schedule.scheduleOrder)")
         print("전체 여정 개수 (totalSchedule): \(schedule.totalSchedule)")
@@ -153,7 +151,8 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         let timeText = formatTimeRange(start: schedule.startTime, end: schedule.endTime)
         let isTimeViewActive = (timeText != "-")
         
-        // 1. 버튼 타입 결정 로직
+        let isLastJourney = (schedule.scheduleOrder > 0 && schedule.totalSchedule == 1)
+        
         let buttonType: DailyJourneyModel.ActionButtonType
         let isScheduleActive = (schedule.scheduleStatus == .nowScheduleExist ||
                                 schedule.scheduleStatus == .firstSchedule ||
@@ -171,7 +170,6 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         
         self.currentButtonType = buttonType
         
-        // 2. 상태별 모델 생성 로직
         switch schedule.scheduleStatus {
         case .firstSchedule, .nowScheduleExist, .nextScheduleExist:
             let bubbleText: String
@@ -196,14 +194,13 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 maxFireStoneCount: schedule.totalSchedule,
                 scheduleOrder: schedule.scheduleOrder,
                 scheduleOrderText: orderText,
-                speechFieldType: .gray,
+                speechFieldType: isLastJourney ? .no : .gray,
                 chipItemType: .inProgressChip,
                 isTimeViewActive: isTimeViewActive,
                 actionButtonType: buttonType
             )
             
         case .noSchedule:
-            // ✨ 로컬 플래그를 사용하여 '스킵 후 종료'와 '원래 휴식일' 구분
             let bubbleText = self.hasHadScheduleToday
             ? "오늘의 여정은 모두 끝났어.\n내일도 우리 함께하자!"
             : "오늘은 휴식의 날인가봐!\n푹 쉬면서 내일의 여정을 위한 힘을 모으자!"
@@ -221,7 +218,6 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 scheduleOrder: schedule.scheduleOrder,
                 scheduleOrderText: "",
                 speechFieldType: .no,
-                // 일정이 있었던 날이면 완료(.completedChip), 없던 날이면 기본(.inProgressChip) 스타일
                 chipItemType: self.hasHadScheduleToday ? .completedChip : .inProgressChip,
                 isTimeViewActive: false,
                 actionButtonType: buttonType

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -130,6 +130,13 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
     
     private func convertDTOToModel(schedule: DailyJourneyDTO, child: ChildrenInfo) -> DailyJourneyModel {
         
+        // 🔍 디버깅을 위한 프린트문 추가
+        print("--- 🏁 여정 진행도 체크 ---")
+        print("현재 여정 순서 (scheduleOrder): \(schedule.scheduleOrder)")
+        print("전체 여정 개수 (totalSchedule): \(schedule.totalSchedule)")
+        print("마지막 일정 여부: \(schedule.scheduleOrder == schedule.totalSchedule ? "✅ 마지막임" : "❌ 아직 더 남음")")
+        print("------------------------")
+        
         let kidName = child.firstName
         let coinCount = child.coinAmount
         let todayDateText = child.today
@@ -171,8 +178,6 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 bubbleText = "다음은 \(scheduleName)의 시간이야!\n다음 여정을 진행하면 \(stoneTypeName)의 불조각을 줄게."
             }
             
-            let isLastJourney = (schedule.scheduleOrder == schedule.totalSchedule)
-            
             return DailyJourneyModel(
                 bubbleText: bubbleText,
                 highlightKeywords: [scheduleName, stoneTypeName],
@@ -185,7 +190,7 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 maxFireStoneCount: schedule.totalSchedule,
                 scheduleOrder: schedule.scheduleOrder,
                 scheduleOrderText: orderText,
-                speechFieldType: isLastJourney ? .no : .gray,
+                speechFieldType: .gray,
                 chipItemType: .inProgressChip,
                 isTimeViewActive: isTimeViewActive,
                 actionButtonType: buttonType
@@ -211,23 +216,43 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
             )
             
         case .fireNotLit:
-            return DailyJourneyModel(
-                bubbleText: "고마워 \(kidName)!\n오늘의 조각들이 모두 모였어! 영웅의 불꽃 을 피워줘!",
-                highlightKeywords: ["영웅의 불꽃"],
-                journeyTimeText: "-",
-                isMissionActive: false,
-                kidName: kidName,
-                dateText: todayDateText,
-                coinCount: coinCount,
-                fireStoneCount: schedule.earnedStones ?? 0,
-                maxFireStoneCount: schedule.totalSchedule,
-                scheduleOrder: schedule.scheduleOrder,
-                scheduleOrderText: "",
-                speechFieldType: .no,
-                chipItemType: .highlightChip,
-                isTimeViewActive: false,
-                actionButtonType: buttonType
-            )
+            if (schedule.earnedStones ?? 0) == 0 {
+                return DailyJourneyModel(
+                    bubbleText: "오늘의 여정은 모두 끝났어.\n내일도 우리 함께하자!",
+                    highlightKeywords: [],
+                    journeyTimeText: "-",
+                    isMissionActive: false,
+                    kidName: kidName,
+                    dateText: todayDateText,
+                    coinCount: coinCount,
+                    fireStoneCount: 0,
+                    maxFireStoneCount: schedule.totalSchedule,
+                    scheduleOrder: schedule.scheduleOrder,
+                    scheduleOrderText: "",
+                    speechFieldType: .no,
+                    chipItemType: .completedChip,
+                    isTimeViewActive: false,
+                    actionButtonType: .hidden
+                )
+            } else {
+                return DailyJourneyModel(
+                    bubbleText: "고마워 \(kidName)!\n오늘의 조각들이 모두 모였어! 영웅의 불꽃 을 피워줘!",
+                    highlightKeywords: ["영웅의 불꽃"],
+                    journeyTimeText: "-",
+                    isMissionActive: false,
+                    kidName: kidName,
+                    dateText: todayDateText,
+                    coinCount: coinCount,
+                    fireStoneCount: schedule.earnedStones ?? 0,
+                    maxFireStoneCount: schedule.totalSchedule,
+                    scheduleOrder: schedule.scheduleOrder,
+                    scheduleOrderText: "",
+                    speechFieldType: .no,
+                    chipItemType: .highlightChip,
+                    isTimeViewActive: false,
+                    actionButtonType: buttonType
+                )
+            }
             
         case .fireLit:
             return DailyJourneyModel(

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -21,6 +21,7 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
     private(set) var currentStoneType: StoneType?
     private var currentButtonType: DailyJourneyModel.ActionButtonType = .hidden
     public var currentEarnedStoneCount: Int = 0
+    private var hasHadScheduleToday: Bool = false
     
     // MARK: - Input & Output
     
@@ -91,8 +92,13 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         } receiveValue: { [weak self] (scheduleDTO, childInfo) in
             guard let self = self else { return }
             
+            // ✨ 로그 분석 결과에 따라, totalSchedule이 1 이상인 데이터를 한 번이라도 받으면 true로 고정
+            if scheduleDTO.totalSchedule > 0 {
+                self.hasHadScheduleToday = true
+            }
+            
             print("🔍 서버 응답 상태: \(scheduleDTO.scheduleStatus)")
-            print("🔍 획득한 돌 개수: \(scheduleDTO.earnedStones ?? -1)")
+            print("🔍 플래그 상태 (hasHadScheduleToday): \(self.hasHadScheduleToday)")
             
             self.currentScheduleDetailId = scheduleDTO.scheduleDetailId
             self.currentStoneType = scheduleDTO.stoneType
@@ -130,11 +136,11 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
     
     private func convertDTOToModel(schedule: DailyJourneyDTO, child: ChildrenInfo) -> DailyJourneyModel {
         
-        // 🔍 디버깅을 위한 프린트문 추가
+        // 🔍 디버깅을 위한 프린트문 (선택 사항)
         print("--- 🏁 여정 진행도 체크 ---")
         print("현재 여정 순서 (scheduleOrder): \(schedule.scheduleOrder)")
         print("전체 여정 개수 (totalSchedule): \(schedule.totalSchedule)")
-        print("마지막 일정 여부: \(schedule.scheduleOrder == schedule.totalSchedule ? "✅ 마지막임" : "❌ 아직 더 남음")")
+        print("플래그 상태 (hasHadScheduleToday): \(self.hasHadScheduleToday)")
         print("------------------------")
         
         let kidName = child.firstName
@@ -147,8 +153,8 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         let timeText = formatTimeRange(start: schedule.startTime, end: schedule.endTime)
         let isTimeViewActive = (timeText != "-")
         
+        // 1. 버튼 타입 결정 로직
         let buttonType: DailyJourneyModel.ActionButtonType
-        
         let isScheduleActive = (schedule.scheduleStatus == .nowScheduleExist ||
                                 schedule.scheduleStatus == .firstSchedule ||
                                 schedule.scheduleStatus == .nextScheduleExist)
@@ -165,16 +171,16 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         
         self.currentButtonType = buttonType
         
+        // 2. 상태별 모델 생성 로직
         switch schedule.scheduleStatus {
         case .firstSchedule, .nowScheduleExist, .nextScheduleExist:
-            
             let bubbleText: String
             switch schedule.scheduleStatus {
             case .firstSchedule:
                 bubbleText = "오늘도 내 불씨를 키워주러 왔구나!\n우리의 \(orderText)번째 여정은 \(scheduleName)!"
             case .nowScheduleExist:
                 bubbleText = "지금은 \(scheduleName)의 시간이야!\n여정을 진행하면 \(stoneTypeName)의 불조각을 줄게."
-            default:
+            default: // .nextScheduleExist
                 bubbleText = "다음은 \(scheduleName)의 시간이야!\n다음 여정을 진행하면 \(stoneTypeName)의 불조각을 줄게."
             }
             
@@ -197,8 +203,13 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
             )
             
         case .noSchedule:
+            // ✨ 로컬 플래그를 사용하여 '스킵 후 종료'와 '원래 휴식일' 구분
+            let bubbleText = self.hasHadScheduleToday
+            ? "오늘의 여정은 모두 끝났어.\n내일도 우리 함께하자!"
+            : "오늘은 휴식의 날인가봐!\n푹 쉬면서 내일의 여정을 위한 힘을 모으자!"
+            
             return DailyJourneyModel(
-                bubbleText: "오늘은 휴식의 날인가봐!\n푹 쉬면서 내일의 여정을 위한 힘을 모으자!",
+                bubbleText: bubbleText,
                 highlightKeywords: [],
                 journeyTimeText: "-",
                 isMissionActive: false,
@@ -210,49 +221,30 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 scheduleOrder: schedule.scheduleOrder,
                 scheduleOrderText: "",
                 speechFieldType: .no,
-                chipItemType: .inProgressChip,
+                // 일정이 있었던 날이면 완료(.completedChip), 없던 날이면 기본(.inProgressChip) 스타일
+                chipItemType: self.hasHadScheduleToday ? .completedChip : .inProgressChip,
                 isTimeViewActive: false,
                 actionButtonType: buttonType
             )
             
         case .fireNotLit:
-            if (schedule.earnedStones ?? 0) == 0 {
-                return DailyJourneyModel(
-                    bubbleText: "오늘의 여정은 모두 끝났어.\n내일도 우리 함께하자!",
-                    highlightKeywords: [],
-                    journeyTimeText: "-",
-                    isMissionActive: false,
-                    kidName: kidName,
-                    dateText: todayDateText,
-                    coinCount: coinCount,
-                    fireStoneCount: 0,
-                    maxFireStoneCount: schedule.totalSchedule,
-                    scheduleOrder: schedule.scheduleOrder,
-                    scheduleOrderText: "",
-                    speechFieldType: .no,
-                    chipItemType: .completedChip,
-                    isTimeViewActive: false,
-                    actionButtonType: .hidden
-                )
-            } else {
-                return DailyJourneyModel(
-                    bubbleText: "고마워 \(kidName)!\n오늘의 조각들이 모두 모였어! 영웅의 불꽃 을 피워줘!",
-                    highlightKeywords: ["영웅의 불꽃"],
-                    journeyTimeText: "-",
-                    isMissionActive: false,
-                    kidName: kidName,
-                    dateText: todayDateText,
-                    coinCount: coinCount,
-                    fireStoneCount: schedule.earnedStones ?? 0,
-                    maxFireStoneCount: schedule.totalSchedule,
-                    scheduleOrder: schedule.scheduleOrder,
-                    scheduleOrderText: "",
-                    speechFieldType: .no,
-                    chipItemType: .highlightChip,
-                    isTimeViewActive: false,
-                    actionButtonType: buttonType
-                )
-            }
+            return DailyJourneyModel(
+                bubbleText: "고마워 \(kidName)!\n오늘의 조각들이 모두 모였어! 영웅의 불꽃 을 피워줘!",
+                highlightKeywords: ["영웅의 불꽃"],
+                journeyTimeText: "-",
+                isMissionActive: false,
+                kidName: kidName,
+                dateText: todayDateText,
+                coinCount: coinCount,
+                fireStoneCount: schedule.earnedStones ?? 0,
+                maxFireStoneCount: schedule.totalSchedule,
+                scheduleOrder: schedule.scheduleOrder,
+                scheduleOrderText: "",
+                speechFieldType: .no,
+                chipItemType: .highlightChip,
+                isTimeViewActive: false,
+                actionButtonType: buttonType
+            )
             
         case .fireLit:
             return DailyJourneyModel(

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -269,8 +269,8 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
     private func convertStoneTypeToKorean(_ type: StoneType?) -> String {
         guard let type = type else { return "" }
         switch type {
-        case .grit: return "용기의 불조각"
-        case .courage: return "인내의 불조각"
+        case .grit: return "인내의 불조각"
+        case .courage: return "용기의 불조각"
         case .wisdom: return "지혜의 불조각"
         }
     }

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -166,7 +166,7 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
             let bubbleText: String
             switch schedule.scheduleStatus {
             case .firstSchedule:
-                bubbleText = "오늘도 내 불씨를 키워주러 왔구나!\n우리의 \(orderText)번째 여정은 \(scheduleName) 야!"
+                bubbleText = "오늘도 내 불씨를 키워주러 왔구나!\n우리의 \(orderText)번째 여정은 \(scheduleName)!"
             case .nowScheduleExist:
                 bubbleText = "지금은 \(scheduleName)의 시간이야!\n여정을 진행하면 \(stoneTypeName)의 불조각을 줄게."
             default:

--- a/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneAnimationView.swift
+++ b/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneAnimationView.swift
@@ -132,9 +132,9 @@ final class GiveFireStoneAnimationView: BaseUIView {
         case "COURAGE":
             return UIImage(resource: .ic3DBluestone)
         case "WISDOM":
-            return UIImage(resource: .ic3DRedstone)
-        case "GRIT":
             return UIImage(resource: .ic3DGreenstone)
+        case "GRIT":
+            return UIImage(resource: .ic3DRedstone)
         default:
             return UIImage(resource: .ic3DBluestone)
         }

--- a/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneResultView.swift
+++ b/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneResultView.swift
@@ -99,16 +99,16 @@ final class GiveFireStoneResultView: BaseUIView {
         
         if coin > 0 {
             lines = [
-                "덕분에 \(stoneNames)이 커졌어!",
+                "덕분에 영웅의 불꽃 이 커졌어!",
                 "선물로 금화 \(coin)개를 줄게"
             ]
-            highlightKeywords = [stoneNames, "\(coin)"]
+            highlightKeywords = ["영웅의 불꽃"]
         } else {
             lines = [
-                "덕분에 \(stoneNames)이 커졌어!",
+                "덕분에 영웅의 불꽃 이 커졌어!",
                 "오늘도 도와줘서 고마워"
             ]
-            highlightKeywords = [stoneNames]
+            highlightKeywords = ["영웅의 불꽃"]
         }
         
         speechField.configure(

--- a/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneResultView.swift
+++ b/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneResultView.swift
@@ -92,24 +92,23 @@ final class GiveFireStoneResultView: BaseUIView {
     // MARK: - Configuration
     
     func configure(coin: Int, stones: [String]) {
-        let firstStoneKey = stones.first ?? ""
-        let stoneKoreanName = mapStoneName(firstStoneKey)
+        let stoneNames = stones.map { mapStoneName($0) }.joined(separator: ", ")
         
         let lines: [String]
         let highlightKeywords: [String]
         
         if coin > 0 {
             lines = [
-                "덕분에 \(stoneKoreanName)이 커졌어!",
+                "덕분에 \(stoneNames)이 커졌어!",
                 "선물로 금화 \(coin)개를 줄게"
             ]
-            highlightKeywords = [stoneKoreanName, "\(coin)"]
+            highlightKeywords = [stoneNames, "\(coin)"]
         } else {
             lines = [
-                "덕분에 \(stoneKoreanName)이 커졌어!",
+                "덕분에 \(stoneNames)이 커졌어!",
                 "오늘도 도와줘서 고마워"
             ]
-            highlightKeywords = [stoneKoreanName]
+            highlightKeywords = [stoneNames]
         }
         
         speechField.configure(
@@ -118,6 +117,15 @@ final class GiveFireStoneResultView: BaseUIView {
             lines: lines,
             highlightKeywords: highlightKeywords
         )
+    }
+    
+    private func mapStoneName(_ key: String) -> String {
+        switch key {
+        case "COURAGE": return "용기의 불꽃"
+        case "WISDOM": return "지혜의 불꽃"
+        case "GRIT": return "인내의 불꽃"
+        default: return "영웅의 불꽃"
+        }
     }
     
     func playGif() {
@@ -158,14 +166,5 @@ final class GiveFireStoneResultView: BaseUIView {
             }
         }
         return totalDuration
-    }
-    
-    private func mapStoneName(_ key: String) -> String {
-        switch key {
-        case "COURAGE": return "용기의 불꽃"
-        case "WISDOM": return "지혜의 불꽃"
-        case "GRIT": return "끈기의 불꽃"
-        default: return "영웅의 불꽃"
-        }
     }
 }

--- a/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneResultView.swift
+++ b/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneResultView.swift
@@ -92,7 +92,7 @@ final class GiveFireStoneResultView: BaseUIView {
     // MARK: - Configuration
     
     func configure(coin: Int, stones: [String]) {
-        let stoneNames = stones.map { mapStoneName($0) }.joined(separator: ", ")
+//        let stoneNames = stones.map { mapStoneName($0) }.joined(separator: ", ")
         
         let lines: [String]
         let highlightKeywords: [String]

--- a/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteModel.swift
+++ b/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteModel.swift
@@ -7,14 +7,21 @@
 
 import UIKit
 
-enum MissionCompleteModel: Int, CaseIterable {
-    case courage = 0
-    case grit
-    case wisdom
+enum MissionCompleteModel: String, CaseIterable {
+    case courage = "COURAGE"
+    case grit = "GRIT"
+    case wisdom = "WISDOM"
     
-    static func from(scheduleDetailId: Int) -> MissionCompleteModel {
-        let index = (scheduleDetailId - 1) % 3
-        return MissionCompleteModel(rawValue: index) ?? .courage
+    static func from(stoneType: StoneType) -> MissionCompleteModel {
+        switch stoneType {
+        case .courage: return .courage
+        case .grit:    return .grit
+        case .wisdom:  return .wisdom
+        }
+    }
+    
+    static func from(serverStrings: [String]) -> [MissionCompleteModel] {
+        return serverStrings.compactMap { MissionCompleteModel(rawValue: $0) }
     }
     
     var name: String {
@@ -33,21 +40,11 @@ enum MissionCompleteModel: Int, CaseIterable {
         }
     }
     
-    var message: String {
-        return "우와! \(self.name)의 불조각 을 손에 넣었어!"
+    func getMessage() -> String {
+        return "우와! \(self.name)의 불조각을 손에 넣었어!"
     }
     
     var highlightKeyword: String {
         return "\(self.name)의 불조각"
-    }
-}
-
-extension MissionCompleteModel {
-    static func from(stoneType: StoneType) -> MissionCompleteModel {
-        switch stoneType {
-        case .courage: return .courage
-        case .grit:    return .grit
-        case .wisdom:  return .wisdom 
-        }
     }
 }

--- a/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteViewModel.swift
+++ b/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteViewModel.swift
@@ -52,12 +52,12 @@ final class MissionCompleteViewModel: BaseViewModel, ViewModelType {
                 }
                 
                 let stoneType = self.receivedStoneType ?? .courage
-                let completeModel = MissionCompleteModel.from(stoneType: stoneType)
+                let completeModel = MissionCompleteModel.from(serverStrings: [stoneType.rawValue]).first ?? .courage
                 
                 return MissionCompleteViewData(
                     capturedImage: self.capturedImage,
                     stoneImage: completeModel.image,
-                    message: completeModel.message,
+                    message: completeModel.getMessage(),
                     highlightKeyword: completeModel.highlightKeyword
                 )
             }


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #151
<br>

## 🍎 작업 내용
- [x]  스피치필드 조사 수정
- [x]  스피치필드 종류 수정 - 다음 여정으로 가기 버튼 사라지는 시점 다시 체크
- [x]  convertStoneTypeToKorean 매핑 수정 & 로직 수정
    - [x]  용기 - courage - 파랑 
    - [x]  인내 - grit - 빨강 
    - [x]  지혜 - wisdom - 초록 
- [x]  인증 사진 찍고 레시피 뷰로 넘어오기까지 시간 확인 - 4초후 다음 화면으로 이동(불조각 두번 둥둥)
    - [x]  현재 로직에 문제 없음
- [x]  하이라이트 칩 - 마음의 불꽃 버튼이 있을때
- [x]  DB에 저장된 사진 URL 이상함
- [x]  [[CT-026-P](https://www.notion.so/CT-026-P-2ef8ff4aed3f806e9c30e030d1f28807?pvs=21)](https://www.notion.so/CT-026-P-2ef8ff4aed3f806e9c30e030d1f28807?pvs=21)
- [x]  [[CT-034-P](https://www.notion.so/CT-034-P-2ed8ff4aed3f805680abd3cfdbbf402b?pvs=21)](https://www.notion.so/CT-034-P-2ed8ff4aed3f805680abd3cfdbbf402b?pvs=21) 
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 화면2 |
|:---------:|:-------------:|:-------------:|
| 기능1 | <img src="" width="250"> | <img src="" width="250"> |
<br>

## 💬 리뷰 코멘트
리뷰어가 신경써서 봐줄 부분을 알려주세요.
