### PR TITLE
[refactor] #177 알림 피드 리팩토링

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/MissionBox/MissionBoxChild.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/MissionBox/MissionBoxChild.swift
@@ -21,21 +21,21 @@ final class MissionBoxChild: UIView {
         var backgroundColor: UIColor {
             switch self {
             case .inProgress: return .gray900
-            case .completed: return UIColor.gray900.withAlphaComponent(0.6)
+            case .completed: return UIColor.gray900.withAlphaComponent(0.5)
             }
         }
         
         var titleColor: UIColor {
             switch self {
             case .inProgress: return .white
-            case .completed: return .white.withAlphaComponent(0.6)
+            case .completed: return .white.withAlphaComponent(0.5)
             }
         }
         
         var rewardColor: UIColor {
             switch self {
             case .inProgress: return .gray400
-            case .completed: return UIColor.gray400.withAlphaComponent(0.6)
+            case .completed: return UIColor.gray400.withAlphaComponent(0.5)
             }
         }
         
@@ -49,7 +49,7 @@ final class MissionBoxChild: UIView {
         var buttonTextColor: UIColor {
             switch self {
             case .inProgress: return .kBlack
-            case .completed: return .white.withAlphaComponent(0.6)
+            case .completed: return .white.withAlphaComponent(0.5)
             }
         }
         

--- a/Kiero/Kiero/Presentation/Common/Components/NotificationFeed/NotificationFeed.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/NotificationFeed/NotificationFeed.swift
@@ -17,6 +17,7 @@ final class NotificationFeed: UIView {
     
     enum State {
         case finishSchedule(
+            key: String,
             time: String,
             childName: String,
             schedule: String,
@@ -137,7 +138,7 @@ final class NotificationFeed: UIView {
         
         proofImageView.snp.makeConstraints {
             $0.top.equalTo(messageLabel.snp.bottom).offset(7)
-            $0.horizontalEdges.equalTo(container).inset(65)
+            $0.horizontalEdges.equalTo(container).inset(13)
             $0.height.equalTo(0)
         }
         
@@ -164,7 +165,7 @@ final class NotificationFeed: UIView {
         let style: UIFont.NotoSans = .title3_16_SB
         
         switch state {
-        case let .finishSchedule(time, childName, schedule, proofImageUrl, isExpanded):
+        case let .finishSchedule(_, time, childName, schedule, proofImageUrl, isExpanded):
             timeLabel.setTypo(.body4_12_R, text: time)
             downButton.isHidden = false
             let subject = "\(childName)\(childName.subjectMarker)"
@@ -220,7 +221,7 @@ final class NotificationFeed: UIView {
     
     private func applyExpanded(_ expanded: Bool, animated: Bool) {
         proofImageView.isHidden = !expanded
-        proofImageView.snp.updateConstraints { $0.height.equalTo(expanded ? 343 : 0) }
+        proofImageView.snp.updateConstraints { $0.height.equalTo(expanded ? 435 : 0) }
         let name = expanded ? UIImage.icUp : UIImage.icDown
         downButton.setImage(name, for: .normal)
     }
@@ -310,8 +311,9 @@ extension NotificationFeed.State {
 
     mutating func toggleExpanded() {
         switch self {
-        case let .finishSchedule(time, childName, schedule, url, isExpanded):
+        case let .finishSchedule(key, time, childName, schedule, url, isExpanded):
             self = .finishSchedule(
+                key: key,
                 time: time,
                 childName: childName,
                 schedule: schedule,
@@ -325,7 +327,7 @@ extension NotificationFeed.State {
 
     var dateKey: String {
         switch self {
-        case let .finishSchedule(time, _, _, _, _),
+        case let .finishSchedule(_, time, _, _, _, _),
              let .finishMission(time, _, _, _),
              let .useCoupon(time, _, _, _),
              let .finishAllSchedule(time, _, _):

--- a/Kiero/Kiero/Presentation/Common/Components/NotificationFeed/NotificationFeed.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/NotificationFeed/NotificationFeed.swift
@@ -64,9 +64,10 @@ final class NotificationFeed: UIView {
     }
     
     private let proofImageView = UIImageView().then {
-        $0.contentMode = .scaleAspectFit
+        $0.contentMode = .scaleAspectFill
         $0.clipsToBounds = true
         $0.isHidden = true
+        $0.layer.cornerRadius = 10
     }
     
     private let coinChip = ChipItem().then {
@@ -136,7 +137,7 @@ final class NotificationFeed: UIView {
         
         proofImageView.snp.makeConstraints {
             $0.top.equalTo(messageLabel.snp.bottom).offset(7)
-            $0.centerX.equalToSuperview()
+            $0.horizontalEdges.equalTo(container).inset(65)
             $0.height.equalTo(0)
         }
         

--- a/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
+++ b/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
@@ -29,6 +29,7 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
     private var nextCursor: String? = nil
     private var canLoadMore: Bool { nextCursor != nil }
     private var cachedChildName: String = ""
+    private var expandedKeys = Set<String>()
     private var seenKeys = Set<String>()
     private var sseStarted = false
     
@@ -318,12 +319,19 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
                 coinEarned: item.metadata.amount ?? 0
             )
         case .schedule:
+            let key = makeDedupKey(
+                eventType: item.eventType,
+                occurredAt: item.occurredAt,
+                metadata: item.metadata
+            )
+            
             return .finishSchedule(
+                key: key,
                 time: time,
                 childName: childName,
                 schedule: item.metadata.content ?? "",
                 proofImageUrl: item.metadata.imageUrl,
-                isExpanded: false
+                isExpanded: expandedKeys.contains(key)
             )
         case .coupon:
             return .useCoupon(
@@ -360,6 +368,15 @@ extension NotificationFeedViewModel {
     func toggleExpansion(at indexPath: IndexPath) {
         guard sections.indices.contains(indexPath.section),
               sections[indexPath.section].items.indices.contains(indexPath.row) else { return }
+        
+        let before = sections[indexPath.section].items[indexPath.row]
+        if case let .finishSchedule(key, _, _, _, _, isExpanded) = before{
+            if isExpanded {
+                expandedKeys.remove(key)
+            } else {
+                expandedKeys.insert(key)
+            }
+        }
         
         sections[indexPath.section].items[indexPath.row].toggleExpanded()
         sectionsSubject.send(sections)


### PR DESCRIPTION
## 📟 연결된 이슈
closed #177
<br>

## 🍎 작업 내용
- 알림 피드 속 인증사진의 모서리를 둥글게 변경하였습니다.
- 알림피드에서 인증사진 부분을 펼친 후 다른 페이지로 이동했다 돌아와도 펼친 상태가 유지됩니다. 
- 금화미션에서 미션 완료시의 opacity를 변경하였습니다. 
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 기능1 | <img src="https://github.com/user-attachments/assets/8b5f177d-1526-4aa5-b2ff-959b9da8ce64" width="250"> | 
<br>

## 💬 리뷰 코멘트
화면 동영상이 링크로 올라가네요.....
시뮬레이터로 돌려서 확인하고 싶었는데 왜인지는 잘 모르겠지만 로그인이 안되더라고요.....?
그래서 일단 프리뷰에서 실행되는 거 확인하고 화면기록하였습니다. 
프리뷰에서는 잘 실행되는데 시뮬로 돌렸을 때는 잘 실행될지 모르겠네요... 코드 확인 부탁드립니다. 

알림피드 펼친 상태가 유지되는 것은 expandedKey를 추가하여 펼쳐진 셀의 정보를 저장하고 해당 셀이 다시 불러와졌을 때 펼쳐져 있을 수 있도록 코드를 구성하였습니다. 