### PR TITLE
[refactor] #180 BaseService 구조 분리

### DIFF
--- a/Kiero/Kiero/Network/Base/BaseResponse.swift
+++ b/Kiero/Kiero/Network/Base/BaseResponse.swift
@@ -14,3 +14,8 @@ struct BaseResponse<T: Decodable>: Decodable {
 }
 
 struct EmptyResponse: Decodable { }
+
+struct ErrorResponse: Decodable {
+    let status: Int
+    let message: String
+}

--- a/Kiero/Kiero/Network/Base/BaseService/BaseService.swift
+++ b/Kiero/Kiero/Network/Base/BaseService/BaseService.swift
@@ -1,0 +1,83 @@
+//
+//  BaseService.swift
+//  Kiero
+//
+//  Created by 신혜연 on 1/8/26.
+//
+
+import Foundation
+
+struct AnyEncodable: Encodable {
+    private let encodeFunc: (Encoder) throws -> Void
+    init(_ value: Encodable) {
+        self.encodeFunc = value.encode
+    }
+    func encode(to encoder: Encoder) throws {
+        try encodeFunc(encoder)
+    }
+}
+
+final class BaseService {
+    
+    static let shared = BaseService()
+    private init() {}
+    
+    func request<Response: Decodable>(
+        endPoint: EndPoint,
+        body: Encodable? = nil,
+        didRetry: Bool = false
+    ) async throws -> Response {
+        
+        do {
+            return try await perform(endPoint: endPoint, body: body)
+            
+        } catch let error as NetworkError {
+            
+            guard case .clientError(let statusCode) = error,
+                  statusCode == 401,
+                  didRetry == false else {
+                throw error
+            }
+            
+            switch endPoint.refreshPolicy {
+                
+            case .none:
+                throw error
+                
+            case .child:
+                try await TokenRefresher.shared.refreshAllTokens()
+                
+            case .parent:
+                do {
+                    try await TokenRefresher.shared.refreshAccessToken()
+                } catch {
+                    try await TokenRefresher.shared.refreshAllTokens()
+                }
+            }
+            
+            return try await request(
+                endPoint: endPoint,
+                body: body,
+                didRetry: true
+            )
+        }
+    }
+    
+    private func perform<Response: Decodable>(
+        endPoint: EndPoint,
+        body: Encodable?
+    ) async throws -> Response {
+        
+        let request = try RequestBuilder.build(
+            endPoint: endPoint,
+            body: body
+        )
+        
+        let (data, httpResponse) = try await NetworkExecutor.execute(request)
+        
+        return try ResponseDecoder.decode(
+            data: data,
+            statusCode: httpResponse.statusCode
+        )
+    }
+}

--- a/Kiero/Kiero/Network/Base/BaseService/NetworkExecutor.swift
+++ b/Kiero/Kiero/Network/Base/BaseService/NetworkExecutor.swift
@@ -1,0 +1,23 @@
+//
+//  NetworkExecutor.swift
+//  Kiero
+//
+//  Created by 신혜연 on 2/24/26.
+//
+
+import Foundation
+
+struct NetworkExecutor {
+    
+    static func execute(_ request: URLRequest) async throws -> (Data, HTTPURLResponse) {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let http = response as? HTTPURLResponse else {
+            throw NetworkError.unknownError
+        }
+        
+        NetworkLogger.shared.responseLog(http, data: data)
+        
+        return (data, http)
+    }
+}

