### PR TITLE
[hotfix] #241 자녀연결 chip 배경 radius 추가

### DIFF
--- a/Kiero/Kiero/Presentation/MyPage/MyPageView.swift
+++ b/Kiero/Kiero/Presentation/MyPage/MyPageView.swift
@@ -134,7 +134,7 @@ struct ConnectionChip: View {
             .foregroundStyle(count == 0 ? .main : .gray500 )
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
-            .background(.gray900)
+            .background(.gray900, in: Capsule())
             .overlay(Capsule().stroke(count == 0 ? .main : .gray500, lineWidth: 1))
     }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #241
<br>

## 🍎 작업 내용
자녀 연결 chip 배경이 캡슐 안으로 들어가도록 설정하였습니다. 
<br>

