### PR TITLE
[refactor] #225 자체 QA 리팩토링

### DIFF
--- a/Kiero/Kiero/Network/Schedule/Schedule/ScheduleDTO.swift
+++ b/Kiero/Kiero/Network/Schedule/Schedule/ScheduleDTO.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 struct ScheduleResponseDTO: Decodable {
     let isFireLit: Bool
@@ -49,6 +50,7 @@ extension ScheduleResponseDTO {
         return items.map {
             let isRecurring = !$0.dayOfWeek.isEmpty
             let dayOfWeekString = $0.dayOfWeek.map { koreanDay($0) }.joined(separator: ", ")
+            let scheduleColor = scheduleColorFromHex($0.colorCode)
             
             return Schedule(
                 id: $0.scheduleId,
@@ -56,13 +58,24 @@ extension ScheduleResponseDTO {
                 isRecurring: isRecurring,
                 startTime: $0.startTime,
                 endTime: $0.endTime,
-                scheduleColor: "SCHEDULE1",
+                scheduleColor: scheduleColor,
                 colorCode: $0.colorCode,
                 dayOfWeek: dayOfWeekString.isEmpty ? nil : dayOfWeekString,
                 date: $0.date,
                 scheduleStatus: $0.scheduleStatus
             )
         }
+    }
+    
+    private func scheduleColorFromHex(_ hex: String) -> String {
+        let mapping: [String: String] = [
+            UIColor.schedule1.toHexString(): "SCHEDULE1",
+            UIColor.schedule2.toHexString(): "SCHEDULE2",
+            UIColor.schedule3.toHexString(): "SCHEDULE3",
+            UIColor.schedule4.toHexString(): "SCHEDULE4",
+            UIColor.schedule5.toHexString(): "SCHEDULE5"
+        ]
+        return mapping[hex.uppercased()] ?? "SCHEDULE1"
     }
     
     private func koreanDay(_ day: String) -> String {

--- a/Kiero/Kiero/Presentation/Common/Components/DetailBottomSheet.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/DetailBottomSheet.swift
@@ -165,7 +165,10 @@ final class DetailBottomSheet: BaseBottomSheetViewController {
             
             var fullDateInfo = "\(formattedDate)\n\(time)"
             if isRecurring {
-                let recurringText = "매주 \(days ?? "") 반복"
+                let allDays = ["월", "화", "수", "목", "금", "토", "일"]
+                let selectedDays = (days ?? "").components(separatedBy: ", ")
+                let isEveryDay = allDays.allSatisfy { selectedDays.contains($0) }
+                let recurringText = isEveryDay ? "매일 반복" : "매주 \(days ?? "") 반복"
                 fullDateInfo += "\n\(recurringText)"
             }
             

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -92,7 +92,9 @@ final class DialogBox: UIView {
         return followingOption.isSelected
     }
     
-    // MARK: - UI Conponents
+    private weak var overlayVC: UIViewController?
+    
+    // MARK: - UI Components
     
     private let closeButton = UIButton().then {
         $0.setImage(UIImage(resource: .icClose), for: .normal)
@@ -118,7 +120,6 @@ final class DialogBox: UIView {
             
             config?.image = isSelected ? UIImage(resource: .btnCheck) : UIImage(resource: .btnUncheck)
             config?.baseForegroundColor = isSelected ? .main : .gray400
-            
             config?.background.backgroundColor = .clear
             button.configuration = config
         }
@@ -256,14 +257,37 @@ final class DialogBox: UIView {
         messageLabel.setContentHuggingPriority(.required, for: .vertical)
     }
     
-    // MARK: - Bind
-    
     private func bind() {
         closeButton.addTarget(self, action: #selector(didTapClose), for: .touchUpInside)
         cancelButton.addTarget(self, action: #selector(didTapCancel), for: .touchUpInside)
         confirmButton.addTarget(self, action: #selector(didTapConfirm), for: .touchUpInside)
         onlyThisOption.addTarget(self, action: #selector(didTapOption), for: .touchUpInside)
         followingOption.addTarget(self, action: #selector(didTapOption), for: .touchUpInside)
+    }
+    
+    // MARK: - Action
+    
+    func show(in viewController: UIViewController) {
+        let overlay = UIViewController()
+        overlay.view.backgroundColor = .kBlack.withAlphaComponent(0.75)
+        overlay.modalPresentationStyle = .overFullScreen
+        overlay.view.addSubview(self)
+        
+        self.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.width.equalTo(343)
+        }
+        
+        let tap = UITapGestureRecognizer(target: self, action: #selector(didTapDim(_:)))
+        overlay.view.addGestureRecognizer(tap)
+        
+        self.overlayVC = overlay
+        viewController.present(overlay, animated: false)
+    }
+    
+    func dismiss() {
+        overlayVC?.dismiss(animated: false)
+        overlayVC = nil
     }
     
     // MARK: - Configure
@@ -346,13 +370,28 @@ final class DialogBox: UIView {
     // MARK: - Actions
     
     @objc
-    private func didTapClose() { onTapClose?() }
+    private func didTapClose() {
+        onTapClose?()
+        dismiss()
+    }
     
     @objc
-    private func didTapCancel() { onTapCancel?() }
+    private func didTapCancel() {
+        onTapCancel?()
+        dismiss()
+    }
     
     @objc
     private func didTapConfirm() { onTapConfirm?() }
+    
+    @objc
+    private func didTapDim(_ gesture: UITapGestureRecognizer) {
+        let location = gesture.location(in: gesture.view)
+        if !self.frame.contains(location) {
+            onTapClose?()
+            dismiss()
+        }
+    }
     
     @objc
     private func didTapOption(_ sender: UIButton) {

--- a/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewController.swift
+++ b/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewController.swift
@@ -122,19 +122,36 @@ final class AIMissionViewController: BaseViewController<AIMissionViewModel> {
         missionResultView.pagingHeader.onLeftButtonTapped = { [weak self] in
             self?.saveCurrentState()
             self?.currentIndex -= 1
-            self?.displayMission(at: self?.currentIndex ?? 0)
+            self?.displayMission(at: self?.currentIndex ?? 0, direction: .right)
         }
-        
+
         missionResultView.pagingHeader.onRightButtonTapped = { [weak self] in
             guard let self = self else { return }
             self.saveCurrentState()
             self.currentIndex += 1
-            
             if self.currentIndex == self.suggestedMissions.count - 1 {
                 self.isAllMissionsViewed = true
             }
-            
-            self.displayMission(at: self.currentIndex)
+            self.displayMission(at: self.currentIndex, direction: .left)
+        }
+        
+        missionResultView.onSwipeLeft = { [weak self] in
+            guard let self = self else { return }
+            guard self.currentIndex < self.suggestedMissions.count - 1 else { return }
+            self.saveCurrentState()
+            self.currentIndex += 1
+            if self.currentIndex == self.suggestedMissions.count - 1 {
+                self.isAllMissionsViewed = true
+            }
+            self.displayMission(at: self.currentIndex, direction: .left)
+        }
+
+        missionResultView.onSwipeRight = { [weak self] in
+            guard let self = self else { return }
+            guard self.currentIndex > 0 else { return }
+            self.saveCurrentState()
+            self.currentIndex -= 1
+            self.displayMission(at: self.currentIndex, direction: .right)
         }
     }
     
@@ -238,7 +255,7 @@ final class AIMissionViewController: BaseViewController<AIMissionViewModel> {
         viewModel?.createBulkMissions(missions: finalMissions)
     }
     
-    private func displayMission(at index: Int) {
+    private func displayMission(at index: Int, direction: UISwipeGestureRecognizer.Direction? = nil) {
         let total = suggestedMissions.count
         let mission = suggestedMissions[index]
         
@@ -259,6 +276,18 @@ final class AIMissionViewController: BaseViewController<AIMissionViewModel> {
         }
         
         missionResultView.deadlineView.dateLabel.text = currentSelectedDate.toFullDateString
+        
+        guard let direction else { return }
+        let contentContainer = missionResultView.contentContainer
+        let offset: CGFloat = direction == .left ? 60 : -60
+        
+        contentContainer.transform = CGAffineTransform(translationX: offset, y: 0)
+        contentContainer.alpha = 0
+        
+        UIView.animate(withDuration: 0.25, delay: 0, options: .curveEaseOut) {
+            contentContainer.transform = .identity
+            contentContainer.alpha = 1
+        }
     }
     
     private func updateButtonState(text: String) {

--- a/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewModel.swift
+++ b/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewModel.swift
@@ -56,7 +56,13 @@ final class AIMissionViewModel: BaseViewModel {
         service.postBulkMissions(childId: childId, missions: items)
             .sink { [weak self] completion in
                 self?.isLoading.send(false)
-            } receiveValue: { [weak self] _ in
+            } receiveValue: { [weak self] response in
+                let sortedAiIds = response.sorted { $0.name < $1.name }.reversed().map { $0.id }
+                
+                var recentActivity = UserDefaults.standard.array(forKey: "recentActivityIds") as? [Int] ?? []
+                recentActivity.append(contentsOf: sortedAiIds)
+                UserDefaults.standard.set(recentActivity, forKey: "recentActivityIds")
+                
                 self?.bulkCreateSuccess.send(())
             }
             .store(in: &cancellables)

--- a/Kiero/Kiero/Presentation/Mission/AIMission/View/AIMissionResultView.swift
+++ b/Kiero/Kiero/Presentation/Mission/AIMission/View/AIMissionResultView.swift
@@ -15,6 +15,8 @@ final class AIMissionResultView: BaseUIView {
     // MARK: - Propertie
     
     var onDeadlineViewTapped: (() -> Void)?
+    var onSwipeLeft: (() -> Void)?
+    var onSwipeRight: (() -> Void)?
     
     var selectedReward: Int {
         return rewardView.selectedReward
@@ -24,7 +26,7 @@ final class AIMissionResultView: BaseUIView {
     
     let pagingHeader = PagingHeader()
     
-    private let contentContainer = UIView().then {
+    private(set) var contentContainer = UIView().then {
         $0.backgroundColor = .gray900
         $0.layer.cornerRadius = 15
     }
@@ -103,6 +105,23 @@ final class AIMissionResultView: BaseUIView {
         
         let backgroundTap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         self.addGestureRecognizer(backgroundTap)
+        let swipeLeft = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipeLeft))
+        swipeLeft.direction = .left
+        self.addGestureRecognizer(swipeLeft)
+        
+        let swipeRight = UISwipeGestureRecognizer(target: self, action: #selector(handleSwipeRight))
+        swipeRight.direction = .right
+        self.addGestureRecognizer(swipeRight)
+    }
+
+    @objc
+    private func handleSwipeLeft() {
+        onSwipeLeft?()
+    }
+
+    @objc
+    private func handleSwipeRight() {
+        onSwipeRight?()
     }
     
     @objc

--- a/Kiero/Kiero/Presentation/Mission/BottomSheet/CalendarCell.swift
+++ b/Kiero/Kiero/Presentation/Mission/BottomSheet/CalendarCell.swift
@@ -48,7 +48,7 @@ final class CalendarCell: UICollectionViewCell {
         }
         
         dateLabel.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.center.equalToSuperview()
         }
     }
     

--- a/Kiero/Kiero/Presentation/Mission/Mission/MissionViewController.swift
+++ b/Kiero/Kiero/Presentation/Mission/Mission/MissionViewController.swift
@@ -23,7 +23,6 @@ final class MissionViewController: BaseViewController<MissionViewModel> {
     
     private let emptyView = EmptyView(text: "등록된 미션이 없어요.\n우측 하단 버튼을 눌러 미션을 추가해보세요!")
     private let missionView = MissionView()
-    
     private let floatingButton = FloatingButton(type: .mission)
     
     // MARK: - Life Cycle
@@ -115,7 +114,6 @@ final class MissionViewController: BaseViewController<MissionViewModel> {
             guard let editVC = self.diContainer.makeWriteMissionViewController() as? WriteMissionViewController else {
                 return
             }
-
             editVC.configureEditMode(with: mission, dueAt: dueAt)
             editVC.hidesBottomBarWhenPushed = true
             self.navigationController?.pushViewController(editVC, animated: true)
@@ -127,26 +125,23 @@ final class MissionViewController: BaseViewController<MissionViewModel> {
                 let dialog = DialogBox()
                 dialog.configure(state: .deleteMission(title: mission.name, coin: "\(mission.reward)"))
                 
-                dialog.onTapCancel = { [weak self] in self?.dismiss(animated: false) }
-                dialog.onTapClose = { [weak self] in self?.dismiss(animated: false) }
-                
+                dialog.onTapClose = { [weak self] in
+                    guard let self = self else { return }
+                    dialog.dismiss()
+                    self.present(bottomSheet, animated: false)
+                }
+                dialog.onTapCancel = { [weak self] in
+                    guard let self = self else { return }
+                    dialog.dismiss()
+                    self.present(bottomSheet, animated: false)
+                }
                 dialog.onTapConfirm = { [weak self] in
                     guard let self = self else { return }
-                    self.dismiss(animated: false)
+                    dialog.dismiss()
                     self.viewModel?.deleteMission(id: mission.id)
                 }
                 
-                let overlay = UIViewController()
-                overlay.view.backgroundColor = .kBlack.withAlphaComponent(0.75)
-                overlay.modalPresentationStyle = .overFullScreen
-                overlay.view.addSubview(dialog)
-                
-                dialog.snp.makeConstraints {
-                    $0.center.equalToSuperview()
-                    $0.width.equalTo(343)
-                }
-                
-                self.present(overlay, animated: false)
+                dialog.show(in: self)
             }
         }
         

--- a/Kiero/Kiero/Presentation/Mission/Mission/MissionViewController.swift
+++ b/Kiero/Kiero/Presentation/Mission/Mission/MissionViewController.swift
@@ -108,7 +108,7 @@ final class MissionViewController: BaseViewController<MissionViewModel> {
             )
         )
         
-        let bottomSheet = DetailBottomSheet(data: detailData)
+        let bottomSheet = DetailBottomSheet(data: detailData, showEditDelete: !mission.isCompleted)
         
         bottomSheet.onEditTap = { [weak self] in
             guard let self = self else { return }

--- a/Kiero/Kiero/Presentation/Mission/Mission/MissionViewModel.swift
+++ b/Kiero/Kiero/Presentation/Mission/Mission/MissionViewModel.swift
@@ -30,23 +30,30 @@ final class MissionViewModel: BaseViewModel {
             } receiveValue: { [weak self] response in
                 guard let self = self else { return }
                 
-                let sortedGroups = response.missionsByDate.sorted { $0.dueAt < $1.dueAt }
-                
-                let finalGroups = sortedGroups.map { group -> MissionGroupDTO in
-                    let sortedMissions = group.missions.sorted { (m1, m2) -> Bool in
-                        if m1.id != m2.id {
-                            return m1.id < m2.id
-                        }
-                        
-                        return m1.name < m2.name
-                    }
-                    
-                    return MissionGroupDTO(
-                        dueAt: group.dueAt,
-                        dayOfWeek: group.dayOfWeek,
-                        missions: sortedMissions
-                    )
+                let recentActivityIds = UserDefaults.standard.array(forKey: "recentActivityIds") as? [Int] ?? []
+
+                var activityOrderMap: [Int: Int] = [:]
+                var order = 0
+                for id in recentActivityIds {
+                    activityOrderMap[id] = order
+                    order += 1
                 }
+
+                let finalGroups = response.missionsByDate
+                    .sorted { $0.dueAt < $1.dueAt }
+                    .map { group -> MissionGroupDTO in
+                        let sortedMissions = group.missions.sorted { m1, m2 in
+                            let o1 = activityOrderMap[m1.id]
+                            let o2 = activityOrderMap[m2.id]
+
+                            guard o1 != nil || o2 != nil else { return m1.id > m2.id }
+                            if o1 == nil { return false }
+                            if o2 == nil { return true }
+
+                            return o1! > o2!
+                        }
+                        return MissionGroupDTO(dueAt: group.dueAt, dayOfWeek: group.dayOfWeek, missions: sortedMissions)
+                    }
                 
                 self.missionGroups = finalGroups
             }

--- a/Kiero/Kiero/Presentation/Mission/WriteMission/WriteMissionViewModel.swift
+++ b/Kiero/Kiero/Presentation/Mission/WriteMission/WriteMissionViewModel.swift
@@ -33,6 +33,11 @@ final class WriteMissionViewModel: BaseViewModel {
                     self?.errorMessage.send("미션 등록에 실패했어요. 잠시 후 다시 시도해주세요.")
                 }
             } receiveValue: { [weak self] response in
+                print("🔍 새로 추가된 미션 id: \(response.id)")
+                var recentActivity = UserDefaults.standard.array(forKey: "recentActivityIds") as? [Int] ?? []
+                recentActivity.append(response.id)
+                UserDefaults.standard.set(recentActivity, forKey: "recentActivityIds")
+                
                 let newMission = Mission(name: response.name, reward: response.reward, dueAt: response.dueAt)
                 self?.isMissionAddSuccess.send(newMission)
             }
@@ -49,6 +54,11 @@ final class WriteMissionViewModel: BaseViewModel {
                     self?.errorMessage.send("미션 수정에 실패했어요. 잠시 후 다시 시도해주세요.")
                 }
             }, receiveValue: { [weak self] _ in
+                var recentActivity = UserDefaults.standard.array(forKey: "recentActivityIds") as? [Int] ?? []
+                recentActivity.removeAll { $0 == id }
+                recentActivity.append(id)
+                UserDefaults.standard.set(recentActivity, forKey: "recentActivityIds")
+                
                 self?.isMissionUpdateSuccess.send(())
             })
             .store(in: &cancellables)

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -259,7 +259,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 let isTodayTimePast = isTodaySelected && (startMin < currentTimeMin)
                 
                 if isCurrentWeek && (hasPastDayInWeek || isTodayTimePast) {
-                    Toast.show(message: "일정이 등록되었어요. (오늘 일정은 마감되어 다음 주부터 적용돼요!)")
+                    Toast.show(message: "일정이 등록되었어요. 오늘은 마감되어 다음부터 적용돼요.")
                 } else {
                     Toast.show(message: "일정이 등록되었어요.")
                 }

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -367,6 +367,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         timeSelectionView.endTimeTapAction = { [weak self] in self?.presentTimePicker(isStart: false) }
         titleTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         colorArrowButton.addTarget(self, action: #selector(didTapColorPicker), for: .touchUpInside)
+        repeatSwitch.addTarget(self, action: #selector(repeatSwitchChanged), for: .valueChanged)
     }
     
     func configure(with schedule: Schedule) {
@@ -559,6 +560,13 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
     }
     
     @objc
+    private func repeatSwitchChanged() {
+        if repeatSwitch.isOn {
+            weekdaySelectionView.isSingleSelectionMode = false
+        }
+    }
+    
+    @objc
     private func textFieldDidChange(_ textField: UITextField) {
         guard let text = textField.text else { return }
         
@@ -605,7 +613,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             weekdaySelectionView.setSelectedIndices(indices)
             updatePagingTitle()
         } else if let dateStr = schedule.date {
-            weekdaySelectionView.isSingleSelectionMode = true
+            weekdaySelectionView.isSingleSelectionMode = false
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy-MM-dd"
             
@@ -755,8 +763,4 @@ extension AddScheduleViewController: UITextFieldDelegate {
         textField.resignFirstResponder()
         return true
     }
-}
-
-#Preview {
-    AppDIContainer.shared.makeAddScheduleViewController()
 }

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -28,6 +28,16 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
     var editingSchedule: Schedule?
     var onEditConfirmed: ((EditScheduleRequestDTO, Bool, @escaping (Bool) -> Void) -> Void)?
     
+    private let colorReverseMapping: [String: UIColor] = [
+        "SCHEDULE1": .schedule1, "SCHEDULE2": .schedule2,
+        "SCHEDULE3": .schedule3, "SCHEDULE4": .schedule4, "SCHEDULE5": .schedule5
+    ]
+
+    private let colorMapping: [UIColor: String] = [
+        .schedule1: "SCHEDULE1", .schedule2: "SCHEDULE2",
+        .schedule3: "SCHEDULE3", .schedule4: "SCHEDULE4", .schedule5: "SCHEDULE5"
+    ]
+    
     // MARK: - UI Components
     
     private let navigationBar = NavigationBar(type: .closeDone(title: "일정 추가"))
@@ -132,7 +142,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
     }
     
     override func setLayout() {
-        navigationBar.snp.makeConstraints{
+        navigationBar.snp.makeConstraints {
             $0.top.equalToSuperview().offset(57)
             $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(32)
@@ -315,12 +325,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             
             self.navigationBar.isRightButtonEnabled = false
             
-            let colorMapping: [UIColor: String] = [
-                .schedule1: "SCHEDULE1", .schedule2: "SCHEDULE2",
-                .schedule3: "SCHEDULE3", .schedule4: "SCHEDULE4", .schedule5: "SCHEDULE5"
-            ]
-            let colorCode = colorMapping[self.currentSelectedColor ?? .schedule1] ?? "SCHEDULE1"
-            
+            let colorCode = self.colorMapping[self.currentSelectedColor ?? .schedule1] ?? "SCHEDULE1"
             let startTimeStr = start.toString(format: "HH:mm:ss")
             let endTimeStr = end.toString(format: "HH:mm:ss")
             
@@ -389,13 +394,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 let isRecurring = self.repeatSwitch.isOn
                 let startTime = self.currentStartTime?.toString(format: "HH:mm:ss") ?? ""
                 let endTime = self.currentEndTime?.toString(format: "HH:mm:ss") ?? ""
-                
-                let colorMapping: [UIColor: String] = [
-                    .schedule1: "SCHEDULE1", .schedule2: "SCHEDULE2",
-                    .schedule3: "SCHEDULE3", .schedule4: "SCHEDULE4", .schedule5: "SCHEDULE5"
-                ]
-                let colorName = colorMapping[self.currentSelectedColor ?? .schedule1] ?? "SCHEDULE1"
-                
+                let colorName = self.colorMapping[self.currentSelectedColor ?? .schedule1] ?? "SCHEDULE1"
                 let hexCode = self.currentSelectedColor?.toHexString() ?? "#FF5C5C"
                 
                 let selectedIndices = self.weekdaySelectionView.selectedIndices.sorted()
@@ -633,7 +632,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             timeSelectionView.updateTime(isStart: false, time: display.string(from: end))
         }
         
-        let color = UIColor(hex: schedule.colorCode)
+        let color = colorReverseMapping[schedule.scheduleColor] ?? UIColor(hex: schedule.colorCode)
         currentSelectedColor = color
         selectedColorChip.isHidden = false
         selectedColorChip.configure(with: color, isSelected: false)
@@ -642,10 +641,6 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
     private func handleEditConfirm() {
         guard let schedule = editingSchedule else { return }
         
-        let colorMapping: [UIColor: String] = [
-            .schedule1: "SCHEDULE1", .schedule2: "SCHEDULE2",
-            .schedule3: "SCHEDULE3", .schedule4: "SCHEDULE4", .schedule5: "SCHEDULE5"
-        ]
         let colorCode = colorMapping[currentSelectedColor ?? .schedule1] ?? "SCHEDULE1"
         let startTimeStr = (currentStartTime ?? Date()).toString(format: "HH:mm:ss")
         let endTimeStr = (currentEndTime ?? Date()).toString(format: "HH:mm:ss")
@@ -703,19 +698,30 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 }
             }
             
-            let overlay = UIViewController()
-            overlay.view.backgroundColor = .kBlack.withAlphaComponent(0.75)
-            overlay.modalPresentationStyle = .overFullScreen
-            overlay.view.addSubview(dialog)
-            
-            dialog.snp.makeConstraints {
-                $0.center.equalToSuperview()
-                $0.width.equalTo(343)
-            }
-            
-            self.present(overlay, animated: false)
+            dialog.show(in: self)
             
         } else {
+            if !isRecurring {
+                let calendar = Calendar.current
+                let today = calendar.startOfDay(for: Date())
+                let now = Date()
+                let currentTimeMin = calendar.component(.hour, from: now) * 60 + calendar.component(.minute, from: now)
+                let startMin = calendar.component(.hour, from: currentStartTime ?? now) * 60 + calendar.component(.minute, from: currentStartTime ?? now)
+                
+                let hasPastDate = selectedIndices.contains { index in
+                    let date = weekDates[index]
+                    let dateStart = calendar.startOfDay(for: date)
+                    if dateStart < today { return true }
+                    if dateStart == today && startMin < currentTimeMin { return true }
+                    return false
+                }
+                
+                if hasPastDate {
+                    Toast.show(message: "과거 날짜에는 일정을 등록할 수 없습니다.")
+                    return
+                }
+            }
+            
             let finalRequest = EditScheduleRequestDTO(
                 name: self.titleTextField.text ?? "",
                 isRecurring: isRecurring,

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -205,9 +205,8 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         }
     }
     
-    func configure(with schedule: Schedule) {
-        isEditMode = true
-        editingSchedule = schedule
+    override func setDelegate() {
+        titleTextField.delegate = self
     }
     
     override func addTarget() {
@@ -368,6 +367,11 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         timeSelectionView.endTimeTapAction = { [weak self] in self?.presentTimePicker(isStart: false) }
         titleTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         colorArrowButton.addTarget(self, action: #selector(didTapColorPicker), for: .touchUpInside)
+    }
+    
+    func configure(with schedule: Schedule) {
+        isEditMode = true
+        editingSchedule = schedule
     }
     
     private func convertTimeToMinutes(_ timeString: String) -> Int {

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleView.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleView.swift
@@ -44,13 +44,12 @@ final class ScheduleView: BaseUIView {
         
         UIView.performWithoutAnimation {
             timeTableView.clearSchedules()
+            timeTableView.setNeedsLayout()
+            timeTableView.layoutIfNeeded()
             
             schedules.forEach { schedule in
                 timeTableView.addSchedule(schedule: schedule)
             }
-            
-            self.timeTableView.setNeedsLayout()
-            self.timeTableView.layoutIfNeeded()
         }
         
         timeTableView.updateEmptyState(isEmpty: schedules.isEmpty)

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/TimeTableViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/TimeTableViewController.swift
@@ -199,21 +199,22 @@ final class TimeTableViewController: BaseViewController<ScheduleViewModel> {
                 let dialog = DialogBox()
                 dialog.configure(state: .deleteSchedule(title: schedule.name, isRecurring: schedule.isRecurring))
                 
-                dialog.onTapCancel = { [weak self] in
-                    self?.dismiss(animated: false)
-                }
-                
                 dialog.onTapClose = { [weak self] in
-                    self?.dismiss(animated: false)
+                    guard let self else { return }
+                    dialog.dismiss()
+                    self.present(bottomSheet, animated: false)
                 }
-                
+                dialog.onTapCancel = { [weak self] in
+                    guard let self else { return }
+                    dialog.dismiss()
+                    self.present(bottomSheet, animated: false)
+                }
                 dialog.onTapConfirm = { [weak self] in
                     guard let self else { return }
-                    self.dismiss(animated: false)
+                    dialog.dismiss()
                     
                     guard let selectedDate = schedule.date else { return }
                     let isIncludeFollowing: Bool = schedule.isRecurring ? dialog.isFollowingSelected : false
-                    
                     self.viewModel?.deleteSchedule(
                         scheduleId: schedule.id,
                         selectedDate: selectedDate,
@@ -221,17 +222,7 @@ final class TimeTableViewController: BaseViewController<ScheduleViewModel> {
                     )
                 }
                 
-                let overlay = UIViewController()
-                overlay.view.backgroundColor = .kBlack.withAlphaComponent(0.75)
-                overlay.modalPresentationStyle = .overFullScreen
-                overlay.view.addSubview(dialog)
-                
-                dialog.snp.makeConstraints {
-                    $0.center.equalToSuperview()
-                    $0.width.equalTo(343)
-                }
-                
-                self.present(overlay, animated: false)
+                dialog.show(in: self)
             }
         }
         

--- a/Kiero/Kiero/Presentation/Schedule/WeeklyTimeTable/WeeklyTimeTableView.swift
+++ b/Kiero/Kiero/Presentation/Schedule/WeeklyTimeTable/WeeklyTimeTableView.swift
@@ -17,6 +17,7 @@ final class WeeklyTimeTableView: BaseUIView {
     private let hourHeight: CGFloat = 40
     private let startHour = 8
     private let endHour = 21
+    private let spacing: CGFloat = 3
     
     private var daysDates: [Date] = []
     var onScheduleTap: ((Schedule) -> Void)?
@@ -103,7 +104,7 @@ final class WeeklyTimeTableView: BaseUIView {
         gridContainer.snp.makeConstraints {
             $0.edges.equalTo(scrollView.contentLayoutGuide)
             $0.width.equalTo(scrollView.frameLayoutGuide)
-            $0.height.equalTo(totalGridHeight+10)
+            $0.height.equalTo(totalGridHeight + 10)
         }
         
         gridBackgroundView.snp.makeConstraints {
@@ -236,8 +237,8 @@ final class WeeklyTimeTableView: BaseUIView {
         let cardHeight = CGFloat(duration) * hourHeight
         let actualColor = UIColor(hex: schedule.colorCode)
         
-        let cardWidth: CGFloat = 44
-        let spacing: CGFloat = 3
+        let totalWidth = cardContainerView.bounds.width
+        let cardWidth = (totalWidth - CGFloat(6) * spacing) / 7
         
         guard let dateString = schedule.date,
               let scheduleDate = dateString.toDate() else { return }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #225 
<br>

## 🍎 작업 내용
`일정`
- 일정 추가 토스트의 UX라이팅을 수정하였습니다.
- 일정 상세 바텀시트에서 '월-일'까지 표시되던 반복일정 라이팅을 '매일 반복'으로 수정하였습니다.
- 시간표 양 끝 여백이 동일하도록 레이아웃 계산 로직을 수정하였습니다.
- 중복되는 colorMapping 로직을 수정하고, 단일 일정 과거 날짜가 등록되지 않도록 조건문을 추가하였습니다.
- 단일 일정에서 중복일정으로 수정되는 로직을 QA 동작에 맞게 수행되도록 리팩토링하였습니다.

`미션`
- 알림장 미션에서 스와이프 제스처로 페이지 이동이 가능하도록 수정하였습니다.
- 완료된 미션 상세에서는 수정/삭제 버튼 미노출 되도록 수정하였습니다.
- 미션 리스트 정렬 로직을 우선순위에 맞춰 수정하였습니다. 
**1순위 마감일
2순위 최신 생성 
3순위 가나다(AI로 생성된 미션의 최초 추가시에만)**

`컴포넌트`
- calendarCell의 dateLabel을 가운데 정렬로 수정하였습니다.
- AddScheduleVC에 누락되어있던 setDelegate 메소드를 구현했습니다.
- DialogBox 내 dim 오버레이와 터치 해제 시 dismiss 되도록 메서드를 추가하였습니다.
기존에 각 VC에서 오버레이까지 따로 만들어서 사용하고 있었는데, 이를 중복해서 만들지 않고 컴포넌트 안에서 공통적으로 사용할 수 있도록 코드를 수정하였습니다. +) 본인 VC에서 오버레이로 dim 만들어서 사용한 게 있다면, 그 부분까지 삭제해주세요 !

사용법은 아래와 같습니다. show(in:) 호출하면 딤 배경 탭 시 자동으로 닫히도록 설정해두었습니다.
```
let dialog = DialogBox()
dialog.configure(state: .deleteMission(title: "우유 마시기", coin: "20"))
dialog.show(in: self)
```
<br>

## 📸 스크린샷
| 기능/화면 | 매일 반복 | 완료된 미션 |
|:---------:|:-------------:|:-------------:|
| 리팩토링 | <img src="https://github.com/user-attachments/assets/81a49ffa-7862-4b34-b6f2-4ff876d2b0a4" width="250"> | <img src="https://github.com/user-attachments/assets/2129003c-013f-4e65-9ae8-6ad5c266ded2" width="250"> |
<br>

## 💬 리뷰 코멘트
dim 관련해서 윤아가 해야할 리팩토링 작업이 있어서 빠르게 PR을 올립니다 !
일요일 토익 시험을 보고나서, 테플 올리기 전에 작업할 부분이 있어서 그 전까지 코드 pull 받아 사용하라고 올려둡니다.

[3/15 11:20] 남은 QA 리팩토링 작업까지 완료했습니다. 코리부탁드려요 ☺︎