--- a/Kiero/Kiero/Network/Base/BaseService/RequestBuilder.swift
+++ b/Kiero/Kiero/Network/Base/BaseService/RequestBuilder.swift
@@ -1,0 +1,44 @@
+//
+//  RequestBuilder.swift
+//  Kiero
+//
+//  Created by 신혜연 on 2/24/26.
+//
+
+import Foundation
+
+struct RequestBuilder {
+    
+    static func build(
+        endPoint: EndPoint,
+        body: Encodable?
+    ) throws -> URLRequest {
+        
+        let urlString = Config.baseURL + endPoint.url
+        guard var components = URLComponents(string: urlString) else {
+            throw NetworkError.invalidURL
+        }
+        
+        if let items = endPoint.queryItems, !items.isEmpty {
+            components.queryItems = items
+        }
+        
+        guard let url = components.url else {
+            throw NetworkError.invalidURL
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = endPoint.method
+        request.timeoutInterval = 5.0
+        
+        endPoint.header.forEach {
+            request.addValue($0.value, forHTTPHeaderField: $0.key)
+        }
+        
+        if let body = body {
+            request.httpBody = try JSONEncoder().encode(AnyEncodable(body))
+        }
+        
+        return request
+    }
+}

--- a/Kiero/Kiero/Network/Base/BaseService/ResponseDecoder.swift
+++ b/Kiero/Kiero/Network/Base/BaseService/ResponseDecoder.swift
@@ -1,0 +1,52 @@
+//
+//  ResponseDecoder.swift
+//  Kiero
+//
+//  Created by 신혜연 on 2/24/26.
+//
+
+import Foundation
+
+struct ResponseDecoder {
+    
+    static func decode<Response: Decodable>(
+        data: Data,
+        statusCode: Int
+    ) throws -> Response {
+        
+        if (400...499).contains(statusCode) {
+            if let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).message {
+                throw NetworkError.codeError(message)
+            } else {
+                throw NetworkError.clientError(statusCode: statusCode)
+            }
+        }
+        
+        if (500...599).contains(statusCode) {
+            throw NetworkError.internalServerError
+        }
+        
+        guard (200...299).contains(statusCode) else {
+            throw NetworkError.unknownError
+        }
+        
+        if data.isEmpty {
+            if Response.self == EmptyResponse.self {
+                return EmptyResponse() as! Response
+            }
+            throw NetworkError.noData
+        }
+        
+        if Response.self == EmptyResponse.self {
+            return EmptyResponse() as! Response
+        }
+        
+        let decoded = try JSONDecoder().decode(BaseResponse<Response>.self, from: data)
+        
+        guard let result = decoded.data else {
+            throw NetworkError.noData
+        }
+        
+        return result
+    }
+}

