### PR TITLE
[fix] #221 알림 피드 조회 method 변경

### DIFF
--- a/Kiero/Kiero/Network/Base/EndPoint.swift
+++ b/Kiero/Kiero/Network/Base/EndPoint.swift
@@ -174,9 +174,9 @@ enum EndPoint {
     
     var method: String {
         switch self {
-        case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor, .fetchFeeds, .fetchJourneyList, .fetchCoupons:
+        case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor, .fetchJourneyList, .fetchCoupons:
             return "GET"
-        case .updateDailyJourney, .skipJourney, .completeSchedule, .purchaseCoupon, .fireLit, .completeMission, .editSchedule, .updateMission, .updateCoupon:
+        case .updateDailyJourney, .skipJourney, .completeSchedule, .purchaseCoupon, .fireLit, .completeMission, .editSchedule, .updateMission, .updateCoupon, .fetchFeeds:
             return "PATCH"
         case .deleteChildDummy, .deleteSchedule, .deleteMission, .deleteCoupon:
             return "DELETE"

--- a/Kiero/Kiero/Network/Base/EndPoint.swift
+++ b/Kiero/Kiero/Network/Base/EndPoint.swift
@@ -134,7 +134,7 @@ enum EndPoint {
         case .fetchWishes:
             return "/api/v1/coupons"
         case .purchaseCoupon(let couponId):
-            return "/api/v1/coupons/\(couponId)"
+            return "/api/v1/coupons/\(couponId)/purchase"
         case .fetchCoupons(let childId), .addCoupon(let childId):
             return "/api/v1/coupons/\(childId)"
         case .deleteCoupon(let couponId), .updateCoupon(let couponId):
@@ -176,7 +176,7 @@ enum EndPoint {
         switch self {
         case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor, .fetchJourneyList, .fetchCoupons:
             return "GET"
-        case .updateDailyJourney, .skipJourney, .completeSchedule, .purchaseCoupon, .fireLit, .completeMission, .editSchedule, .updateMission, .updateCoupon, .fetchFeeds:
+        case .updateDailyJourney, .skipJourney, .completeSchedule, .fireLit, .completeMission, .editSchedule, .updateMission, .updateCoupon, .fetchFeeds:
             return "PATCH"
         case .deleteChildDummy, .deleteSchedule, .deleteMission, .deleteCoupon:
             return "DELETE"

--- a/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
+++ b/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
@@ -202,7 +202,7 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             
-            if payload.eventType == "FEED_ITEM_CREATED" {                
+            if payload.eventType == "FEED_ITEM_CREATED" {
                 self.sseRefreshSubject.send(())
             }
         }

--- a/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
+++ b/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
@@ -23,13 +23,13 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
     private let isLoadingSubject = CurrentValueSubject<Bool, Never>(false)
     private let isLoadingMoreSubject = CurrentValueSubject<Bool, Never>(false)
     private let sectionsSubject = CurrentValueSubject<[FeedSection], Never>([])
+    private let sseRefreshSubject = PassthroughSubject<Void, Never>()
     
     private(set) var sections: [FeedSection] = []
     private var nextCursor: String? = nil
     private var canLoadMore: Bool { nextCursor != nil }
     private var cachedChildName: String = ""
     private var expandedKeys = Set<String>()
-    private var seenKeys = Set<String>()
     private var sseStarted = false
     
     init(
@@ -58,7 +58,7 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
     
     func transform(input: Input) -> Output {
         
-        let idTrigger = Publishers.Merge(input.viewDidload, input.refresh)
+        let idTrigger = Publishers.Merge3(input.viewDidload, input.refresh, sseRefreshSubject)
             .handleEvents(receiveOutput: { [weak self] _ in
                 self?.isLoadingSubject.send(true)
                 self?.nextCursor = nil
@@ -200,34 +200,11 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
     
     private func handleSse(payload: SseEventPayload) {
         DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
+            guard let self = self else { return }
             
-            let eventType = self.mapServerEventType(payload.eventType)
-            let occurredAt = payload.occurredAt ?? ""
-            
-            let metadata = FeedMetadata(
-                content: payload.metadata?.content,
-                imageUrl: payload.metadata?.imageUrl,
-                amount: payload.metadata?.amount
-            )
-            
-            let key = self.makeDedupKey(eventType: eventType, occurredAt: occurredAt, metadata: metadata)
-            guard !self.seenKeys.contains(key) else { return }
-            self.seenKeys.insert(key)
-            
-            let newItem = FeedItem(
-                eventType: eventType,
-                occurredAt: occurredAt,
-                metadata: metadata
-            )
-            
-            var current = self.itemsSubject.value
-            current.insert(newItem, at: 0)
-            self.itemsSubject.send(current)
-            
-            let newSections = self.makeSections(items: current, childName: self.cachedChildName)
-            self.sections = newSections
-            self.sectionsSubject.send(newSections)
+            if payload.eventType == "FEED_ITEM_CREATED" {                
+                self.sseRefreshSubject.send(())
+            }
         }
     }
     
@@ -243,16 +220,6 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
             metadata.imageUrl ?? "",
             String(metadata.amount ?? -1)
         ].joined(separator: "|")
-    }
-    
-    private func mapServerEventType(_ raw: String) -> FeedEventType {
-        switch raw {
-        case "MISSION_COMPLETED": return .mission
-        case "SCHEDULE_COMPLETED": return .schedule
-        case "COUPON_PURCHASED": return .coupon
-        case "FIRE_LIT": return .complete
-        default: return .mission
-        }
     }
     
     // MARK: - Helpers

--- a/Kiero/Kiero/Presentation/Reward/RewardView.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardView.swift
@@ -59,19 +59,22 @@ struct RewardView: View {
                         .padding(.top, 8)
                     }
                 }
-                VStack {
+                
+                VStack(spacing: 0) {
                     Spacer()
-                    
-                    FloatingButtonWrapper(
-                        type: .schedule,
-                        action: {
-                            isShowingAddView = true
-                        }
-                    )
-                    .frame(width: 53, height: 53)
-                    .padding(.bottom, 100)
-                    .padding(.leading, 291)
+                    HStack(spacing: 0) {
+                        Spacer()
+                        FloatingButtonWrapper(
+                            type: .schedule,
+                            action: {
+                                isShowingAddView = true
+                            }
+                        )
+                        .frame(width: 53, height: 53)
+                        .offset(x: -41, y: -124)
+                    }
                 }
+                .ignoresSafeArea()
                 
                 if viewModel.showDeleteDialog, let reward = viewModel.selectedReward {
                     Color.kBlack.opacity(0.75)


### PR DESCRIPTION
## 📟 연결된 이슈
closed #221 
<br>

## 🍎 작업 내용
메인 기능
- 알림 피드 조회 http method를 get -> patch 로 수정하였습니다. 
- 소원의 우물 http method를 patch -> post로 변경했습니다. 
- 알림 피드의 sse 조회 enum을 FEED_ITEM_CREATED로 변경했습니다. 
- 보상 뷰의 floating 버튼 위치를 수정했습니다. 
<br>

## 💬 리뷰 코멘트
UIKIt이랑 SwiftUI의 레이아웃방식이 다른지 플로팅 버튼 위치 수정을 제가 숫자 하나하나 바꿔가며 맞췄습니다.....
더 좋은 방법있으면 코멘트 부탁드립니다. 
