### PR TITLE
[refactor] #227 1차 스프린트 오늘의 여정 자체 QA

### DIFF
--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyMap/DailyJourneyMapModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyMap/DailyJourneyMapModel.swift
@@ -36,7 +36,7 @@ struct DailyJourneyMapSchedule: Decodable, Identifiable {
     
     enum ScheduleStatus: String, Decodable {
         case PENDING
-        case COMPLETE
+        case COMPLETED
         case FAILED
         case SKIPPED
         case VERIFIED

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyMap/DailyJourneyMapState/DailyJourneyStoneRewardView.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyMap/DailyJourneyMapState/DailyJourneyStoneRewardView.swift
@@ -26,7 +26,7 @@ struct DailyJourneyStoneRewardView: View {
     
     private var ringColor: Color {
         switch status {
-        case "COMPLETE", "VERIFIED":
+        case "COMPLETED", "VERIFIED":
             return .main
         case "FAILED", "SKIPPED":
             return .point
@@ -34,25 +34,25 @@ struct DailyJourneyStoneRewardView: View {
             return .white
         }
     }
-    
+
     private var hasGlow: Bool {
-        status == "COMPLETE" || status == "VERIFIED" || status == "FAILED" || status == "SKIPPED"
+        status == "COMPLETED" || status == "VERIFIED" || status == "FAILED" || status == "SKIPPED"
     }
-    
+
     private var resultText: String? {
         switch status {
-        case "COMPLETE", "VERIFIED": 
+        case "COMPLETED", "VERIFIED":
             return "획득!"
-        case "FAILED", "SKIPPED":    
+        case "FAILED", "SKIPPED":
             return "실패!"
         default:
             return nil
         }
     }
-    
+
     private var resultColor: Color {
         switch status {
-        case "COMPLETE", "VERIFIED":
+        case "COMPLETED", "VERIFIED":
             return .main
         case "FAILED", "SKIPPED":
             return .point

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyMap/DailyJourneyMapViewController.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyMap/DailyJourneyMapViewController.swift
@@ -38,6 +38,7 @@ final class DailyJourneyMapViewController: BaseViewController<DailyJourneyMapVie
         let swiftUIView = DailyJourneyMapView(viewModel: viewModel)
         let hosting = UIHostingController(rootView: swiftUIView)
         hosting.view.backgroundColor = .clear
+        hosting.view.clipsToBounds = true
         
         addChild(hosting)
         view.addSubview(hosting.view)

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyMap/DailyJourneyMapViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyMap/DailyJourneyMapViewModel.swift
@@ -56,7 +56,8 @@ final class DailyJourneyMapViewModel: BaseViewModel, ViewModelType, ObservableOb
                 await MainActor.run {
                     SseStreamManager.shared.startIfNeeded(initialToken: token) { [weak self] payload in
                         guard payload.eventType == "SCHEDULE_STATUS_UPDATED"
-                           || payload.eventType == "SCHEDULE_MODIFIED" else { return }
+                                || payload.eventType == "SCHEDULE_MODIFIED"
+                                || payload.eventType == "DATE_CHANGED" else { return }
                         print("📩 [DailyJourneyMapVM] SSE Event: \(payload.eventType)")
                         self?.fetchJourneyList()
                     }

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -158,6 +158,9 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
             
             await MainActor.run {
                 SseStreamManager.shared.startIfNeeded(initialToken: validToken) { [weak self] payload in
+                    guard payload.eventType == "SCHEDULE_STATUS_UPDATED"
+                       || payload.eventType == "SCHEDULE_MODIFIED"
+                       || payload.eventType == "DATE_CHANGED" else { return }
                     print("📩 [DailyJourneyViewModel] SSE Event received: \(payload.eventType)")
                     self?.fetchDailyJourney()
                 }


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #227
<br>

## 🍎 작업 내용
- 완료 일정 `"COMPLETE"` → `"COMPLETED"` 문자열 불일치 수정
- `DailyJourneyMapViewModel`에 `DATE_CHANGED` 이벤트 처리 추가
- 오늘의 여정 SSE 이벤트 필터링 개선 (`SCHEDULE_STATUS_UPDATED`, `SCHEDULE_MODIFIED`, `DATE_CHANGED`만 처리)
- 오늘의 여정 지도 화면에서 오늘의 여정 메인으로 이동시 배경 겹침 현상 해결
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 화면2 |
|:---------:|:-------------:|:-------------:|
| 기능1 | <img src="" width="250"> | <img src="" width="250"> |
<br>

## 💬 리뷰 코멘트
자나깨나 오타 조심

그리고 오늘의 `여정 지도 화면에서 오늘의 여정 메인으로 이동시 배경 겹침 현상 해결` 이 이슈가 시뮬레이터에서는 없었고 실기기에서만 있었거덩요! 이유를 찾아보니까 맥과 아이폰의 GPU차이 때문이라고 합니다! 

```
💻 시뮬레이터                                                                                                            
  - Mac의 CPU/소프트웨어 기반 렌더러 사용                                                                               
  - 네비게이션 전환 시 view 스냅샷을 찍는데, 이 과정에서 암묵적으로 bounds 기준으로 클리핑됨                            
  - clipsToBounds = false여도 overflow 콘텐츠가 스냅샷에서 잘려나감                                                     

📱 실기기
  - Metal GPU 렌더링 사용
  - CALayer 트리를 GPU가 직접 렌더링하며, clipsToBounds = false인 경우 overflow 콘텐츠를 그대로 렌더링함
  - 네비게이션 전환 애니메이션 중 layer 이동 시에도 bounds 밖 콘텐츠가 그대로 따라오기 때문에 겹쳐 보임

즉, 시뮬레이터의 소프트웨어 렌더러가 실기기 Metal 렌더러보다 관대하게 클리핑을 처리해줘서 발견이 늦어진 케이스입니다.
실기기에서만 발생하는 렌더링 이슈들이 대부분 이런 원인입니다.
```