--- a/Kiero/Kiero/Network/Base/BaseService/ResponseDecoder.swift
+++ b/Kiero/Kiero/Network/Base/BaseService/ResponseDecoder.swift
@@ -14,6 +14,10 @@ struct ResponseDecoder {
         statusCode: Int
     ) throws -> Response {
         
+        if statusCode == 401 {
+            throw NetworkError.clientError(statusCode: 401)
+        }
+
         if (400...499).contains(statusCode) {
             if let message = try? JSONDecoder().decode(ErrorResponse.self, from: data).message {
                 throw NetworkError.codeError(message)

--- a/Kiero/Kiero/Network/Base/BaseService/TokenRefresher.swift
+++ b/Kiero/Kiero/Network/Base/BaseService/TokenRefresher.swift
@@ -1,170 +1,18 @@
 //
-//  BaseService.swift
+//  TokenRefresher.swift
 //  Kiero
 //
-//  Created by 신혜연 on 1/8/26.
+//  Created by 신혜연 on 2/24/26.
 //
 
 import Foundation
 
-struct AnyEncodable: Encodable {
-    private let encodeFunc: (Encoder) throws -> Void
-    init(_ value: Encodable) {
-        self.encodeFunc = value.encode
-    }
-    func encode(to encoder: Encoder) throws {
-        try encodeFunc(encoder)
-    }
-}
-
-struct ErrorResponse: Decodable {
-    let status: Int
-    let message: String
-}
-
-final class BaseService {
-    static let shared = BaseService()
-    private init() { }
+final class TokenRefresher {
     
-    func request<Response: Decodable>(
-        endPoint: EndPoint,
-        body: Encodable? = nil,
-        didRetry: Bool = false
-    ) async throws -> Response {
-        
-        do {
-            return try await perform(endPoint: endPoint, body: body)
-        } catch let error as NetworkError {
-            
-            guard case .clientError(let statusCode) = error, statusCode == 401, didRetry == false else {
-                throw error
-            }
-            
-            switch endPoint.refreshPolicy {
-            case .none:
-                throw error
-                
-            case .child:
-                // 자녀: 항상 allTokens
-                try await refreshAllTokens()
-                return try await request(endPoint: endPoint, body: body, didRetry: true)
-                
-            case .parent:
-                // 부모: accessOnly 먼저 → 실패하면 allTokens
-                do {
-                    try await refreshAccessToken()
-                } catch {
-                    // accessOnly 재발급 실패 = refresh 만료 가능성 → allTokens 시도
-                    try await refreshAllTokens()
-                }
-                return try await request(endPoint: endPoint, body: body, didRetry: true)
-            }
-        }
-    }
+    static let shared = TokenRefresher()
+    private init() {}
     
-    func decodeServerMessage(from data: Data) -> String? {
-        guard let error = try? JSONDecoder().decode(ErrorResponse.self, from: data) else {
-            return nil
-        }
-        return error.message
-    }
-    
-    private func perform<Response: Decodable>(
-        endPoint: EndPoint,
-        body: Encodable?
-    ) async throws -> Response {
-        
-        // URL 구성
-        let urlString = Config.baseURL + endPoint.url
-        guard var components = URLComponents(string: urlString) else {
-            throw NetworkError.invalidURL
-        }
-        if let items = endPoint.queryItems, !items.isEmpty {
-            components.queryItems = items
-        }
-        guard let url = components.url else {
-            throw NetworkError.invalidURL
-        }
-        
-        // Request 준비
-        var request = URLRequest(url: url)
-        request.httpMethod = endPoint.method
-        request.timeoutInterval = 5.0
-        endPoint.header.forEach { key, value in
-            request.addValue(value, forHTTPHeaderField: key)
-        }
-        
-        // Body가 있다면 JSON 인코딩
-        if let body = body {
-            request.httpBody = try JSONEncoder().encode(AnyEncodable(body))
-        }
-        
-        // Network 호출
-        let (data, response) = try await URLSession.shared.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw NetworkError.unknownError
-        }
-        
-        NetworkLogger.shared.responseLog(httpResponse, data: data)
-        
-        // 상태 코드 체크
-        let statusCode = httpResponse.statusCode
-        
-        if (400...499).contains(statusCode) {
-            if let message = decodeServerMessage(from: data) {
-                throw NetworkError.codeError(message)
-            } else {
-                throw NetworkError.clientError(statusCode: statusCode)
-            }
-        } else if (500...599).contains(statusCode) {
-            throw NetworkError.internalServerError
-        } else if !(200...299).contains(statusCode) {
-            throw NetworkError.unknownError
-        }
-        
-        // Empty Body 대응 (데이터가 아예 없는 경우)
-        if data.isEmpty {
-            if Response.self == EmptyResponse.self {
-                return EmptyResponse() as! Response
-            } else {
-                throw NetworkError.noData
-            }
-        }
-        
-        //  디코딩
-        do {
-            if Response.self == EmptyResponse.self {
-                return EmptyResponse() as! Response
-            }
-            
-            let decoded = try JSONDecoder().decode(BaseResponse<Response>.self, from: data)
-            
-            if let data = decoded.data {
-                return data
-            }
-            else if Response.self == EmptyResponse.self {
-                return EmptyResponse() as! Response
-            }
-            else if let nilValue = (decoded.data as Any?) as? Response {
-                return nilValue
-            }
-            else {
-                throw NetworkError.noData
-            }
-            
-        } catch let error as NetworkError {
-            throw error
-        } catch {
-            if Response.self == EmptyResponse.self {
-                return EmptyResponse() as! Response
-            }
-            print("❌ Decoding Error 상세: \(error)")
-            throw NetworkError.responseDecodingError
-        }
-    }
-    
-    // accessToken 재발급
-    private func refreshAccessToken() async throws {
+    func refreshAccessToken() async throws {
         guard let refresh = TokenManager.shared.getRefreshToken(), !refresh.isEmpty else {
             TokenManager.shared.clearTokens()
             throw NetworkError.clientError(statusCode: 401)
@@ -188,7 +36,6 @@ final class BaseService {
             throw NetworkError.clientError(statusCode: http.statusCode)
         }
         
-        //  응답에서 accessToken 추출
         do {
             let decoded = try JSONDecoder().decode(BaseResponse<AccessTokenData>.self, from: data)
             guard let tokenData = decoded.data else { throw NetworkError.noData }
@@ -198,7 +45,7 @@ final class BaseService {
         }
     }
     
-    private func refreshAllTokens() async throws {
+    func refreshAllTokens() async throws {
         guard let refresh = TokenManager.shared.getRefreshToken(), !refresh.isEmpty else {
             TokenManager.shared.clearAll()
             throw NetworkError.clientError(statusCode: 401)
@@ -304,7 +151,6 @@ final class BaseService {
     }
     
     private func parseCookie(from setCookie: String, cookieName: String) -> String? {
-        // 예: "refreshToken=abc123; Path=/; HttpOnly; Secure"
         let parts = setCookie
             .split(separator: ";")
             .map { $0.trimmingCharacters(in: .whitespaces) }

--- a/Kiero/Kiero/Network/Base/BaseService/TokenRefresher.swift
+++ b/Kiero/Kiero/Network/Base/BaseService/TokenRefresher.swift
@@ -10,9 +10,26 @@ import Foundation
 final class TokenRefresher {
     
     static let shared = TokenRefresher()
+    private var refreshTask: Task<Void, Error>?
+    private var refreshAllTask: Task<Void, Error>?
     private init() {}
     
     func refreshAccessToken() async throws {
+        if let task = refreshTask {
+            return try await task.value
+        }
+        
+        let task = Task {
+            try await performRefreshAccessToken()
+        }
+        
+        refreshTask = task
+        defer { refreshTask = nil }
+        
+        try await task.value
+    }
+    
+    private func performRefreshAccessToken() async throws {
         guard let refresh = TokenManager.shared.getRefreshToken(), !refresh.isEmpty else {
             TokenManager.shared.clearTokens()
             throw NetworkError.clientError(statusCode: 401)
@@ -36,16 +53,28 @@ final class TokenRefresher {
             throw NetworkError.clientError(statusCode: http.statusCode)
         }
         
-        do {
-            let decoded = try JSONDecoder().decode(BaseResponse<AccessTokenData>.self, from: data)
-            guard let tokenData = decoded.data else { throw NetworkError.noData }
-            TokenManager.shared.saveAccessToken(tokenData.accessToken)
-        } catch {
-            throw NetworkError.responseDecodingError
-        }
+        let decoded = try JSONDecoder().decode(BaseResponse<AccessTokenData>.self, from: data)
+        guard let tokenData = decoded.data else { throw NetworkError.noData }
+        
+        TokenManager.shared.saveAccessToken(tokenData.accessToken)
     }
     
     func refreshAllTokens() async throws {
+        if let task = refreshAllTask {
+            return try await task.value
+        }
+        
+        let task = Task {
+            try await performRefreshAllTokens()
+        }
+        
+        refreshAllTask = task
+        defer { refreshAllTask = nil }
+        
+        try await task.value
+    }
+    
+    private func performRefreshAllTokens() async throws {
         guard let refresh = TokenManager.shared.getRefreshToken(), !refresh.isEmpty else {
             TokenManager.shared.clearAll()
             throw NetworkError.clientError(statusCode: 401)
@@ -69,18 +98,16 @@ final class TokenRefresher {
             throw NetworkError.clientError(statusCode: http.statusCode)
         }
         
-        do {
-            let decoded = try JSONDecoder().decode(BaseResponse<AccessTokenData>.self, from: data)
-            guard let tokenData = decoded.data else { throw NetworkError.noData }
-            TokenManager.shared.saveAccessToken(tokenData.accessToken)
-        } catch {
-            throw NetworkError.responseDecodingError
-        }
+        let decoded = try JSONDecoder().decode(BaseResponse<AccessTokenData>.self, from: data)
+        guard let tokenData = decoded.data else { throw NetworkError.noData }
+        
+        TokenManager.shared.saveAccessToken(tokenData.accessToken)
         
         guard let newRefresh = extractCookieValue(from: http, cookieName: "refreshToken") else {
             TokenManager.shared.clearAll()
             throw NetworkError.responseDecodingError
         }
+        
         TokenManager.shared.saveRefreshToken(newRefresh)
     }
     

--- a/Kiero/Kiero/Network/Login/SseStreamManager.swift
+++ b/Kiero/Kiero/Network/Login/SseStreamManager.swift
@@ -60,7 +60,7 @@ final class SseStreamManager {
                 self.onRefreshWillStart?()
                 
                 do {
-                    let newToken = try await BaseService.shared.reissueSseAccessToken()
+                    let newToken = try await TokenRefresher.shared.reissueSseAccessToken()
                     self.sseAccessToken = newToken
                     
                     await MainActor.run { [weak self] in

--- a/Kiero/Kiero/Presentation/CoinMission/CoinMissionViewModel.swift
+++ b/Kiero/Kiero/Presentation/CoinMission/CoinMissionViewModel.swift
@@ -150,7 +150,7 @@ final class CoinMissionViewModel: BaseViewModel, ViewModelType {
             guard let self else { return }
             
             do {
-                let initialToken = try await BaseService.shared.reissueSseAccessToken()
+                let initialToken = try await TokenRefresher.shared.reissueSseAccessToken()
                 
                 await MainActor.run { [weak self] in
                     guard let self else { return }

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -146,7 +146,7 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
             if token == nil {
                 print("⚠️ [DailyJourneyViewModel] No SSE Token found. Reissuing...")
                 do {
-                    token = try await BaseService.shared.reissueSseAccessToken()
+                    token = try await TokenRefresher.shared.reissueSseAccessToken()
                     print("✅ [DailyJourneyViewModel] SSE Token reissued successfully.")
                 } catch {
                     print("❌ [DailyJourneyViewModel] Failed to reissue SSE Token: \(error)")

--- a/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
+++ b/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
@@ -177,7 +177,7 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
             guard let self else { return }
             
             do {
-                let initialToken = try await BaseService.shared.reissueSseAccessToken()
+                let initialToken = try await TokenRefresher.shared.reissueSseAccessToken()
                 
                 await MainActor.run { [weak self] in
                     guard let self else { return }

--- a/Kiero/Kiero/Presentation/Onboarding/ViewModel/ParentOnboardingViewModel.swift
+++ b/Kiero/Kiero/Presentation/Onboarding/ViewModel/ParentOnboardingViewModel.swift
@@ -61,7 +61,7 @@ final class ParentOnboardingViewModel: BaseViewModel {
 
                 print("✅ [VM] 2) reissueSseAccessToken() 호출 직전")
 
-                let sseToken = try await BaseService.shared.reissueSseAccessToken()
+                let sseToken = try await TokenRefresher.shared.reissueSseAccessToken()
 
                 print("✅ [VM] 2) sseToken 발급 성공:", sseToken.prefix(10))
 


### PR DESCRIPTION
## 📟 연결된 이슈
closed #180 
<br>

## 🍎 작업 내용
1️⃣ 네트워크 레이어 구조 개선
기존 BaseService 중심 구조를 역할별로 분리하여 책임을 명확히 했습니다.

`분리 목적`
- 네트워크 요청 생성 / 실행 / 디코딩 / 재시도 로직의 관심사 분리
- 토큰 재발급 흐름을 서비스 로직과 독립적으로 관리
- 테스트 및 유지보수 용이성 확보
- 향후 API 확장 시 영향 범위 최소화

`구성`
BaseService → 전체 요청 흐름 관리 및 재시도 처리
RequestBuilder → URLRequest 생성 책임 분리
NetworkExecutor → 실제 통신 실행 분리
ResponseDecoder → 응답 디코딩 및 상태코드 처리 분리
TokenRefresher → 토큰 재발급 전담 객체
<br>

## 💬 리뷰 코멘트
현재 로그아웃 API 서버 수정 중으로 보이며
아이 더미 데이터 삭제 요청에서 500 에러가 발생하고 있습니다 ,, 

아이와 연결되지 않은 테스트 계정이 있는 경우
일정 등록 → 아이 앱 반영 여부까지 확인 부탁드립니다 ⚒️

+) 윤아의 꼼꼼한 리뷰 부탁드립니다 🙌🏻