### PR TITLE
[refactor] #244 1차 전체 QA 수정 반영

### DIFF
--- a/Kiero/Kiero/Network/Base/EndPoint.swift
+++ b/Kiero/Kiero/Network/Base/EndPoint.swift
@@ -66,6 +66,7 @@ enum EndPoint {
     
     //NotificationFeed
     case fetchFeeds(childId: Int64, size: Int?, cursor: String?)
+    case fetchUnreadFeed
     
     // CoinMission
     case completeMission(missionId: Int64)
@@ -165,6 +166,8 @@ enum EndPoint {
             if let cursor, !cursor.isEmpty { query.append("cursor=\(cursor)") }
             let queryString = query.isEmpty ? "" : "?\(query.joined(separator: "&"))"
             return "/api/v1/feeds/\(childId)\(queryString)"
+        case .fetchUnreadFeed:
+            return "/api/v1/feeds/unread"
         case .completeMission(let missionId):
             return "/api/v1/missions/\(missionId)/complete"
         case .deleteSchedule(let scheduleId, let selectedDate):
@@ -182,7 +185,7 @@ enum EndPoint {
     
     var method: String {
         switch self {
-        case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor, .fetchJourneyList, .fetchCoupons, .fetchTodayStatus:
+        case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor, .fetchJourneyList, .fetchCoupons, .fetchTodayStatus, .fetchUnreadFeed:
             return "GET"
         case .updateDailyJourney, .skipJourney, .completeSchedule, .fireLit, .completeMission, .editSchedule, .updateMission, .updateCoupon, .postImageRead, .fetchFeeds:
             return "PATCH"

--- a/Kiero/Kiero/Network/Base/EndPoint.swift
+++ b/Kiero/Kiero/Network/Base/EndPoint.swift
@@ -184,7 +184,7 @@ enum EndPoint {
         switch self {
         case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor, .fetchJourneyList, .fetchCoupons, .fetchTodayStatus:
             return "GET"
-        case .updateDailyJourney, .skipJourney, .completeSchedule, .purchaseCoupon, .fireLit, .completeMission, .editSchedule, .updateMission, .updateCoupon, .postImageRead, .fetchFeeds:
+        case .updateDailyJourney, .skipJourney, .completeSchedule, .fireLit, .completeMission, .editSchedule, .updateMission, .updateCoupon, .postImageRead, .fetchFeeds:
             return "PATCH"
         case .deleteChildDummy, .deleteSchedule, .deleteMission, .deleteCoupon:
             return "DELETE"

--- a/Kiero/Kiero/Network/Login/SseStreamManager.swift
+++ b/Kiero/Kiero/Network/Login/SseStreamManager.swift
@@ -85,15 +85,22 @@ final class SseStreamManager {
             return
         }
         isConnecting = true
-        
-        // 기존 연결 종료
+
         client?.disconnect()
-        
-        // 새 클라이언트 생성
+
         client = SseClient(
             url: sseURL,
-            tokenProvider: { [weak self] in self?.sseAccessToken },
-            onEvent: onEvent,
+            tokenProvider: { [weak self] in
+                return self?.sseAccessToken
+            },
+            onEvent: { payload in
+                NotificationCenter.default.post(
+                    name: .sseEventReceived,
+                    object: nil,
+                    userInfo: ["payload": payload]
+                )
+                onEvent(payload)
+            },
             onConnected: { [weak self] in
                 guard let self else { return }
                 print("✅ [SSEManager] onConnected -> onReconnected")
@@ -101,12 +108,11 @@ final class SseStreamManager {
                 self.isConnecting = false
             },
             onError: { [weak self] error in
-                // 필요 시 backoff 재연결
                 print("❌ [SSEClient] error:", error)
                 self?.isConnecting = false
             }
         )
-        
+
         client?.connect()
     }
     

--- a/Kiero/Kiero/Network/NotificationFeed/NotificationBadgeCenter.swift
+++ b/Kiero/Kiero/Network/NotificationFeed/NotificationBadgeCenter.swift
@@ -1,0 +1,25 @@
+//
+//  NotificationBadgeCenter.swift
+//  Kiero
+//
+//  Created by 정윤아 on 3/19/26.
+//
+
+import Combine
+import Foundation
+
+extension Notification.Name {
+    static let feedItemCreated = Notification.Name("feedItemCreated")
+    static let sseEventReceived = Notification.Name("sseEventReceived") 
+}
+
+final class NotificationBadgeCenter {
+    static let shared = NotificationBadgeCenter()
+    private init() {}
+
+    let hasUnreadSubject = CurrentValueSubject<Bool, Never>(false)
+
+    func setUnread(_ value: Bool) {
+        hasUnreadSubject.send(value)
+    }
+}

--- a/Kiero/Kiero/Network/NotificationFeed/NotificationFeedDTO.swift
+++ b/Kiero/Kiero/Network/NotificationFeed/NotificationFeedDTO.swift
@@ -32,6 +32,11 @@ struct FeedMetadataDTO: Decodable {
     let amount: Int?
 }
 
+struct UnreadNotificationDTO: Decodable {
+    let hasUnread: Bool
+    let unreadChildIds: [Int]
+}
+
 extension FeedResponseDTO {
     func toEntity() -> FeedPage {
         .init(

--- a/Kiero/Kiero/Network/NotificationFeed/NotificationFeedDTO.swift
+++ b/Kiero/Kiero/Network/NotificationFeed/NotificationFeedDTO.swift
@@ -1,5 +1,5 @@
 //
-//  NotificatioinFeedDTO.swift
+//  NotificationFeedDTO.swift
 //  Kiero
 //
 //  Created by 정윤아 on 1/21/26.

--- a/Kiero/Kiero/Network/NotificationFeed/NotificationFeedService.swift
+++ b/Kiero/Kiero/Network/NotificationFeed/NotificationFeedService.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol FeedServiceType {
     func fetchFeeds(childId: Int64, size: Int?, cursor: String?) -> AnyPublisher<FeedPage, NetworkError>
+    func fetchUnreadFeed() -> AnyPublisher<UnreadNotificationDTO, NetworkError>
 }
 
 final class FeedService: FeedServiceType {
@@ -21,6 +22,30 @@ final class FeedService: FeedServiceType {
                 do {
                     let dto: FeedResponseDTO = try await BaseService.shared.request(endPoint: endPoint)
                     promise(.success(dto.toEntity()))
+                } catch let error as NetworkError {
+                    promise(.failure(error))
+                } catch {
+                    promise(.failure(.unknownError))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    func fetchUnreadFeed() -> AnyPublisher<UnreadNotificationDTO, NetworkError> {
+        let endPoint = EndPoint.fetchUnreadFeed
+
+        return Future<UnreadNotificationDTO, NetworkError> { promise in
+            Task {
+                do {
+                    let response: BaseResponse<UnreadNotificationDTO> = try await BaseService.shared.request(endPoint: endPoint)
+
+                    guard let data = response.data else {
+                        promise(.failure(.unknownError))
+                        return
+                    }
+
+                    promise(.success(data))
                 } catch let error as NetworkError {
                     promise(.failure(error))
                 } catch {

--- a/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
+++ b/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 신혜연 on 1/9/26.
 //
 
+import Combine
 import UIKit
 
 import SnapKit
@@ -25,6 +26,12 @@ struct TabNavigationBarStyle {
 }
 
 public final class TabBarViewController: UITabBarController {
+    
+    private let feedService: FeedServiceType = FeedService()
+    private var cancellables = Set<AnyCancellable>()
+    private var hasUnreadNotification = false
+    private var globalSseStarted = false
+    private var isShowingNotificationFeed = false
     
     public override var selectedIndex: Int {
         didSet {
@@ -80,6 +87,13 @@ public final class TabBarViewController: UITabBarController {
         setCustomNavigationBarUI()
         setCustomTabBarUI()
         bindNotifications()
+        bindUnreadState()
+        bindSSEEvents()
+        
+        if isParent {
+            fetchInitialUnreadStatus()
+            startGlobalFeedSSEIfNeeded()
+        }
         updateNavigationBar()
     }
     
@@ -144,7 +158,7 @@ private extension TabBarViewController {
     
     func setCustomNavigationBarUI() {
         view.addSubview(customNavigationBar)
-         
+        
         customNavigationBar.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(13)
             $0.horizontalEdges.equalToSuperview()
@@ -250,6 +264,8 @@ private extension TabBarViewController {
     func handleNavigationBarRightTap() {
         let notificationVC = factory.makeNotificationFeedViewController()
         
+        NotificationBadgeCenter.shared.setUnread(false)
+        
         guard let nav = selectedViewController as? UINavigationController else { return }
         nav.pushViewController(notificationVC, animated: true)
     }
@@ -258,15 +274,15 @@ private extension TabBarViewController {
         if isParent {
             switch index {
             case 0:
-                return .init(title: nil, type: .main(title: nil), isNotificationActive: false)
+                return .init(title: nil, type: .main(title: nil), isNotificationActive: hasUnreadNotification)
             case 1:
-                return .init(title: "일정", type: .main(title: "일정"), isNotificationActive: false)
+                return .init(title: "일정", type: .main(title: "일정"), isNotificationActive: hasUnreadNotification)
             case 2:
-                return .init(title: "미션", type: .main(title: "미션"), isNotificationActive: false)
+                return .init(title: "미션", type: .main(title: "미션"), isNotificationActive: hasUnreadNotification)
             case 3:
-                return .init(title: "보상", type: .main(title: "보상"), isNotificationActive: false)
+                return .init(title: "보상", type: .main(title: "보상"), isNotificationActive: hasUnreadNotification)
             case 4:
-                return .init(title: "마이페이지", type: .main(title: "마이페이지"), isNotificationActive: false)
+                return .init(title: "마이페이지", type: .main(title: "마이페이지"), isNotificationActive: hasUnreadNotification)
             default:
                 return nil
             }
@@ -294,7 +310,7 @@ private extension TabBarViewController {
     @objc
     private func handleChromeAlpha(_ notification: Notification) {
         guard let isDimmed = notification.object as? Bool else { return }
-
+        
         UIView.animate(withDuration: 0.25) {
             self.customNavigationBar.alpha = isDimmed ? 0.25 : 1.0
             self.customTabBar.alpha = isDimmed ? 0.25 : 1.0
@@ -371,15 +387,93 @@ extension TabBarViewController: UINavigationControllerDelegate {
     ) {
         let shouldHideTabBar = viewController.hidesBottomBarWhenPushed
         let shouldHideNavigationBar = viewController is NotificationFeedViewController
-
+        
+        isShowingNotificationFeed = viewController is NotificationFeedViewController
+        
         customTabBar.isHidden = shouldHideTabBar
         customTabBar.isUserInteractionEnabled = !shouldHideTabBar
-
+        
         customNavigationBar.isHidden = shouldHideNavigationBar
         customNavigationBar.isUserInteractionEnabled = !shouldHideNavigationBar
-
+        
         if !shouldHideNavigationBar {
             updateNavigationBar()
         }
+    }
+}
+
+private extension TabBarViewController {
+    func bindUnreadState() {
+        NotificationBadgeCenter.shared.hasUnreadSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] hasUnread in
+                guard let self else { return }
+                self.hasUnreadNotification = hasUnread
+                self.customNavigationBar.isNotificationActive = hasUnread
+            }
+            .store(in: &cancellables)
+    }
+    
+    func fetchInitialUnreadStatus() {
+        feedService.fetchUnreadFeed()
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    print("✅ unread fetch finished")
+                case .failure(let error):
+                    print("❌ unread fetch failed:", String(reflecting: error))
+                    debugPrint(error)
+                }
+            } receiveValue: { status in
+                print("✅ unread status:", status.hasUnread)
+                NotificationBadgeCenter.shared.setUnread(status.hasUnread)
+            }
+            .store(in: &cancellables)
+    }
+    
+    func startGlobalFeedSSEIfNeeded() {
+        guard !globalSseStarted else { return }
+        globalSseStarted = true
+        
+        Task { [weak self] in
+            guard let self else { return }
+            
+            do {
+                let initialToken = try await TokenRefresher.shared.reissueSseAccessToken()
+                
+                await MainActor.run {
+                    SseStreamManager.shared.startIfNeeded(initialToken: initialToken) { payload in
+                        print("📡 raw SSE event:", payload.eventType)
+                    }
+                    print("✅ [TabBar] global SSE started")
+                }
+            } catch {
+                print("❌ [TabBar] SSE start failed:", error)
+                self.globalSseStarted = false
+            }
+        }
+    }
+    
+    func bindSSEEvents() {
+        NotificationCenter.default.publisher(for: .sseEventReceived)
+            .compactMap { $0.userInfo?["payload"] as? SseEventPayload }
+            .sink { [weak self] payload in
+                guard let self else { return }
+                print("📡 TabBar received SSE:", payload.eventType)
+                
+                guard payload.eventType == "FEED_ITEM_CREATED" else { return }
+                
+                NotificationCenter.default.post(
+                    name: .feedItemCreated,
+                    object: nil,
+                    userInfo: ["payload": payload]
+                )
+                
+                if !self.isShowingNotificationFeed {
+                    NotificationBadgeCenter.shared.setUnread(true)
+                }
+            }
+            .store(in: &cancellables)
     }
 }

--- a/Kiero/Kiero/Presentation/Common/Components/NotificationFeed/NotificationFeed.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/NotificationFeed/NotificationFeed.swift
@@ -120,7 +120,7 @@ final class NotificationFeed: UIView {
         }
         
         messageLabel.snp.makeConstraints {
-            $0.top.equalTo(timeLabel.snp.bottom).offset(4)
+            $0.top.equalTo(timeLabel.snp.bottom).offset(10)
             $0.leading.equalToSuperview().inset(13)
             $0.trailing.equalTo(downButton.snp.leading).offset(0)
         }

--- a/Kiero/Kiero/Presentation/Common/Components/RewardBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/RewardBox.swift
@@ -11,7 +11,7 @@ struct RewardBox: View {
     let reward: Reward
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .center, spacing: 8) {
             Text("\(reward.title)")
                 .font(Font(UIFont.body3_14_R))
                 .foregroundStyle(.white)
@@ -23,8 +23,8 @@ struct RewardBox: View {
             )
             .frame(width: 66, height: 24)
         }
-        .padding(.leading, 12)
-        .frame(width: 165, height: 119, alignment: .leading)
+        .padding(.vertical, 35)
+        .frame(maxWidth: .infinity)
         .background(.gray900)
         .cornerRadius(10)
     }

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyMap/DailyJourneyMapViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyMap/DailyJourneyMapViewModel.swift
@@ -44,7 +44,6 @@ final class DailyJourneyMapViewModel: BaseViewModel, ViewModelType, ObservableOb
         
         input.confirmButtonTap
             .sink { [weak self] in
-                self?.pauseSseConnection()
                 self?.dismissSubject.send()
             }
             .store(in: &cancellables)
@@ -76,11 +75,6 @@ final class DailyJourneyMapViewModel: BaseViewModel, ViewModelType, ObservableOb
                 print("❌ [DailyJourneyMapVM] SSE 토큰 발급 실패: \(error)")
             }
         }
-    }
-    
-    private func pauseSseConnection() {
-        print("⏸ [DailyJourneyMapVM] pauseSseConnection called")
-        SseStreamManager.shared.pause()
     }
     
     // MARK: - Network

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -52,10 +52,6 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
             }
             .store(in: &cancellables)
         
-        input.viewWillDisappear
-            .sink { [weak self] in self?.pauseSseConnection() }
-            .store(in: &cancellables)
-        
         input.nextJourneyButtonTap
             .sink { [weak self] in self?.routeSubject.send(.showNextJourneyDialogBox) }
             .store(in: &cancellables)
@@ -166,11 +162,6 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 }
             }
         }
-    }
-    
-    func pauseSseConnection() {
-        print("⏸ [DailyJourneyViewModel] pauseSseConnection called")
-        SseStreamManager.shared.pause()
     }
     
     // MARK: - Converter

--- a/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
+++ b/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
@@ -109,7 +109,6 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
             }
             .store(in: &cancellables)
         
-        // 무한 스크롤 처리
         input.loadMore
             .filter { [weak self] in
                 guard let self = self else { return false }

--- a/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
+++ b/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
@@ -30,7 +30,6 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
     private var canLoadMore: Bool { nextCursor != nil }
     private var cachedChildName: String = ""
     private var expandedKeys = Set<String>()
-    private var sseStarted = false
     
     init(
         feedService: FeedServiceType,
@@ -110,14 +109,6 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
             }
             .store(in: &cancellables)
         
-        idTrigger
-            .filter { $0 != 0 }
-            .sink { [weak self] _ in
-                guard let self else { return }
-                self.startSSEIfNeeded()
-            }
-            .store(in: &cancellables)
-        
         // 무한 스크롤 처리
         input.loadMore
             .filter { [weak self] in
@@ -154,10 +145,12 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
             }
             .store(in: &cancellables)
         
-        input.viewWillDisappear
-            .sink (receiveValue:{ [weak self] _ in
-                self?.stopSSE()
-            })
+        NotificationCenter.default.publisher(for: .feedItemCreated)
+            .compactMap { $0.userInfo?["payload"] as? SseEventPayload }
+            .sink { [weak self] payload in
+                print("✅ FeedVM received SSE:", payload.eventType)
+                self?.sseRefreshSubject.send(())
+            }
             .store(in: &cancellables)
         
         return Output(
@@ -165,47 +158,6 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
             isLoading: isLoadingSubject.eraseToAnyPublisher(),
             isLoadingMore: isLoadingMoreSubject.eraseToAnyPublisher()
         )
-    }
-    
-    // MARK: - SSE
-    
-    private func startSSEIfNeeded() {
-        guard !sseStarted else { return }
-        sseStarted = true
-        
-        Task { [weak self] in
-            guard let self else { return }
-            
-            do {
-                let initialToken = try await TokenRefresher.shared.reissueSseAccessToken()
-                
-                await MainActor.run { [weak self] in
-                    guard let self else { return }
-                    SseStreamManager.shared.startIfNeeded(initialToken: initialToken) { [weak self] payload in
-                        self?.handleSse(payload: payload)
-                    }
-                    print("✅ [FeedVM] SSE started")
-                }
-            } catch {
-                print("❌ [FeedVM] SSE initial token reissue failed:", error)
-                self.sseStarted = false
-            }
-        }
-    }
-    
-    private func stopSSE() {
-        SseStreamManager.shared.stop()
-        sseStarted = false
-    }
-    
-    private func handleSse(payload: SseEventPayload) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
-            
-            if payload.eventType == "FEED_ITEM_CREATED" {
-                self.sseRefreshSubject.send(())
-            }
-        }
     }
     
     private func makeDedupKey(

--- a/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
+++ b/Kiero/Kiero/Presentation/NotificationFeed/NotificationFeedViewModel.swift
@@ -224,11 +224,28 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
     
     // MARK: - Helpers
     
+    private func getWeekday(from dateString: String) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy.MM.dd"
+        
+        guard let date = formatter.date(from: dateString) else { return "" }
+        
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "E"
+        return formatter.string(from: date)
+    }
+    
     private func splitOccurredAt(_ occurredAt: String) -> (date: String, time: String) {
         if occurredAt.contains("T") {
             let parts = occurredAt.split(separator: "T", maxSplits: 1)
-            var date = parts.first.map(String.init) ?? occurredAt
-            date = date.replacingOccurrences(of: "-", with: ".")
+            let rawDateString = parts.first.map(String.init) ?? occurredAt
+            
+            let weekday = getWeekday(from: rawDateString)
+            
+            var date = rawDateString.replacingOccurrences(of: "-", with: ".")
+            if !weekday.isEmpty {
+                date = "\(date).(\(weekday))"
+            }
             
             let timePart = parts.count > 1 ? String(parts[1]) : ""
             let beforeDot = String(timePart.split(separator: ".", maxSplits: 1).first ?? Substring(timePart))
@@ -242,7 +259,17 @@ final class NotificationFeedViewModel: BaseViewModel, ViewModelType {
         }
         
         let parts = occurredAt.split(separator: " ")
-        if parts.count >= 2 { return (String(parts[0]), String(parts[1])) }
+        if parts.count >= 2 {
+            let rawDateString = String(parts[0])
+            let weekday = getWeekday(from: rawDateString)
+            
+            var date = rawDateString
+            if !weekday.isEmpty {
+                date = "\(date).(\(weekday))"
+            }
+            
+            return (date, String(parts[1]))
+        }
         
         return (occurredAt, "")
     }

--- a/Kiero/Kiero/Presentation/Reward/RewardEditView.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardEditView.swift
@@ -143,10 +143,10 @@ struct RewardEditView: View {
     private func validateCoinRange() {
         if coinCount > 500 {
             coinCount = 500
-            Toast.show(message: "최대 보상은 500개입니다")
+            Toast.show(message: "최대 보상은 500개입니다", bottomInset: 88)
         } else if coinCount < 1 {
             coinCount = 1
-            Toast.show(message: "보상을 입력해주세요.")
+            Toast.show(message: "보상을 입력해주세요.", bottomInset: 88)
         }
     }
     
@@ -155,28 +155,28 @@ struct RewardEditView: View {
         coinCount = newValue
         
         if coinCount < 1 {
-            Toast.show(message: "보상을 입력해주세요.")
+            Toast.show(message: "보상을 입력해주세요.", bottomInset: 88)
             coinCount = 1
             return
         }
         
         if coinCount > 500 {
-            Toast.show(message: "최대 보상은 500개입니다")
+            Toast.show(message: "최대 보상은 500개입니다", bottomInset: 88)
             coinCount = 500
         }
     }
     
     private func saveAction() {
         if rewardTitle.trimmingCharacters(in: .whitespaces).isEmpty {
-            Toast.show(message: "보상 이름을 입력해주세요.")
+            Toast.show(message: "보상 이름을 입력해주세요.", bottomInset: 88)
             return
         }
         
         switch mode {
         case .add:
-            Toast.show(message: "보상이 등록되었습니다.")
+            Toast.show(message: "보상이 등록되었습니다.", bottomInset: 88)
         case .edit(_):
-            Toast.show(message: "보상이 수정되었습니다.")
+            Toast.show(message: "보상이 수정되었습니다.", bottomInset: 88)
         }
         
         onSave(rewardTitle, coinCount)

--- a/Kiero/Kiero/Presentation/Reward/RewardHostingController.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardHostingController.swift
@@ -37,7 +37,7 @@ extension RewardHostingController: ScrollToTopAvailable {
     
     private func findScrollViewAndScrollToTop(in view: UIView) {
         if let scrollView = view as? UIScrollView {
-            scrollView.setContentOffset(.zero, animated: true)
+            scrollView.setContentOffset(CGPoint(x: 0, y: -66), animated: true)
             return
         }
         

--- a/Kiero/Kiero/Presentation/Reward/RewardViewModel.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardViewModel.swift
@@ -63,7 +63,7 @@ final class RewardViewModel: BaseViewModel, ObservableObject {
                     
                 case .failure(let error):
                     print(" 쿠폰 추가 API 실패: \(error)")
-                    Toast.show(message: "보상 추가에 실패했습니다.")
+                    Toast.show(message: "보상 추가에 실패했습니다.", bottomInset: 88)
                 }
             } receiveValue: { _ in }
             .store(in: &cancellables)
@@ -80,13 +80,13 @@ final class RewardViewModel: BaseViewModel, ObservableObject {
                         self?.rewards.remove(at: index)
                     }
                     
-                    Toast.show(message: "보상을 삭제했습니다.")
+                    Toast.show(message: "보상을 삭제했습니다.", bottomInset: 88)
                     self?.showDeleteDialog = false
                     self?.selectedReward = nil
                     
                 case .failure(let error):
                     print("쿠폰 삭제 API 실패: \(error)")
-                    Toast.show(message: "보상을 삭제에 실패했습니다.")
+                    Toast.show(message: "보상을 삭제에 실패했습니다.", bottomInset: 88)
                 }
             } receiveValue: { _  in }
             .store(in: &cancellables)

--- a/Kiero/Kiero/Presentation/TodayStatus/TodayStatusViewModel.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/TodayStatusViewModel.swift
@@ -126,7 +126,6 @@ final class TodayStatusViewModel: BaseViewModel, ObservableObject {
         refreshWorkItem?.cancel()
         refreshWorkItem = nil
         isSseBound = false
-        SseStreamManager.shared.pause()
     }
     
     private func shouldRefreshTodayStatus(for payload: SseEventPayload) -> Bool {


### PR DESCRIPTION
## 📟 연결된 이슈
closed #244
<br>

## 🍎 작업 내용
- 알림 피드 요일 추가
- 보상 탭 재 클릭시 grid 위치 수정
- 보상 뷰 박스 크기 수정 및 글씨 가운데 정렬
- 소원의 우물 sse 반영 안됨 이슈 해결
- 토스트 메세지 위치 변경
- red dot 활성화
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 화면2 |
|:---------:|:-------------:|:-------------:|
| 기능1 | ![Simulator Screen Recording - iPhone 12 - 2026-03-19 at 15 00 24](https://github.com/user-attachments/assets/98e2d960-30dc-406d-bcf4-7b751fa13152) | ![Simulator Screen Recording - iPhone 17 - 2026-03-19 at 15 00 20](https://github.com/user-attachments/assets/278378cc-9ecb-470a-8d4d-4704bbfe1d2c)|
<br>

## 💬 리뷰 코멘트
red dot 활성화하는게 생각보다 조금 많이 힘들었는데요....ㅠㅠㅠㅠ
지금 sse 연결이 각 페이지 마다 연결하고 끊는 형식이라 red dot 활성화를 위해서는 sse가 계속 연결되어있어야 하는데 끊기는 문제가 있었습니다. 따라서 pause를 통해 sse를 중지시키는 화면들은 해당 코드를 삭제하여 sse 연결이 일단 끊기지 않도록 해두었는데 아무래도 sse 연결에 대한 전체적인 리팩토링은 필요해 보입니다. 
현재 전역으로 notificationCenter를 두어 sse 연결을 알리도록 하였습니다. 이상한 점이나 수정해야할 부분이 있다면 알려주세요!

그리고 endpoint conflict이 머지할 때 많이 나는데 지워지지 않도록 주의 부탁드립니다.ㅠㅠ
