### PR TITLE
[refactor] #179 오늘의 여정 리팩토링

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
@@ -119,8 +119,7 @@ final class SpeechField: UIView {
         }
 
         nameLabel.snp.makeConstraints {
-            $0.edges.equalToSuperview().inset(
-                UIEdgeInsets(top: 2, left: 10, bottom: 2, right: 12))
+            $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 2, left: 10, bottom: 2, right: 12))
         }
         
         containerView.snp.makeConstraints {

--- a/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
@@ -115,12 +115,12 @@ final class SpeechField: UIView {
         nameContainerView.snp.makeConstraints {
             $0.top.equalToSuperview().offset(15)
             $0.height.equalTo(21)
-            $0.width.greaterThanOrEqualTo(43)
             $0.leading.equalTo(containerView.snp.leading).offset(18)
         }
-        
+
         nameLabel.snp.makeConstraints {
-            $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 2, left: 10, bottom: 2, right: 10))
+            $0.edges.equalToSuperview().inset(
+                UIEdgeInsets(top: 2, left: 10, bottom: 2, right: 12))
         }
         
         containerView.snp.makeConstraints {

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyHeaderView.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyHeaderView.swift
@@ -6,74 +6,75 @@
 //
 
 import UIKit
-
 import SnapKit
 import Then
 
 final class DailyJourneyHeaderView: BaseUIView {
-    
+
     // MARK: - UI Components
-    
+
     private let profileIcon = UIImageView().then {
         $0.image = UIImage(resource: .icKidProfile)
         $0.contentMode = .scaleAspectFit
     }
-    
+
     private let nameLabel = UILabel().then {
         $0.textColor = .white
     }
-    
+
+    private let nameStack = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 10
+        $0.alignment = .center
+    }
+
     private let dateLabel = UILabel().then {
         $0.textColor = .gray500
     }
-    
+
     private let coinChip = ChipItem()
-    
     private let fireStoneChip = ChipItem()
-    
-    private let chipStackView = UIStackView().then {
-        $0.axis = .vertical
-        $0.spacing = 11
-        $0.alignment = .trailing
-        $0.distribution = .fill
-    }
-    
+
     // MARK: - Setup UI
-    
+
     override func setUI() {
-        addSubviews(profileIcon, nameLabel, dateLabel, chipStackView)
-        chipStackView.addArrangedSubviews(coinChip, fireStoneChip)
+        nameStack.addArrangedSubviews(profileIcon, nameLabel)
+        addSubviews(nameStack, coinChip, fireStoneChip, dateLabel)
     }
-    
+
     override func setLayout() {
+        nameStack.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(0)
+            $0.leading.equalToSuperview().inset(16)
+            $0.height.equalTo(40)
+        }
+
         profileIcon.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(5)
-            $0.leading.equalToSuperview().offset(16)
             $0.size.equalTo(40)
         }
-        
-        nameLabel.snp.makeConstraints {
-            $0.leading.equalTo(profileIcon.snp.trailing).offset(6)
-            $0.centerY.equalTo(profileIcon)
+
+        coinChip.snp.makeConstraints {
+            $0.centerY.equalTo(nameStack)
+            $0.trailing.equalToSuperview().inset(16)
         }
-        
+
+        fireStoneChip.snp.makeConstraints {
+            $0.top.equalTo(coinChip.snp.bottom).offset(11)
+            $0.trailing.equalToSuperview().inset(16)
+        }
+
         dateLabel.snp.makeConstraints {
-            $0.top.equalTo(nameLabel.snp.bottom).offset(10)
-            $0.leading.equalTo(profileIcon)
-        }
-        
-        chipStackView.snp.makeConstraints {
-            $0.centerY.equalToSuperview()
-            $0.trailing.equalToSuperview().offset(-20)
+            $0.top.equalTo(nameStack.snp.bottom).offset(10)
+            $0.leading.equalToSuperview().inset(16)
         }
     }
-    
+
     override func setStyle() {
-        self.backgroundColor = .clear
+        backgroundColor = .clear
     }
-    
+
     // MARK: - Configure
-    
+
     func configure(
         kidName: String,
         date: String,
@@ -84,10 +85,10 @@ final class DailyJourneyHeaderView: BaseUIView {
     ) {
         nameLabel.setTypo(.title3_16_SB, text: kidName)
         dateLabel.setTypo(.body3_14_R, text: date)
-        
+
         let coinImg = UIImage(resource: .ic3DCoin)
         let stoneImg = UIImage(resource: .ic3DBluestone)
-        
+
         coinChip.configure(style: .currentCoinChip, icon: coinImg, text: "\(coinCount) 개")
         fireStoneChip.configure(style: chipType, icon: stoneImg, text: "\(fireStoneCount) / \(maxFireStoneCount) 개")
     }

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
@@ -56,7 +56,7 @@ final class DailyJourneyView: BaseUIView {
             1.0
         ] as [NSNumber]
         gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.5)
