### PR TITLE
[refactor] #162 오늘의 여정 QA 반영

### DIFF
--- a/Kiero/Kiero/Application/AppDIContainer.swift
+++ b/Kiero/Kiero/Application/AppDIContainer.swift
@@ -16,7 +16,7 @@ final class AppDIContainer: ViewControllerFactory, ServiceFactory{
     private init() {}
     
     lazy var sseManager: SseStreamManager = {
-        SseStreamManager(sseURL: Config.sseURL)
+        SseStreamManager.shared
     }()
 }
 

--- a/Kiero/Kiero/Network/Base/BaseService.swift
+++ b/Kiero/Kiero/Network/Base/BaseService.swift
@@ -247,6 +247,7 @@ final class BaseService {
         do {
             let decoded = try JSONDecoder().decode(BaseResponse<AccessTokenData>.self, from: data)
             guard let tokenData = decoded.data else { throw NetworkError.noData }
+            TokenManager.shared.saveSseToken(tokenData.accessToken)
             return tokenData.accessToken
         } catch {
             throw NetworkError.responseDecodingError

--- a/Kiero/Kiero/Network/Login/SseStreamManager.swift
+++ b/Kiero/Kiero/Network/Login/SseStreamManager.swift
@@ -12,6 +12,8 @@ final class SseStreamManager {
     var onRefreshWillStart: (() -> Void)?
     var onReconnected: (() -> Void)?
     
+    static let shared = SseStreamManager(sseURL: Config.sseURL)
+    
     private let sseURL: URL
     private var client: SseClient?
     

--- a/Kiero/Kiero/Network/Login/TokenManager.swift
+++ b/Kiero/Kiero/Network/Login/TokenManager.swift
@@ -93,6 +93,7 @@ final class TokenManager {
     func clearAll() {
         clearTokens()
         clearUserInfo()
+        SseStreamManager.shared.stop()
     }
 
     var isLoggedIn: Bool {

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
@@ -14,6 +14,7 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
     
     private let mainView = DailyJourneyView()
     private let viewWillAppearSubject = PassthroughSubject<Void, Never>()
+    private let viewWillDisappearSubject = PassthroughSubject<Void, Never>()
     private let nextButtonTapSubject = PassthroughSubject<Void, Never>()
     private let verifyButtonTapSubject = PassthroughSubject<Void, Never>()
     private let skipConfirmSubject = PassthroughSubject<Void, Never>()
@@ -33,6 +34,11 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
         viewWillAppearSubject.send(())
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        viewWillDisappearSubject.send(())
+    }
+    
     override func addTarget() {
         super.addTarget()
         mainView.onNextJourneyTap = { [weak self] in
@@ -46,6 +52,7 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
         
         let input = DailyJourneyViewModel.Input(
             viewWillAppear: viewWillAppearSubject.eraseToAnyPublisher(),
+            viewWillDisappear: viewWillDisappearSubject.eraseToAnyPublisher(),
             nextJourneyButtonTap: nextButtonTapSubject.eraseToAnyPublisher(),
             verifyButtonTap: verifyButtonTapSubject.eraseToAnyPublisher(),
             skipConfirmTap: skipConfirmSubject.eraseToAnyPublisher()

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -159,7 +159,6 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
             await MainActor.run {
                 SseStreamManager.shared.startIfNeeded(initialToken: validToken) { [weak self] payload in
                     print("📩 [DailyJourneyViewModel] SSE Event received: \(payload.eventType)")
-                    // 이벤트 수신 시 데이터 갱신
                     self?.fetchDailyJourney()
                 }
             }
@@ -264,7 +263,6 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 scheduleOrder: schedule.scheduleOrder,
                 scheduleOrderText: "",
                 speechFieldType: .no,
-                // 하나라도 했으면 완료 칩(파란색), 아니면 대기 칩(회색/진행중)
                 chipItemType: hasCompletedAnySchedule ? .completedChip : .inProgressChip,
                 isTimeViewActive: false,
                 actionButtonType: buttonType

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -21,7 +21,6 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
     private(set) var currentStoneType: StoneType?
     private var currentButtonType: DailyJourneyModel.ActionButtonType = .hidden
     public var currentEarnedStoneCount: Int = 0
-    private var hasHadScheduleToday: Bool = false
     
     // MARK: - Input & Output
     
@@ -92,13 +91,6 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         } receiveValue: { [weak self] (scheduleDTO, childInfo) in
             guard let self = self else { return }
             
-            if scheduleDTO.totalSchedule > 0 {
-                self.hasHadScheduleToday = true
-            }
-            
-            print("🔍 서버 응답 상태: \(scheduleDTO.scheduleStatus)")
-            print("🔍 플래그 상태 (hasHadScheduleToday): \(self.hasHadScheduleToday)")
-            
             self.currentScheduleDetailId = scheduleDTO.scheduleDetailId
             self.currentStoneType = scheduleDTO.stoneType
             self.currentEarnedStoneCount = scheduleDTO.earnedStones ?? 0
@@ -133,13 +125,14 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
             .store(in: &cancellables)
     }
     
+    
+    
+    // MARK: - Converter
+    
     private func convertDTOToModel(schedule: DailyJourneyDTO, child: ChildrenInfo) -> DailyJourneyModel {
         
-        print("--- 🏁 여정 진행도 체크 ---")
-        print("현재 여정 순서 (scheduleOrder): \(schedule.scheduleOrder)")
-        print("전체 여정 개수 (totalSchedule): \(schedule.totalSchedule)")
-        print("플래그 상태 (hasHadScheduleToday): \(self.hasHadScheduleToday)")
-        print("------------------------")
+        let earnedStones = schedule.earnedStones ?? 0
+        let totalSchedule = schedule.totalSchedule
         
         let kidName = child.firstName
         let coinCount = child.coinAmount
@@ -151,7 +144,9 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         let timeText = formatTimeRange(start: schedule.startTime, end: schedule.endTime)
         let isTimeViewActive = (timeText != "-")
         
-        let isLastJourney = (schedule.scheduleOrder > 0 && schedule.totalSchedule == 1)
+        let isLastJourney = (schedule.scheduleOrder > 0 && totalSchedule == 1)
+        
+        let isCurrentTimeMatched = isCurrentTimeInSchedule(start: schedule.startTime, end: schedule.endTime)
         
         let buttonType: DailyJourneyModel.ActionButtonType
         let isScheduleActive = (schedule.scheduleStatus == .nowScheduleExist ||
@@ -161,7 +156,7 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         if isScheduleActive && !schedule.isNowScheduleVerified {
             buttonType = .verify
         }
-        else if schedule.scheduleStatus == .fireNotLit && (schedule.earnedStones ?? 0) > 0 {
+        else if schedule.scheduleStatus == .fireNotLit && earnedStones > 0 {
             buttonType = .lightFire
         }
         else {
@@ -170,15 +165,20 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         
         self.currentButtonType = buttonType
         
+        
         switch schedule.scheduleStatus {
         case .firstSchedule, .nowScheduleExist, .nextScheduleExist:
             let bubbleText: String
-            switch schedule.scheduleStatus {
-            case .firstSchedule:
-                bubbleText = "오늘도 내 불씨를 키워주러 왔구나!\n우리의 \(orderText)번째 여정은 \(scheduleName)!"
-            case .nowScheduleExist:
+            
+            if schedule.scheduleStatus == .nowScheduleExist ||
+                (schedule.scheduleStatus == .firstSchedule && isCurrentTimeMatched) {
+                
                 bubbleText = "지금은 \(scheduleName)의 시간이야!\n여정을 진행하면 \(stoneTypeName) 을 줄게."
-            default:
+                
+            } else if schedule.scheduleStatus == .firstSchedule {
+                bubbleText = "오늘도 내 불씨를 키워주러 왔구나!\n우리의 \(orderText)번째 여정은 \(scheduleName)!"
+                
+            } else {
                 bubbleText = "다음은 \(scheduleName)의 시간이야!\n다음 여정을 진행하면 \(stoneTypeName) 을 줄게."
             }
             
@@ -190,8 +190,8 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 kidName: kidName,
                 dateText: todayDateText,
                 coinCount: coinCount,
-                fireStoneCount: schedule.earnedStones ?? 0,
-                maxFireStoneCount: schedule.totalSchedule,
+                fireStoneCount: earnedStones,
+                maxFireStoneCount: totalSchedule,
                 scheduleOrder: schedule.scheduleOrder,
                 scheduleOrderText: orderText,
                 speechFieldType: isLastJourney ? .no : .gray,
@@ -201,7 +201,9 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
             )
             
         case .noSchedule:
-            let bubbleText = self.hasHadScheduleToday
+            let hasCompletedAnySchedule = (totalSchedule > 0 && earnedStones > 0)
+            
+            let bubbleText = hasCompletedAnySchedule
             ? "오늘의 여정은 모두 끝났어.\n내일도 우리 함께하자!"
             : "오늘은 휴식의 날인가봐!\n푹 쉬면서 내일의 여정을 위한 힘을 모으자!"
             
@@ -213,17 +215,38 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 kidName: kidName,
                 dateText: todayDateText,
                 coinCount: coinCount,
-                fireStoneCount: schedule.earnedStones ?? 0,
-                maxFireStoneCount: schedule.totalSchedule,
+                fireStoneCount: earnedStones,
+                maxFireStoneCount: totalSchedule,
                 scheduleOrder: schedule.scheduleOrder,
                 scheduleOrderText: "",
                 speechFieldType: .no,
-                chipItemType: self.hasHadScheduleToday ? .completedChip : .inProgressChip,
+                // 하나라도 했으면 완료 칩(파란색), 아니면 대기 칩(회색/진행중)
+                chipItemType: hasCompletedAnySchedule ? .completedChip : .inProgressChip,
                 isTimeViewActive: false,
                 actionButtonType: buttonType
             )
             
         case .fireNotLit:
+            if earnedStones == 0 {
+                return DailyJourneyModel(
+                    bubbleText: "오늘은 휴식의 날인가봐!\n푹 쉬면서 내일의 여정을 위한 힘을 모으자!",
+                    highlightKeywords: [],
+                    journeyTimeText: "-",
+                    isMissionActive: false,
+                    kidName: kidName,
+                    dateText: todayDateText,
+                    coinCount: coinCount,
+                    fireStoneCount: 0,
+                    maxFireStoneCount: totalSchedule,
+                    scheduleOrder: schedule.scheduleOrder,
+                    scheduleOrderText: "",
+                    speechFieldType: .no,
+                    chipItemType: .inProgressChip,
+                    isTimeViewActive: false,
+                    actionButtonType: .hidden
+                )
+            }
+            
             return DailyJourneyModel(
                 bubbleText: "고마워 \(kidName)!\n오늘의 조각들이 모두 모였어! 영웅의 불꽃 을 피워줘!",
                 highlightKeywords: ["영웅의 불꽃"],
@@ -232,8 +255,8 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 kidName: kidName,
                 dateText: todayDateText,
                 coinCount: coinCount,
-                fireStoneCount: schedule.earnedStones ?? 0,
-                maxFireStoneCount: schedule.totalSchedule,
+                fireStoneCount: earnedStones,
+                maxFireStoneCount: totalSchedule,
                 scheduleOrder: schedule.scheduleOrder,
                 scheduleOrderText: "",
                 speechFieldType: .no,
@@ -251,8 +274,8 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 kidName: kidName,
                 dateText: todayDateText,
                 coinCount: coinCount,
-                fireStoneCount: schedule.earnedStones ?? 0,
-                maxFireStoneCount: schedule.totalSchedule,
+                fireStoneCount: earnedStones,
+                maxFireStoneCount: totalSchedule,
                 scheduleOrder: schedule.scheduleOrder,
                 scheduleOrderText: "",
                 speechFieldType: .no,
@@ -261,6 +284,34 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 actionButtonType: buttonType
             )
         }
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func isCurrentTimeInSchedule(start: String?, end: String?) -> Bool {
+        guard let start = start, let end = end else { return false }
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        formatter.locale = Locale(identifier: "ko_KR")
+        
+        let now = Date()
+        let calendar = Calendar.current
+        
+        let todayComponents = calendar.dateComponents([.year, .month, .day], from: now)
+        
+        guard let startDateOrigin = formatter.date(from: start),
+              let endDateOrigin = formatter.date(from: end) else { return false }
+        
+        let startComponents = calendar.dateComponents([.hour, .minute, .second], from: startDateOrigin)
+        let endComponents = calendar.dateComponents([.hour, .minute, .second], from: endDateOrigin)
+        
+        guard let startDate = calendar.date(byAdding: startComponents, to: calendar.date(from: todayComponents)!),
+              let endDate = calendar.date(byAdding: endComponents, to: calendar.date(from: todayComponents)!) else {
+            return false
+        }
+        
+        return now >= startDate && now <= endDate
     }
     
     // MARK: - Helper Methods

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -26,6 +26,7 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
     
     struct Input {
         let viewWillAppear: AnyPublisher<Void, Never>
+        let viewWillDisappear: AnyPublisher<Void, Never>
         let nextJourneyButtonTap: AnyPublisher<Void, Never>
         let verifyButtonTap: AnyPublisher<Void, Never>
         let skipConfirmTap: AnyPublisher<Void, Never>
@@ -45,7 +46,14 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
     
     func transform(input: Input) -> Output {
         input.viewWillAppear
-            .sink { [weak self] in self?.fetchDailyJourney() }
+            .sink { [weak self] in 
+                self?.fetchDailyJourney()
+                self?.startSseConnection()
+            }
+            .store(in: &cancellables)
+        
+        input.viewWillDisappear
+            .sink { [weak self] in self?.pauseSseConnection() }
             .store(in: &cancellables)
         
         input.nextJourneyButtonTap
@@ -126,6 +134,42 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
     }
     
     
+    
+    // MARK: - SSE Logic
+    
+    func startSseConnection() {
+        print("✅ [DailyJourneyViewModel] startSseConnection called")
+        
+        Task {
+            var token = TokenManager.shared.getSseToken()
+            
+            if token == nil {
+                print("⚠️ [DailyJourneyViewModel] No SSE Token found. Reissuing...")
+                do {
+                    token = try await BaseService.shared.reissueSseAccessToken()
+                    print("✅ [DailyJourneyViewModel] SSE Token reissued successfully.")
+                } catch {
+                    print("❌ [DailyJourneyViewModel] Failed to reissue SSE Token: \(error)")
+                    return
+                }
+            }
+            
+            guard let validToken = token else { return }
+            
+            await MainActor.run {
+                SseStreamManager.shared.startIfNeeded(initialToken: validToken) { [weak self] payload in
+                    print("📩 [DailyJourneyViewModel] SSE Event received: \(payload.eventType)")
+                    // 이벤트 수신 시 데이터 갱신
+                    self?.fetchDailyJourney()
+                }
+            }
+        }
+    }
+    
+    func pauseSseConnection() {
+        print("⏸ [DailyJourneyViewModel] pauseSseConnection called")
+        SseStreamManager.shared.pause()
+    }
     
     // MARK: - Converter
     

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -177,9 +177,9 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
             case .firstSchedule:
                 bubbleText = "오늘도 내 불씨를 키워주러 왔구나!\n우리의 \(orderText)번째 여정은 \(scheduleName)!"
             case .nowScheduleExist:
-                bubbleText = "지금은 \(scheduleName)의 시간이야!\n여정을 진행하면 \(stoneTypeName)의 불조각을 줄게."
-            default: // .nextScheduleExist
-                bubbleText = "다음은 \(scheduleName)의 시간이야!\n다음 여정을 진행하면 \(stoneTypeName)의 불조각을 줄게."
+                bubbleText = "지금은 \(scheduleName)의 시간이야!\n여정을 진행하면 \(stoneTypeName) 을 줄게."
+            default:
+                bubbleText = "다음은 \(scheduleName)의 시간이야!\n다음 여정을 진행하면 \(stoneTypeName) 을 줄게."
             }
             
             return DailyJourneyModel(

--- a/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneResultView.swift
+++ b/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneResultView.swift
@@ -106,7 +106,7 @@ final class GiveFireStoneResultView: BaseUIView {
         } else {
             lines = [
                 "덕분에 영웅의 불꽃 이 커졌어!",
-                "오늘도 도와줘서 고마워"
+                "오늘도 도와줘서 고마워."
             ]
             highlightKeywords = ["영웅의 불꽃"]
         }

--- a/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneViewController.swift
+++ b/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneViewController.swift
@@ -33,6 +33,7 @@ final class GiveFireStoneViewController: BaseViewController<GiveFireStoneViewMod
     // MARK: - Life Cycle
     
     override func viewDidLoad() {
+        self.hidesBottomBarWhenPushed = true
         super.viewDidLoad()
         view.backgroundColor = .kBlack
         entryView.configure(count: viewModel?.earnedStoneCount ?? 0)

--- a/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteViewController.swift
+++ b/Kiero/Kiero/Presentation/MissionComplete/MissionCompleteViewController.swift
@@ -21,8 +21,10 @@ final class MissionCompleteViewController: BaseViewController<MissionCompleteVie
     
     var initialImage: UIImage?
     
-    private let viewDidAppearSubject = PassthroughSubject<Void, Never>()
+    private var isAnimationFinished = false
+    private var isApiSuccess = false
     
+    private let viewDidAppearSubject = PassthroughSubject<Void, Never>()
     private let completeButtonTapSubject = PassthroughSubject<Void, Never>()
     
     // MARK: - Init
@@ -61,16 +63,30 @@ final class MissionCompleteViewController: BaseViewController<MissionCompleteVie
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
             guard let self = self else { return }
             
-            self.mainView.startFloatingAnimation { }
+            self.mainView.startFloatingAnimation { [weak self] in
+                print("✨ 애니메이션 종료 (4초)")
+                self?.isAnimationFinished = true
+                self?.checkAndPopViewController()
+            }
             
-            print("화면 진입 -> 자동으로 인증 프로세스 시작")
+            print("🚀 화면 진입 -> 인증 프로세스 시작")
             self.didTapCompleteButton()
         }
     }
     
-    @objc
+    // MARK: - Logic
+    
     private func didTapCompleteButton() {
         completeButtonTapSubject.send(())
+    }
+    
+    private func checkAndPopViewController() {
+        if isAnimationFinished && isApiSuccess {
+            print("✅ 모든 조건 충족 (애니메이션 끝 + 인증 성공) -> 화면 이동")
+            self.navigationController?.popViewController(animated: true)
+        } else {
+            print("⏳ 대기 중... (애니메이션 완료: \(isAnimationFinished), API 성공: \(isApiSuccess))")
+        }
     }
     
     // MARK: - Bind
@@ -109,13 +125,16 @@ final class MissionCompleteViewController: BaseViewController<MissionCompleteVie
         output.event
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in
+                guard let self = self else { return }
+                
                 switch event {
                 case .success:
-                    print("인증 완료! 이전 화면으로 이동합니다.")
-                    self?.navigationController?.popViewController(animated: true)
+                    print("🎉 서버 인증 성공~~ 룰루~~")
+                    self.isApiSuccess = true
+                    self.checkAndPopViewController()
                     
                 case .failure(let errorMessage):
-                    print("인증 실패: \(errorMessage)")
+                    print("❌ 인증 실패: \(errorMessage)")
                 }
             }
             .store(in: &cancellables)


### PR DESCRIPTION
## 📟 연결된 이슈
closed #162 
<br>

## 🍎 작업 내용
- SSE 매니저 Singleton 패턴 적용 (SseStreamManager.swift, AppDIContainer.swift) 
    - 연결 상태 관리 및 리소스 낭비를 막기 위해 싱글톤 인스턴스를 사용하도록 변경

- 오늘의 여정 화면 연동 및 생명주기 처리 (DailyJourneyViewModel.swift, DailyJourneyViewController.swift)

- 토큰 방어 로직(DailyJourneyViewModel.swift)
    - SSE 연결 시도 시, 저장된 토큰이 없으면(nil) 즉시 BaseService.shared.reissueSseAccessToken()을 호출하여 새 토큰을 발급받은 후 연결을 시도하도록 함

- SSE 토큰 재발급 시 TokenManager에 자동으로 저장되도록 수정 (BaseService.swift, TokenManager.swift)
- 로그아웃(TokenManager.clearAll) 시 SseStreamManager.shared.stop()을 호출하여 서버와의 구독을 완전히 종료
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 화면2 |
|:---------:|:-------------:|:-------------:|
| 기능1 | <img src="" width="250"> | <img src="" width="250"> |
<br>

## 💬 리뷰 코멘트
산더미 같은 QA...
<img width="300" alt="image" src="https://github.com/user-attachments/assets/159b44e4-5e8b-4625-9da6-78eb401cdcc0" />
