### PR TITLE
[refactor] #154 자녀 온보딩 뷰 점검

### DIFF
--- a/Kiero/Kiero/Application/AppDIContainer.swift
+++ b/Kiero/Kiero/Application/AppDIContainer.swift
@@ -43,14 +43,12 @@ extension AppDIContainer {
     //    }
     
     func makeChildOnboardingViewController() -> UIViewController {
-        let items: [SpeechItem] = [
-            .init(image: .imgStory1, name: "꾸비", lines: ["드디어 만났다! 나의 짝꿍 근영", "난 꼬마 히어로 꾸비야. 우리 같이 모험을 떠나볼까?"], highlightKeywords: []),
-            .init(image: .imgStory2, name: "꾸비", lines: ["다른 도깨비들은 장난치는 걸 좋아하지만,", "난 '영웅의 불씨'를 품고 태어난 특별한 도깨비야!", "너의 노력을 멋진 소원으로 바꾸는 꼬마 히어로 지"], highlightKeywords: ["꼬마 히어로"]),
-            .init(image: .imgStory3, name: "꾸비", lines: ["그런데 큰일이야...", "배에 있는 ‘영웅의 불씨'가 자꾸 꺼지려고 해.", "나 혼자서는 지킬 수 없거든", "오직 너만이 이 불씨를 다시 키울 수 있어!"], highlightKeywords: ["오직 너만이 이 불씨를 다시 키울 수 있어!"]),
-            .init(image: .imgStory4, name: "꾸비", lines: ["오늘의 여정을 따라 하루를 보내고", "불조각을 나에게 건네줘!", "너가 준 [용기, 인내, 지혜의 불조각] 이", "내 마음의 불꽃을 키워줄거야."], highlightKeywords: ["[용기, 인내, 지혜의 불조각]"]),
-            .init(image: .imgStory5, name: "꾸비", lines: ["그 힘으로 내가 반짝이는 금화를 만들어줄게!", "소원의 우물에서 금화를 통해", "너의 소원을 이룰 수 있을거야!"], highlightKeywords: [])
-        ]
-        let viewModel = ChildrenOnboardingViewModel(items: items)
+        let userName = TokenManager.shared.getFirstName() ?? "사용자"
+        let items = ChildOnboardingScript.items
+        let viewModel = ChildrenOnboardingViewModel(
+            items: items,
+            userName: userName
+        )
         return ChildrenOnboardingViewController(viewModel: viewModel, diContainer: self)
     }
 }

--- a/Kiero/Kiero/Application/AppDIContainer.swift
+++ b/Kiero/Kiero/Application/AppDIContainer.swift
@@ -53,6 +53,15 @@ extension AppDIContainer {
     }
 }
 
