### PR TITLE
[refactor] #164 스케줄 관리 QA 반영

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Extensions/UIViewController+Dialog.swift
+++ b/Kiero/Kiero/Presentation/Common/Extensions/UIViewController+Dialog.swift
@@ -4,6 +4,8 @@ import Then
 
 extension UIViewController {
     func showLogoutDialog(onConfirm: @escaping () -> Void) {
+        let targetView: UIView = self.tabBarController?.view ?? self.navigationController?.view ?? self.view
+        
         let dimmedView = UIView().then {
             $0.backgroundColor = UIColor.kBlack.withAlphaComponent(0.75)
             $0.alpha = 1
@@ -14,7 +16,7 @@ extension UIViewController {
             $0.alpha = 1
         }
         
-        view.addSubviews(dimmedView, dialogBox)
+        targetView.addSubviews(dimmedView, dialogBox)
         
         dimmedView.snp.makeConstraints {
             $0.edges.equalToSuperview()
@@ -24,6 +26,9 @@ extension UIViewController {
             $0.center.equalToSuperview()
             $0.horizontalEdges.equalToSuperview().inset(16)
         }
+        
+        targetView.bringSubviewToFront(dimmedView)
+        targetView.bringSubviewToFront(dialogBox)
         
         dialogBox.onTapCancel = { [weak self] in
             self?.dismissDialog(dimmedView, dialogBox)

--- a/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewController.swift
+++ b/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewController.swift
@@ -31,6 +31,12 @@ final class AIMissionViewController: BaseViewController<AIMissionViewModel> {
     private var currentIndex: Int = 0
     private var editedMissions: [Int: Mission] = [:]
     
+    private var isAllMissionsViewed: Bool = false {
+        didSet {
+            updateButtonState(text: "")
+        }
+    }
+    
     // MARK: - UI Components
     
     private let navigationBar = NavigationBar(type: .close(title: "알림장 미션 추가"))
@@ -120,9 +126,15 @@ final class AIMissionViewController: BaseViewController<AIMissionViewModel> {
         }
         
         missionResultView.pagingHeader.onRightButtonTapped = { [weak self] in
-            self?.saveCurrentState()
-            self?.currentIndex += 1
-            self?.displayMission(at: self?.currentIndex ?? 0)
+            guard let self = self else { return }
+            self.saveCurrentState()
+            self.currentIndex += 1
+            
+            if self.currentIndex == self.suggestedMissions.count - 1 {
+                self.isAllMissionsViewed = true
+            }
+            
+            self.displayMission(at: self.currentIndex)
         }
     }
     
@@ -152,10 +164,15 @@ final class AIMissionViewController: BaseViewController<AIMissionViewModel> {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] missions in
                 guard let self = self, !missions.isEmpty else { return }
-                self.suggestedMissions = missions
-                self.currentIndex = 0
-                self.isAnalysisDone = true
-                self.displayMission(at: 0)
+                if missions.isEmpty {
+                    self.addMissionButton.isEnabled = true
+                } else {
+                    self.suggestedMissions = missions
+                    self.currentIndex = 0
+                    self.isAnalysisDone = true
+                    self.isAllMissionsViewed = (missions.count <= 1)
+                    self.displayMission(at: 0)
+                }
             }
             .store(in: &cancellables)
         
@@ -173,10 +190,11 @@ final class AIMissionViewController: BaseViewController<AIMissionViewModel> {
             .sink { [weak self] message in
                 guard let self = self else { return }
                 
+                self.addMissionButton.isEnabled = true
+                
                 if let presented = self.presentedViewController as? LoadingViewController {
                     presented.dismiss(animated: false)
                 }
-                
                 Toast.show(message: message, bottomInset: 40)
             }
             .store(in: &cancellables)
@@ -187,8 +205,11 @@ final class AIMissionViewController: BaseViewController<AIMissionViewModel> {
         if !isAnalysisDone {
             self.view.endEditing(true)
             guard let text = missionInputView.textView.text, !text.isEmpty else { return }
+            
+            addMissionButton.isEnabled = false
             viewModel?.analyzeNotice(text: text)
         } else {
+            addMissionButton.isEnabled = false
             saveActualMission()
         }
     }
@@ -245,9 +266,13 @@ final class AIMissionViewController: BaseViewController<AIMissionViewModel> {
             let isValid = text.count >= 10 && text.count <= 1000
             addMissionButton.isEnabled = isValid
             addMissionButton.alpha = isValid ? 1.0 : 0.5
+            addMissionButton.configure(title: "분석하고 미션추가하기")
         } else {
-            addMissionButton.isEnabled = true
-            addMissionButton.alpha = 1.0
+            addMissionButton.isEnabled = isAllMissionsViewed
+            addMissionButton.alpha = isAllMissionsViewed ? 1.0 : 0.5
+            
+            let title = isAllMissionsViewed ? "저장하기" : "마지막 미션까지 확인해주세요"
+            addMissionButton.configure(title: title)
         }
     }
     
@@ -255,14 +280,7 @@ final class AIMissionViewController: BaseViewController<AIMissionViewModel> {
         missionInputView.isHidden = isAnalysisDone
         missionResultView.isHidden = !isAnalysisDone
         
-        let buttonTitle = isAnalysisDone ? "저장하기" : "분석하고 미션추가하기"
-        addMissionButton.configure(title: buttonTitle)
-        
-        if !isAnalysisDone {
-            updateButtonState(text: missionInputView.textView.text)
-        } else {
-            updateButtonState(text: "")
-        }
+        updateButtonState(text: missionInputView.textView.text)
     }
     
     private func presentEndDateViewController() {

--- a/Kiero/Kiero/Presentation/Mission/Mission/MissionViewController.swift
+++ b/Kiero/Kiero/Presentation/Mission/Mission/MissionViewController.swift
@@ -26,7 +26,9 @@ final class MissionViewController: BaseViewController<MissionViewModel> {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        viewModel?.fetchMissions()
+        if viewModel?.missionGroups.isEmpty ?? true {
+            viewModel?.fetchMissions()
+        }
     }
     
     override func viewDidLoad() {
@@ -60,9 +62,6 @@ final class MissionViewController: BaseViewController<MissionViewModel> {
                 
                 if hasData {
                     self.missionView.updateMissionGroups(groups)
-                    DispatchQueue.main.async {
-                        self.missionView.scrollToTop()
-                    }
                 }
             }
             .store(in: &cancellables)

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -235,17 +235,12 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             let currentWeekDayIndex = (calendar.component(.weekday, from: now) + 5) % 7
             let isCurrentWeek = calendar.isDate(self.baseDate, inSameDayAs: today) || (weekDates.first! <= today && weekDates.last! >= today)
             
-            var startDateToSend: String? = nil
-            
             if isRecurring {
                 let hasPastDayInWeek = selectedIndices.contains { $0 < currentWeekDayIndex }
                 let isTodaySelected = selectedIndices.contains(currentWeekDayIndex)
                 let isTodayTimePast = isTodaySelected && (startMin < currentTimeMin)
                 
                 if isCurrentWeek && (hasPastDayInWeek || isTodayTimePast) {
-                    if let nextMonday = calendar.date(byAdding: .day, value: 7 - currentWeekDayIndex, to: today) {
-                        startDateToSend = nextMonday.toString(format: "yyyy-MM-dd")
-                    }
                     Toast.show(message: "일정이 등록되었어요. (오늘 일정은 마감되어 다음 주부터 적용돼요!)")
                 } else {
                     Toast.show(message: "일정이 등록되었어요.")
@@ -288,10 +283,27 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             if isRecurring {
                 let dayLabels = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
                 let dayOfWeekStr = selectedIndices.map { dayLabels[$0] }.joined(separator: ", ")
-                viewModel?.addSchedule(name: title, isRecurring: true, startTime: startTimeStr, endTime: endTimeStr, color: colorCode, dayOfWeek: dayOfWeekStr, dates: nil)
+                
+                viewModel?.addSchedule(
+                    name: title,
+                    isRecurring: true,
+                    startTime: startTimeStr,
+                    endTime: endTimeStr,
+                    color: colorCode,
+                    dayOfWeek: dayOfWeekStr,
+                    dates: nil
+                )
             } else {
                 let datesStr = selectedIndices.map { weekDates[$0].toString(format: "yyyy-MM-dd") }.joined(separator: ", ")
-                viewModel?.addSchedule(name: title, isRecurring: false, startTime: startTimeStr, endTime: endTimeStr, color: colorCode, dayOfWeek: nil, dates: datesStr)
+                viewModel?.addSchedule(
+                    name: title,
+                    isRecurring: false,
+                    startTime: startTimeStr,
+                    endTime: endTimeStr,
+                    color: colorCode,
+                    dayOfWeek: nil,
+                    dates: datesStr
+                )
             }
             
             self.view.endEditing(true)

--- a/Kiero/Kiero/Presentation/Schedule/BottomSheet/ColorPickerViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/BottomSheet/ColorPickerViewController.swift
@@ -77,18 +77,12 @@ final class ColorPickerViewController: BaseBottomSheetViewController {
     }
     
     private func setAction() {
-        navigationBar.leftButtonAction = { [weak self] in
-            self?.hideSheet()
+        navigationBar.leftButtonAction = {
+            super.hideSheet()
         }
         
         navigationBar.rightButtonAction = { [weak self] in
-            guard let self = self, let color = self.selectedColor else {
-                self?.hideSheet()
-                return
-            }
-            
-            self.onColorSelected?(color)
-            self.hideSheet()
+            self?.hideSheet()
         }
     }
     
@@ -118,6 +112,10 @@ final class ColorPickerViewController: BaseBottomSheetViewController {
     }
     
     override func hideSheet() {
+        if let color = self.selectedColor {
+            self.onColorSelected?(color)
+        }
+        
         self.onDismiss?()
         super.hideSheet()
     }

--- a/Kiero/Kiero/Presentation/Schedule/WeeklyTimeTable/WeeklyTimeTableView.swift
+++ b/Kiero/Kiero/Presentation/Schedule/WeeklyTimeTable/WeeklyTimeTableView.swift
@@ -72,8 +72,8 @@ final class WeeklyTimeTableView: BaseUIView {
     override func setLayout() {
         headerStackView.snp.makeConstraints {
             $0.top.equalToSuperview()
-            $0.leading.equalToSuperview().offset(27)
-            $0.trailing.equalToSuperview().inset(5)
+            $0.leading.equalTo(gridBackgroundView.snp.leading)
+            $0.trailing.equalTo(gridBackgroundView.snp.trailing)
             $0.height.equalTo(25)
         }
         
@@ -149,7 +149,8 @@ final class WeeklyTimeTableView: BaseUIView {
     
     private func updateHeaderLabels() {
         headerStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
-        
+        headerStackView.isLayoutMarginsRelativeArrangement = true
+        headerStackView.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: -9)
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
         


### PR DESCRIPTION
## 📟 연결된 이슈
closed #164 
<br>

## 🍎 작업 내용
- 스크롤 뒤 하단 탭바 이동 후 다시 돌아왔을 때 원래 상태가 유지되도록 수정했습니다.
- 일정 컬러 dim 클릭시에도 적용되도록 하였습니다.
- 반복 일정 등록 시 필드를 중복 전송하여 등록되지 않는 문제를 해결했습니다.
- 알림장 미션을 끝까지 확인해야 버튼 활성화되도록 수정했습니다.
- 스케줄 관리 내 시간표의 헤더에 위치한 일자를 표시하는 부분의 왼쪽 쏠림현상을 수정했습니다.
<br>

## 💬 리뷰 코멘트
너무 고생했어요 다들 ☺︎