### PR TITLE
[hotfix] #252 보상 뷰 grid 위치 수정

### DIFF
--- a/Kiero/Kiero/Presentation/Reward/RewardHostingController.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardHostingController.swift
@@ -37,7 +37,7 @@ extension RewardHostingController: ScrollToTopAvailable {
     
     private func findScrollViewAndScrollToTop(in view: UIView) {
         if let scrollView = view as? UIScrollView {
-            scrollView.setContentOffset(CGPoint(x: 0, y: -66), animated: true)
+            scrollView.setContentOffset(CGPoint(x: 0, y: -61), animated: true)
             return
         }
         


### PR DESCRIPTION
## 📟 연결된 이슈
closed #252
<br>

## 🍎 작업 내용
- 보상 뷰 grid 탭바 재클릭시 위치 수정
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 기능1 | ![Simulator Screen Recording - iPhone 17 - 2026-03-21 at 15 03 29](https://github.com/user-attachments/assets/f689e72f-026d-489e-a912-4df03f580475) |
<br>

## 💬 리뷰 코멘트
없습니당