+// MARK: - Onboarding
+
+extension AppDIContainer {
+    func makeChildLoadingViewController() -> UIViewController {
+        let viewModel = BaseViewModel()
+        return ChildrenLoadingViewController(viewModel: viewModel, diContainer: self)
+    }
+}
+
 // MARK: - Schedule
 
 extension AppDIContainer {

--- a/Kiero/Kiero/Network/Login/TokenManager.swift
+++ b/Kiero/Kiero/Network/Login/TokenManager.swift
@@ -20,6 +20,7 @@ final class TokenManager {
         static let name = "user_name"
         static let profile = "profile_url"
         static let sse = "sse_token"
+        static let nameKey = "firstName"
     }
 
     func saveAccessToken(_ access: String) {
@@ -52,6 +53,14 @@ final class TokenManager {
     
     func getUserName() -> String? {
         userDefaults.string(forKey: Key.name)
+    }
+    
+    func saveFirstName(_ name: String) {
+        UserDefaults.standard.set(name, forKey: Key.nameKey)
+    }
+    
+    func getFirstName() -> String? {
+        UserDefaults.standard.string(forKey: Key.nameKey)
     }
     
     func saveProfile(_ profile: String) {

--- a/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
@@ -181,6 +181,8 @@ final class SpeechField: UIView {
         
         self.type = fieldType
         
+        buttonContainerView.isHidden = (fieldType == .no)
+        
         updateGestures()
         nameLabel.setTypo(.body5_10_R, text: name)
         contentStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }

--- a/Kiero/Kiero/Presentation/Login/View/ChildrenLoginViewController.swift
+++ b/Kiero/Kiero/Presentation/Login/View/ChildrenLoginViewController.swift
@@ -132,7 +132,7 @@ final class ChildrenLoginViewController: BaseViewController<ChildrenLoginViewMod
                     self.startButton.isEnabled = true
                     self.startButton.alpha = 1.0
                     print("ChildSignup 실패:", message)
-                    // TODO: 토스트/알럿 붙이기
+                    Toast.show(message: "이름이나 초대코드를 다시 확인해줘!", bottomInset: 83)
                 }
             }
             .store(in: &cancellables)

--- a/Kiero/Kiero/Presentation/Login/ViewModel/ChildrenLoginViewModel.swift
+++ b/Kiero/Kiero/Presentation/Login/ViewModel/ChildrenLoginViewModel.swift
@@ -70,6 +70,7 @@ final class ChildrenLoginViewModel: BaseViewModel {
                 TokenManager.shared.saveRefreshToken(data.refreshToken)
                 TokenManager.shared.saveUserRole(data.role)
                 TokenManager.shared.saveUserName("\(data.lastName)\(data.firstName)")
+                TokenManager.shared.saveFirstName(data.firstName)
 
                 await MainActor.run {
                     self.stateSubject.send(.idle)

--- a/Kiero/Kiero/Presentation/Onboarding/Model/ChildrenOnboardingModel.swift
+++ b/Kiero/Kiero/Presentation/Onboarding/Model/ChildrenOnboardingModel.swift
@@ -13,3 +13,13 @@ struct SpeechItem {
     let lines: [String]
     let highlightKeywords: [String]
 }
+
+enum ChildOnboardingScript {
+    static let items: [SpeechItem] = [
+        .init(image: .imgStory1, name: "꾸비", lines: ["드디어 만났다! 나의 짝꿍 {userName}", "난 꼬마 히어로 꾸비야. 우리 같이 모험을 떠나볼까?"], highlightKeywords: []),
+        .init(image: .imgStory2, name: "꾸비", lines: ["다른 도깨비들은 장난치는 걸 좋아하지만,", "난 '영웅의 불씨'를 품고 태어난 특별한 도깨비야!", "너의 노력을 멋진 소원으로 바꾸는 꼬마 히어로 지"], highlightKeywords: ["꼬마 히어로"]),
+        .init(image: .imgStory3, name: "꾸비", lines: ["그런데 큰일이야...", "배에 있는 ‘영웅의 불씨'가 자꾸 꺼지려고 해.", "나 혼자서는 지킬 수 없거든", "오직 너만이 이 불씨를 다시 키울 수 있어!"], highlightKeywords: ["오직 너만이 이 불씨를 다시 키울 수 있어!"]),
+        .init(image: .imgStory4, name: "꾸비", lines: ["오늘의 여정을 따라 하루를 보내고", "불조각을 나에게 건네줘!", "너가 준 [용기, 인내, 지혜의 불조각] 이", "내 마음의 불꽃을 키워줄거야."], highlightKeywords: ["[용기, 인내, 지혜의 불조각]"]),
+        .init(image: .imgStory5, name: "꾸비", lines: ["그 힘으로 내가 반짝이는 금화를 만들어줄게!", "소원의 우물에서 금화를 통해", "너의 소원을 이룰 수 있을거야!"], highlightKeywords: [])
+    ]
+}

--- a/Kiero/Kiero/Presentation/Onboarding/View/ChildrenOnboardingViewController.swift
+++ b/Kiero/Kiero/Presentation/Onboarding/View/ChildrenOnboardingViewController.swift
@@ -21,6 +21,8 @@ final class ChildrenOnboardingViewController: BaseViewController<ChildrenOnboard
     
     private var latestItem: SpeechItem?
     
+    private var currentFieldType: SpeechField.fieldType = .main
+    
     // MARK: - UI Components
     
     private let storyImageView = UIImageView().then {
@@ -91,7 +93,7 @@ final class ChildrenOnboardingViewController: BaseViewController<ChildrenOnboard
                 self.storyImageView.image = item.image
 
                 self.currentSpeech?.configure(
-                    fieldType: .main,
+                    fieldType: self.currentFieldType,
                     name: item.name,
                     lines: item.lines,
                     highlightKeywords: item.highlightKeywords
@@ -103,6 +105,7 @@ final class ChildrenOnboardingViewController: BaseViewController<ChildrenOnboard
             .receive(on: DispatchQueue.main)
             .sink { [weak self] type in
                 guard let self else { return }
+                self.currentFieldType = type
                 
                 let nextSpeech = (type == .no) ? self.noSF : self.mainSF
                 
@@ -122,7 +125,7 @@ final class ChildrenOnboardingViewController: BaseViewController<ChildrenOnboard
                     
                     if let item = self.latestItem {
                         nextSpeech.configure(
-                            fieldType: .main,
+                            fieldType: type,
                             name: item.name,
                             lines: item.lines,
                             highlightKeywords: item.highlightKeywords

--- a/Kiero/Kiero/Presentation/Onboarding/View/ChildrenOnboardingViewController.swift
+++ b/Kiero/Kiero/Presentation/Onboarding/View/ChildrenOnboardingViewController.swift
@@ -169,6 +169,12 @@ final class ChildrenOnboardingViewController: BaseViewController<ChildrenOnboard
     
     @objc
     private func startButtonDidTap() {
-        navigateToChildrenTap()
+        let loadingVC = AppDIContainer.shared.makeChildLoadingViewController()
+        loadingVC.modalPresentationStyle = .fullScreen
+        present(loadingVC, animated: false)
+        
+        DispatchQueue.main.asyncAfter (deadline: .now() + 4) { [weak self] in
+            self?.navigateToChildrenTap()
+        }
     }
 }

--- a/Kiero/Kiero/Presentation/Onboarding/ViewModel/ChildrenOnboardingViewModel.swift
+++ b/Kiero/Kiero/Presentation/Onboarding/ViewModel/ChildrenOnboardingViewModel.swift
@@ -9,41 +9,41 @@ import Combine
 import UIKit
 
 final class ChildrenOnboardingViewModel: BaseViewModel, ViewModelType {
-
+    
     // MARK: - Input / Output
-
+    
     struct Input {
         let nextTapped: AnyPublisher<Void, Never>
     }
-
+    
     struct Output {
         let item: AnyPublisher<SpeechItem, Never>
         let fieldType: AnyPublisher<SpeechField.fieldType, Never>
         let isLast: AnyPublisher<Bool, Never>
     }
-
+    
     // MARK: - Properties
-
+    
     private let items: [SpeechItem]
     private let indexSubject = CurrentValueSubject<Int, Never>(0)
-
+    private let userName: String
+    
     // MARK: - Init
-
-    init(items: [SpeechItem]) {
+    
+    init(items: [SpeechItem], userName: String) {
         self.items = items
-        super.init()
-        print(items.count)
+        self.userName = userName
     }
-
+    
     // MARK: - Transform
-
+    
     func transform(input: Input) -> Output {
-
+        
         input.nextTapped
             .sink { [weak self] in
                 guard let self else { return }
                 guard !self.items.isEmpty else { return }
-
+                
                 let nextIndex = min(
                     self.indexSubject.value + 1,
                     self.items.count - 1
@@ -51,14 +51,27 @@ final class ChildrenOnboardingViewModel: BaseViewModel, ViewModelType {
                 self.indexSubject.send(nextIndex)
             }
             .store(in: &cancellables)
-
+        
         let itemPublisher = indexSubject
             .compactMap { [items] index -> SpeechItem? in
                 guard items.indices.contains(index) else { return nil }
-                return items[index]
+                
+                let original = self.items[index]
+                let name = self.userName.isEmpty ? "사용자" : self.userName
+                
+                let newLines = original.lines.map {
+                    $0.replacingOccurrences(of: "{userName}", with: name)
+                }
+                
+                return SpeechItem(
+                    image: original.image,
+                    name: original.name,
+                    lines: newLines,
+                    highlightKeywords: original.highlightKeywords
+                )
             }
             .eraseToAnyPublisher()
-
+        
         let fieldTypePublisher = indexSubject
             .map { [items] index -> SpeechField.fieldType in
                 guard !items.isEmpty else { return .no }
@@ -73,7 +86,7 @@ final class ChildrenOnboardingViewModel: BaseViewModel, ViewModelType {
             }
             .removeDuplicates()
             .eraseToAnyPublisher()
-
+        
         return Output(
             item: itemPublisher,
             fieldType: fieldTypePublisher,


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #154
<br>

## 🍎 작업 내용
자녀 온보딩 뷰를 점검합니다. 
- 이름, 초대코드 잘못 작성시 토스트 메세지 표출
- 자녀 스토리 화면 이름 반영
- 스토리 뷰 마지막 화면에 '다음' 버튼 없애기
- '시작해보자' 버튼 클릭시 로딩창 표시
<br>

## 💬 리뷰 코멘트