-        gradientLayer.endPoint   = CGPoint(x: 1.0, y: 1.0)
+        gradientLayer.endPoint = CGPoint(x: 1.0, y: 1.0)
         
         $0.layer.addSublayer(gradientLayer)
     }

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
@@ -104,7 +104,7 @@ final class DailyJourneyView: BaseUIView {
     
     override func setLayout() {
         backgroundImageView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(106)
+            $0.top.equalToSuperview().offset(126)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(410)
             $0.height.equalTo(437)
@@ -137,7 +137,7 @@ final class DailyJourneyView: BaseUIView {
         }
         
         kkubiCharacterImageView.snp.makeConstraints {
-            $0.top.equalTo(journeyTimeView.snp.bottom).offset(20)
+            $0.top.equalTo(journeyTimeView.snp.bottom).offset(60)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(343)
             $0.height.equalTo(343)

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyView.swift
@@ -25,13 +25,39 @@ final class DailyJourneyView: BaseUIView {
         $0.clipsToBounds = true
     }
     
+    private let dimOverlayView = UIView().then {
+        $0.backgroundColor = UIColor.kBlack.withAlphaComponent(0.6)
+        $0.isUserInteractionEnabled = false
+    }
+    
     private let backgroundMaskView = UIView().then {
         let gradientLayer = CAGradientLayer()
         gradientLayer.type = .radial
-        gradientLayer.colors = [UIColor.black.cgColor, UIColor.clear.cgColor]
+        
+        gradientLayer.colors = [
+            UIColor(white: 1.0, alpha: 1.0).cgColor,
+            UIColor(white: 1.0, alpha: 1.0).cgColor,
+            UIColor(white: 1.0, alpha: 0.85).cgColor,
+            UIColor(white: 1.0, alpha: 0.65).cgColor,
+            UIColor(white: 1.0, alpha: 0.45).cgColor,
+            UIColor(white: 1.0, alpha: 0.25).cgColor,
+            UIColor(white: 1.0, alpha: 0.12).cgColor,
+            UIColor(white: 1.0, alpha: 0.0).cgColor
+        ]
+        
+        gradientLayer.locations = [
+            0.0,
+            0.75,
+            0.82,
+            0.88,
+            0.92,
+            0.95,
+            0.97,
+            1.0
+        ] as [NSNumber]
         gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.5)
-        gradientLayer.endPoint = CGPoint(x: 1.0, y: 1.0)
-        gradientLayer.locations = [0.0, 1.0]
+        gradientLayer.endPoint   = CGPoint(x: 1.0, y: 1.0)
+        
         $0.layer.addSublayer(gradientLayer)
     }
     
@@ -67,7 +93,7 @@ final class DailyJourneyView: BaseUIView {
     // MARK: - Setup Methods
     
     override func setUI() {
-        addSubviews(backgroundImageView, headerView, journeyTimeView, kkubiCharacterImageView, speechField, verifyPhotoButton)
+        addSubviews(backgroundImageView, dimOverlayView, headerView, journeyTimeView, kkubiCharacterImageView, speechField, verifyPhotoButton)
         
         speechField.onTap = { [weak self] in
             self?.onNextJourneyTap?()
@@ -78,10 +104,14 @@ final class DailyJourneyView: BaseUIView {
     
     override func setLayout() {
         backgroundImageView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(106)
+            $0.centerX.equalToSuperview()
             $0.width.equalTo(410)
             $0.height.equalTo(437)
-            $0.top.equalToSuperview().offset(106)
-            $0.leading.equalToSuperview().offset(-17)
+        }
+        
+        dimOverlayView.snp.makeConstraints {
+            $0.edges.equalTo(backgroundImageView)
         }
         
         headerView.snp.makeConstraints {


### PR DESCRIPTION
## 📟 연결된 이슈
closed #179 
<br>

## 🍎 작업 내용
DailyJourneyHeaderView
- 코인칩/불조각칩 위치를 “금화 미션” 화면과 동일한 기준으로 정렬
- 이름/프로필 영역 레이아웃 정리 (중복 constraint 제거 및 정렬 안정화)

SpeechField
- “꾸비” 이름 레이블을 중앙 정렬되도록 UI 정렬 개선

DailyJourneyView
- backgroundMaskView gradient 범위 및 투명도 세밀 조정
- dimOverlayView 추가로 배경 명도 보정
<br>

## 📸 스크린샷
| 기능/화면 | Preview 화면 |
|:---------:|:-------------:|
| 오늘의 여정 | <img width="250" alt="image" src="https://github.com/user-attachments/assets/d3b1c2a1-60f3-4544-aac1-b87e009c865b" /> | 
<br>

## 💬 리뷰 코멘트
시뮬로 금화미션이랑 오늘의 여정 헤더 위치 동일한거 확인했습니다!!