### PR TITLE
[refactor] #236 오늘의 여정 지도 날짜 레이블 미갱신 문제 해결

### DIFF
--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyMap/DailyJourneyMapViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyMap/DailyJourneyMapViewModel.swift
@@ -11,6 +11,12 @@ import UIKit
 final class DailyJourneyMapViewModel: BaseViewModel, ViewModelType, ObservableObject {
     
     @Published var scheduleData: DailyJourneyMapData?
+    @Published var todayDateText: String = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "M월 d일 EEEE"
+        return formatter.string(from: Date())
+    }()
     
     let confirmButtonTapSubject = PassthroughSubject<Void, Never>()
     
@@ -24,6 +30,7 @@ final class DailyJourneyMapViewModel: BaseViewModel, ViewModelType, ObservableOb
     }
     
     private let dismissSubject = PassthroughSubject<Void, Never>()
+    private var shouldUpdateDateOnNextFetch = false
     
     func transform(input: Input) -> Output {
         input.viewWillAppear
@@ -59,6 +66,9 @@ final class DailyJourneyMapViewModel: BaseViewModel, ViewModelType, ObservableOb
                                 || payload.eventType == "SCHEDULE_MODIFIED"
                                 || payload.eventType == "DATE_CHANGED" else { return }
                         print("📩 [DailyJourneyMapVM] SSE Event: \(payload.eventType)")
+                        if payload.eventType == "DATE_CHANGED" {
+                            self?.shouldUpdateDateOnNextFetch = true
+                        }
                         self?.fetchJourneyList()
                     }
                 }
@@ -83,15 +93,17 @@ final class DailyJourneyMapViewModel: BaseViewModel, ViewModelType, ObservableOb
                     print("❌ DailyJourneyMap fetch 에러: \(error)")
                 }
             } receiveValue: { [weak self] data in
-                self?.scheduleData = data
+                guard let self else { return }
+                if self.shouldUpdateDateOnNextFetch {
+                    self.shouldUpdateDateOnNextFetch = false
+                    let formatter = DateFormatter()
+                    formatter.locale = Locale(identifier: "ko_KR")
+                    formatter.dateFormat = "M월 d일 EEEE"
+                    self.todayDateText = formatter.string(from: Date())
+                }
+                self.scheduleData = data
             }
             .store(in: &cancellables)
     }
     
-    var todayDateText: String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "M월 d일 EEEE"
-        return formatter.string(from: Date())
-    }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #234 
<br>

## 🍎 작업 내용
- DATE_CHANGED SSE 이벤트 수신 시 일정 리스트는 갱신되지만 상단 날짜 레이블은 computed property로 구현되어 있어 업데이트되지 않는 문제
- todayDateText를 `@Published` 프로퍼티로 변환
- `shouldUpdateDateOnNextFetch` 플래그를 두어 DATE_CHANGED 이벤트 수신 시 마킹
- `fetchJourneyList()` 응답 도착 시점에 날짜 텍스트와 일정 데이터를 동시에 업데이트 → 날짜 레이블과 리스트가 같은 렌더 사이클에서 함께 갱신됨
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 화면2 |
|:---------:|:-------------:|:-------------:|
| 기능1 | <img src="" width="250"> | <img src="" width="250"> |
<br>

## 💬 리뷰 코멘트
자체 QA 끝내고~ 테플 배포하고~ 찐 QA까지 화이팅 하자~~