### PR TITLE
[refactor] #262 부모 일정 2차 QA 반영

### DIFF
--- a/Kiero/Kiero/Application/AppDIContainer.swift
+++ b/Kiero/Kiero/Application/AppDIContainer.swift
@@ -83,15 +83,22 @@ extension AppDIContainer {
     }
     
     func makeAddScheduleViewController() -> UIViewController {
+        return makeAddScheduleViewController(isFireLit: false, scheduleList: [])
+    }
+    
+    func makeAddScheduleViewController(isFireLit: Bool, scheduleList: [Schedule]) -> AddScheduleViewController {
         let service = AddScheduleService()
         let selectedChildId = UserDefaults.standard.integer(forKey: "selectedChildId")
         
         let viewModel = AddScheduleViewModel(service: service, childId: selectedChildId)
+        viewModel.isFireLit = isFireLit
+        viewModel.scheduleList = scheduleList
+        
         return AddScheduleViewController(viewModel: viewModel, diContainer: self)
     }
     
     func makeEditScheduleViewController(schedule: Schedule) -> AddScheduleViewController {
-        let vc = makeAddScheduleViewController() as! AddScheduleViewController
+        let vc = makeAddScheduleViewController(isFireLit: false, scheduleList: [])
         vc.isEditMode = true
         vc.editingSchedule = schedule
         return vc

--- a/Kiero/Kiero/Presentation/Common/Components/DetailBottomSheet.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/DetailBottomSheet.swift
@@ -75,11 +75,6 @@ final class DetailBottomSheet: BaseBottomSheetViewController {
             self.updateData(data)
             self.editButton.isHidden = !showEditDelete
             self.deleteButton.isHidden = !showEditDelete
-            if !showEditDelete {
-                self.containerView.snp.updateConstraints {
-                    $0.height.equalTo(191)
-                }
-            }
         }
     }
     

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -317,8 +317,8 @@ final class DialogBox: UIView {
             if isRecurring {
                 optionStack.isHidden = false
                 optionStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
-                onlyThisOption.setConfigurationTypo(.body4_12_R, text: " 이번 일정만 포함")
-                followingOption.setConfigurationTypo(.body4_12_R, text: " 이후 일정 포함")
+                onlyThisOption.setConfigurationTypo(.body4_12_R, text: " 이번 주차만 포함")
+                followingOption.setConfigurationTypo(.body4_12_R, text: " 이후 주차 포함")
                 onlyThisOption.isSelected = true
                 followingOption.isSelected = false
                 optionStack.addArrangedSubviews(onlyThisOption, followingOption)

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -20,7 +20,6 @@ final class DialogBox: UIView {
         case wishWell(title: String, coin: String)
         case nextJourney
         case deleteSchedule(title: String, isRecurring: Bool)
-        case editSchedule(title: String, isRecurring: Bool)
         case deleteReward(title: String, coin: String)
         case deleteMission(title: String, coin: String)
         
@@ -34,7 +33,7 @@ final class DialogBox: UIView {
                 return title
             case .nextJourney:
                 return "다음 여정으로 갈거야?"
-            case .deleteSchedule(let title, _), .editSchedule(let title, _):
+            case .deleteSchedule(let title, _):
                 return title
             case .deleteReward(let title, _):
                 return title
@@ -55,8 +54,6 @@ final class DialogBox: UIView {
                 return "한번 다음 여정으로 넘어가면\n다시 지금 여정으로 돌아올 수 없어!"
             case .deleteSchedule, .deleteReward, .deleteMission:
                 return "삭제하시겠습니까?"
-            case .editSchedule:
-                return "저장하시겠습니까?"
             }
         }
         
@@ -317,22 +314,6 @@ final class DialogBox: UIView {
         
         switch state {
         case .deleteSchedule(_, let isRecurring):
-            if isRecurring {
-                optionStack.isHidden = false
-                optionStack.distribution = .equalSpacing
-                
-                let spacer = UIView()
-                followingOption.setConfigurationTypo(.body4_12_R, text: " 이후 반복되는 일정 포함")
-                followingOption.isSelected = true
-                
-                optionStack.addArrangedSubviews(spacer, followingOption)
-                contentStack.setCustomSpacing(12, after: messageLabel)
-            } else {
-                optionStack.isHidden = true
-                contentStack.setCustomSpacing(0, after: messageLabel)
-            }
-            
-        case .editSchedule(_, let isRecurring):
             if isRecurring {
                 optionStack.isHidden = false
                 optionStack.arrangedSubviews.forEach { $0.removeFromSuperview() }

--- a/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewController.swift
+++ b/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewController.swift
@@ -220,7 +220,7 @@ final class AIMissionViewController: BaseViewController<AIMissionViewModel> {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 guard let self = self else { return }
-                Toast.show(message: "미션이 등록되었어요.")
+                Toast.show(message: "미션이 등록되었어요.", bottomInset: 88)
                 
                 NotificationCenter.default.post(name: .hideTabBar, object: false)
                 NotificationCenter.default.post(name: .hideNavigationBar, object: false)

--- a/Kiero/Kiero/Presentation/Mission/Mission/MissionView.swift
+++ b/Kiero/Kiero/Presentation/Mission/Mission/MissionView.swift
@@ -29,8 +29,8 @@ final class MissionView: BaseUIView {
         $0.dataSource = self
         $0.delegate = self
         $0.sectionHeaderTopPadding = 0
-        $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 100, right: 0)
-        $0.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: 100, right: 0)
+        $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 172, right: 0)
+        $0.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: 172, right: 0)
         $0.contentInsetAdjustmentBehavior = .never
     }
     

--- a/Kiero/Kiero/Presentation/Mission/Mission/MissionViewController.swift
+++ b/Kiero/Kiero/Presentation/Mission/Mission/MissionViewController.swift
@@ -44,8 +44,7 @@ final class MissionViewController: BaseViewController<MissionViewModel> {
     
     override func setLayout() {
         emptyView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(62)
-            $0.horizontalEdges.bottom.equalToSuperview()
+            $0.center.equalToSuperview()
         }
         
         missionView.snp.makeConstraints {

--- a/Kiero/Kiero/Presentation/Mission/WriteMission/WriteMissionViewController.swift
+++ b/Kiero/Kiero/Presentation/Mission/WriteMission/WriteMissionViewController.swift
@@ -143,7 +143,7 @@ final class WriteMissionViewController: BaseViewController<WriteMissionViewModel
             .receive(on: DispatchQueue.main)
             .sink { [weak self] message in
                 self?.isRequesting = false
-                Toast.show(message: message)
+                Toast.show(message: message, bottomInset: 88)
             }
             .store(in: &cancellables)
     }

--- a/Kiero/Kiero/Presentation/Reward/RewardView.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardView.swift
@@ -51,6 +51,9 @@ struct RewardView: View {
                             }
                             .padding(.horizontal, 16)
                             .padding(.top, 66)
+                            
+                            Spacer()
+                                .frame(height: 153)
                         }
                     }
                 }

--- a/Kiero/Kiero/Presentation/Reward/RewardView.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardView.swift
@@ -49,14 +49,15 @@ struct RewardView: View {
                                         }
                                 }
                             }
-                            .padding(.horizontal, 16)
-                            .padding(.top, 66)
                             
                             Spacer()
                                 .frame(height: 153)
                         }
+                        .scrollIndicators(.hidden)
                     }
                 }
+                .padding(.horizontal, 16)
+                .padding(.top, 66)
                 
                 VStack(spacing: 0) {
                     Spacer()

--- a/Kiero/Kiero/Presentation/Reward/RewardView.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardView.swift
@@ -21,75 +21,74 @@ struct RewardView: View {
     ]
     
     var body: some View {
-            ZStack {
-                Color.kBlack.ignoresSafeArea()
-                
-                VStack(spacing: 0) {
-                    if viewModel.rewards.isEmpty {
-                        
-                        Spacer().frame(height: 45)
-                        
-                        EmptyViewWrapper(text: "등록된 보상이 없어요.\n우측 하단 버튼을 눌러 보상을 추가해보세요!")
-                        
-                        Spacer()
-                    } else {
-                        ScrollView {
-                            LazyVGrid(columns: columns, spacing: 13) {
-                                ForEach(viewModel.rewards) { reward in
-                                    RewardBox(reward: reward)
-                                        .onTapGesture {
-                                            showRewardBottomSheet(
-                                                reward: reward,
-                                                onEdit: { self.selectedReward = reward },
-                                                onDelete: {
-                                                    viewModel.selectedReward = reward
-                                                    viewModel.showDeleteDialog = true
-                                                }
-                                            )
-                                        }
-                                }
+        ZStack {
+            Color.kBlack.ignoresSafeArea()
+            
+            if viewModel.rewards.isEmpty {
+                EmptyViewWrapper(text: "등록된 보상이 없어요.\n우측 하단 버튼을 눌러 보상을 추가해보세요!")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .ignoresSafeArea()
+            }
+            
+            VStack(spacing: 0) {
+                if !viewModel.rewards.isEmpty {
+                    ScrollView {
+                        LazyVGrid(columns: columns, spacing: 13) {
+                            ForEach(viewModel.rewards) { reward in
+                                RewardBox(reward: reward)
+                                    .onTapGesture {
+                                        showRewardBottomSheet(
+                                            reward: reward,
+                                            onEdit: { self.selectedReward = reward },
+                                            onDelete: {
+                                                viewModel.selectedReward = reward
+                                                viewModel.showDeleteDialog = true
+                                            }
+                                        )
+                                    }
                             }
-                            
-                            Spacer()
-                                .frame(height: 153)
                         }
-                        .scrollIndicators(.hidden)
-                    }
-                }
-                .padding(.horizontal, 16)
-                .padding(.top, 66)
-                
-                VStack(spacing: 0) {
-                    Spacer()
-                    HStack(spacing: 0) {
+                        
                         Spacer()
-                        FloatingButtonWrapper(
-                            type: .schedule,
-                            action: {
-                                isShowingAddView = true
-                            }
-                        )
-                        .frame(width: 53, height: 53)
-                        .offset(x: -41, y: -124)
+                            .frame(height: 153)
                     }
+                    .scrollIndicators(.hidden)
                 }
-                .ignoresSafeArea()
-                
-                if viewModel.showDeleteDialog, let reward = viewModel.selectedReward {
-                    Color.kBlack.opacity(0.75)
-                        .ignoresSafeArea()
-                        .onTapGesture { viewModel.showDeleteDialog = false }
-                    
-                    DialogBoxWrapper(
-                        state: .deleteReward(title: reward.title, coin: "\(reward.cost)"),
-                        isPresented: $viewModel.showDeleteDialog,
-                        onConfirm: {
-                            viewModel.deleteReward(reward: reward)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 66)
+            
+            VStack(spacing: 0) {
+                Spacer()
+                HStack(spacing: 0) {
+                    Spacer()
+                    FloatingButtonWrapper(
+                        type: .schedule,
+                        action: {
+                            isShowingAddView = true
                         }
                     )
-                    .frame(width: 327, height: 216)
-                    .transition(.scale.combined(with: .opacity))
+                    .frame(width: 53, height: 53)
+                    .offset(x: -41, y: -124)
                 }
+            }
+            .ignoresSafeArea()
+            
+            if viewModel.showDeleteDialog, let reward = viewModel.selectedReward {
+                Color.kBlack.opacity(0.75)
+                    .ignoresSafeArea()
+                    .onTapGesture { viewModel.showDeleteDialog = false }
+                
+                DialogBoxWrapper(
+                    state: .deleteReward(title: reward.title, coin: "\(reward.cost)"),
+                    isPresented: $viewModel.showDeleteDialog,
+                    onConfirm: {
+                        viewModel.deleteReward(reward: reward)
+                    }
+                )
+                .frame(width: 327, height: 216)
+                .transition(.scale.combined(with: .opacity))
+            }
         }
         .onAppear { viewModel.fetchCoupons() }
         .onChange(of: isShowingAddView) { isPresented in

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -226,13 +226,13 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             guard let self = self else { return }
             
             guard let title = self.titleTextField.text, !title.trimmingCharacters(in: .whitespaces).isEmpty else {
-                Toast.show(message: "일정 이름을 입력해주세요.")
+                Toast.show(message: "일정 이름을 입력해주세요.", bottomInset: 88)
                 return
             }
             
             let selectedIndices = self.weekdaySelectionView.selectedIndices.sorted()
             if selectedIndices.isEmpty {
-                Toast.show(message: "요일을 선택해주세요.")
+                Toast.show(message: "요일을 선택해주세요.", bottomInset: 88)
                 return
             }
             
@@ -242,7 +242,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             let endMin = Calendar.current.component(.hour, from: end) * 60 + Calendar.current.component(.minute, from: end)
             
             if startMin >= endMin {
-                Toast.show(message: "종료시간은 시작시간보다 늦어야 합니다.")
+                Toast.show(message: "종료시간은 시작시간보다 늦어야 합니다.", bottomInset: 88)
                 return
             }
             
@@ -266,17 +266,17 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 
                 if hasToday {
                     if startMin < currentTimeMin {
-                        Toast.show(message: "이미 지난 시간에는 일정을 등록할 수 없어요.")
+                        Toast.show(message: "이미 지난 시간에는 일정을 등록할 수 없어요.", bottomInset: 88)
                         return
                     }
                     
                     if isFireLit {
-                        Toast.show(message: "오늘 일정이 마감되어, 일정을 추가할 수 없어요.")
+                        Toast.show(message: "오늘 일정이 마감되어, 일정을 추가할 수 없어요.", bottomInset: 88)
                         return
                     }
                     
                     if hasActedLaterSchedule(endMin: endMin, now: now) {
-                        Toast.show(message: "이후의 일정이 이미 시작되어, 일정을 추가할 수 없어요.")
+                        Toast.show(message: "이후의 일정이 이미 시작되어, 일정을 추가할 수 없어요.", bottomInset: 88)
                         return
                     }
                 }
@@ -286,7 +286,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 }
                 
                 if hasPastDate {
-                    Toast.show(message: "이미 지난 시간에는 일정을 등록할 수 없어요.")
+                    Toast.show(message: "이미 지난 시간에는 일정을 등록할 수 없어요.", bottomInset: 88)
                     return
                 }
             }
@@ -402,12 +402,12 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                     )
                     
                     if shouldShowWarning {
-                        Toast.show(message: "일정 등록이 마감된 날이 있어, 오늘 이후부터 적용돼요.")
+                        Toast.show(message: "일정 등록이 마감된 날이 있어, 오늘 이후부터 적용돼요.", bottomInset: 88)
                     } else {
-                        Toast.show(message: "일정이 등록되었어요.")
+                        Toast.show(message: "일정이 등록되었어요.", bottomInset: 88)
                     }
                 } else {
-                    Toast.show(message: "일정이 등록되었어요.")
+                    Toast.show(message: "일정이 등록되었어요.", bottomInset: 88)
                 }
                 
                 if isRecurring && shouldShowWarning {
@@ -455,7 +455,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         viewModel.errorMessage
             .receive(on: DispatchQueue.main)
             .sink { [weak self] message in
-                Toast.show(message: message)
+                Toast.show(message: message, bottomInset: 88)
                 self?.navigationBar.isRightButtonEnabled = true
             }
             .store(in: &cancellables)
@@ -511,7 +511,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         if newDateWeekStart <= calendar.startOfDay(for: maxDate) {
             self.baseDate = newDate
         } else {
-            Toast.show(message: "현재 날짜 기준 12주 이내만 선택 가능합니다.")
+            Toast.show(message: "현재 날짜 기준 12주 이내만 선택 가능합니다.", bottomInset: 88)
         }
     }
     
@@ -725,7 +725,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         let isSameColor = colorCode == schedule.scheduleColor
 
         if isSameName && isSameStart && isSameEnd && isSameColor {
-            Toast.show(message: "변경사항이 없어요.")
+            Toast.show(message: "변경사항이 없어요.", bottomInset: 88)
             return
         }
         
@@ -745,7 +745,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             }
             
             if hasPastDate {
-                Toast.show(message: "과거 날짜에는 일정을 등록할 수 없습니다.")
+                Toast.show(message: "과거 날짜에는 일정을 등록할 수 없습니다.", bottomInset: 88)
                 return
             }
         }

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -257,7 +257,6 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             let weekDates = self.baseDate.daysOfWeek
             let isRecurring = self.repeatSwitch.isOn
             let isFireLit = self.viewModel?.isFireLit ?? false
-            
             let currentTimeMin = calendar.component(.hour, from: now) * 60 + calendar.component(.minute, from: now)
             
             if !isRecurring {
@@ -276,22 +275,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                         return
                     }
                     
-                    let scheduleList = viewModel?.scheduleList ?? []
-                    let dateFormatter = DateFormatter()
-                    dateFormatter.dateFormat = "yyyy-MM-dd"
-                    
-                    let hasActedLaterSchedule = scheduleList.contains { other in
-                        guard let otherStart = other.startTime.toDate(format: "HH:mm:ss"),
-                              let otherDateStr = other.date,
-                              let otherDate = dateFormatter.date(from: otherDateStr) else { return false }
-                        guard calendar.isDate(otherDate, inSameDayAs: now) else { return false }
-                        let otherStartMin = calendar.component(.hour, from: otherStart) * 60 + calendar.component(.minute, from: otherStart)
-                        let isAfter = otherStartMin >= endMin
-                        let isActed = other.scheduleStatus != nil && other.scheduleStatus != "PENDING"
-                        return isAfter && isActed
-                    }
-                    
-                    if hasActedLaterSchedule {
+                    if hasActedLaterSchedule(endMin: endMin, now: now) {
                         Toast.show(message: "이후의 일정이 이미 시작되어, 일정을 추가할 수 없어요.")
                         return
                     }
@@ -302,7 +286,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 }
                 
                 if hasPastDate {
-                    Toast.show(message: "과거 날짜에는 일정을 추가할 수 없습니다.")
+                    Toast.show(message: "이미 지난 시간에는 일정을 등록할 수 없어요.")
                     return
                 }
             }
@@ -397,15 +381,28 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 let currentWeekDayIndex = (calendar.component(.weekday, from: now) + 5) % 7
                 let isCurrentWeek = weekDates.first! <= today && weekDates.last! >= today
                 let startMin = calendar.component(.hour, from: self.currentStartTime ?? now) * 60
-                             + calendar.component(.minute, from: self.currentStartTime ?? now)
+                + calendar.component(.minute, from: self.currentStartTime ?? now)
+                let endMin = calendar.component(.hour, from: self.currentEndTime ?? now) * 60
+                + calendar.component(.minute, from: self.currentEndTime ?? now)
+                
+                var shouldShowWarning = false
                 
                 if isRecurring {
                     let hasPastDayInWeek = selectedIndices.contains { $0 < currentWeekDayIndex }
                     let isTodaySelected = selectedIndices.contains(currentWeekDayIndex)
                     let isTodayTimePast = isTodaySelected && (startMin < currentTimeMin)
+                    let isFireLit = self.viewModel?.isFireLit ?? false
+                    let hasActedLater = isTodaySelected && hasActedLaterSchedule(endMin: endMin, now: now)
+
+                    shouldShowWarning = isCurrentWeek && (
+                        hasPastDayInWeek ||
+                        isTodayTimePast ||
+                        (isTodaySelected && isFireLit) ||
+                        hasActedLater
+                    )
                     
-                    if isCurrentWeek && (hasPastDayInWeek || isTodayTimePast) {
-                        Toast.show(message: "일정이 등록되었어요. 오늘은 마감되어 다음부터 적용돼요.")
+                    if shouldShowWarning {
+                        Toast.show(message: "일정 등록이 마감된 날이 있어, 오늘 이후부터 적용돼요.")
                     } else {
                         Toast.show(message: "일정이 등록되었어요.")
                     }
@@ -413,7 +410,27 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                     Toast.show(message: "일정이 등록되었어요.")
                 }
                 
-                if let firstIndex = selectedIndices.first {
+                if isRecurring && shouldShowWarning {
+                    guard let nextWeekDate = calendar.date(byAdding: .weekOfYear, value: 1, to: weekDates[selectedIndices[0]]) else {
+                        self.dismiss(animated: true)
+                        return
+                    }
+                    
+                    let actualSchedule = Schedule(
+                        id: Int(Date().timeIntervalSince1970 * 1000),
+                        name: name,
+                        isRecurring: true,
+                        startTime: startTime,
+                        endTime: endTime,
+                        scheduleColor: colorName,
+                        colorCode: hexCode,
+                        dayOfWeek: selectedIndices.map { ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"][$0] }.joined(separator: ", "),
+                        date: nil,
+                        scheduleStatus: nil
+                    )
+                    self.onScheduleAdded?(actualSchedule, nextWeekDate)
+                    
+                } else if let firstIndex = selectedIndices.first {
                     let targetDate = weekDates[firstIndex]
                     
                     let actualSchedule = Schedule(
@@ -428,7 +445,6 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                         date: isRecurring ? nil : targetDate.toString(format: "yyyy-MM-dd"),
                         scheduleStatus: nil
                     )
-                    
                     self.onScheduleAdded?(actualSchedule, targetDate)
                 }
                 
@@ -457,6 +473,24 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 }
             }
             .store(in: &cancellables)
+    }
+    
+    private func hasActedLaterSchedule(endMin: Int, now: Date) -> Bool {
+        let calendar = Calendar.current
+        let scheduleList = viewModel?.scheduleList ?? []
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        return scheduleList.contains { other in
+            guard let otherStart = other.startTime.toDate(format: "HH:mm:ss"),
+                  let otherDateStr = other.date,
+                  let otherDate = dateFormatter.date(from: otherDateStr) else { return false }
+            guard calendar.isDate(otherDate, inSameDayAs: now) else { return false }
+            let otherStartMin = calendar.component(.hour, from: otherStart) * 60 + calendar.component(.minute, from: otherStart)
+            let isAfter = otherStartMin >= endMin
+            let isActed = other.scheduleStatus != nil && other.scheduleStatus != "PENDING"
+            return isAfter && isActed
+        }
     }
     
     private func moveWeek(value: Int) {
@@ -570,7 +604,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
     @objc
     private func repeatSwitchChanged() {
         if repeatSwitch.isOn {
-            weekdaySelectionView.isSingleSelectionMode = false
+            weekdaySelectionView.selectionMode = .normal
         }
     }
     
@@ -605,7 +639,21 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         guard let schedule = editingSchedule else { return }
         navigationBar.setTitle("일정 수정")
         titleTextField.text = schedule.name
-        repeatSwitch.isOn = schedule.isRecurring
+        weekdaySelectionView.selectionMode = .edit
+
+        repeatSwitch.isHidden = true
+        if schedule.isRecurring {
+            repeatLabel.text = "매주 반복"
+            repeatLabel.isHidden = false
+            repeatLabel.textColor = .gray500
+            
+            repeatLabel.snp.remakeConstraints {
+                $0.centerY.equalTo(daySectionTitle)
+                $0.trailing.equalToSuperview().inset(27)
+            }
+        } else {
+            repeatLabel.isHidden = true
+        }
         
         if schedule.isRecurring, let dayOfWeek = schedule.dayOfWeek {
             if let dateStr = schedule.date {
@@ -621,7 +669,6 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             weekdaySelectionView.setSelectedIndices(indices)
             updatePagingTitle()
         } else if let dateStr = schedule.date {
-            weekdaySelectionView.isSingleSelectionMode = false
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy-MM-dd"
             
@@ -665,97 +712,57 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         let startTimeStr = (currentStartTime ?? Date()).toString(format: "HH:mm:ss")
         let endTimeStr = (currentEndTime ?? Date()).toString(format: "HH:mm:ss")
         let isRecurring = repeatSwitch.isOn
-        let wasRecurring = schedule.isRecurring
         let weekDates = baseDate.daysOfWeek
         let selectedIndices = weekdaySelectionView.selectedIndices.sorted()
         
         let dayLabels = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
         let dayOfWeekStr: String? = isRecurring ? selectedIndices.map { dayLabels[$0] }.joined(separator: ", ") : nil
         let datesStr: String? = isRecurring ? nil : selectedIndices.map { weekDates[$0].toString(format: "yyyy-MM-dd") }.joined(separator: ", ")
+
+        let isSameName = (titleTextField.text ?? "") == schedule.name
+        let isSameStart = startTimeStr == schedule.startTime
+        let isSameEnd = endTimeStr == schedule.endTime
+        let isSameColor = colorCode == schedule.scheduleColor
+
+        if isSameName && isSameStart && isSameEnd && isSameColor {
+            Toast.show(message: "변경사항이 없어요.")
+            return
+        }
         
-        let originalDayIndices: Set<Int> = {
-            guard let dayOfWeek = schedule.dayOfWeek else { return [] }
-            let dayLabelsKor = ["월": 0, "화": 1, "수": 2, "목": 3, "금": 4, "토": 5, "일": 6]
-            return Set(dayOfWeek.components(separatedBy: ", ").compactMap { dayLabelsKor[$0.trimmingCharacters(in: .whitespaces)] })
-        }()
-        let currentDayIndices = Set(selectedIndices)
-        let isDayChanged = originalDayIndices != currentDayIndices
-        let isRecurringChanged = wasRecurring != isRecurring
+        if !isRecurring {
+            let calendar = Calendar.current
+            let today = calendar.startOfDay(for: Date())
+            let now = Date()
+            let currentTimeMin = calendar.component(.hour, from: now) * 60 + calendar.component(.minute, from: now)
+            let startMin = calendar.component(.hour, from: currentStartTime ?? now) * 60 + calendar.component(.minute, from: currentStartTime ?? now)
+            
+            let hasPastDate = selectedIndices.contains { index in
+                let date = weekDates[index]
+                let dateStart = calendar.startOfDay(for: date)
+                if dateStart < today { return true }
+                if dateStart == today && startMin < currentTimeMin { return true }
+                return false
+            }
+            
+            if hasPastDate {
+                Toast.show(message: "과거 날짜에는 일정을 등록할 수 없습니다.")
+                return
+            }
+        }
         
-        let shouldShowDialog = wasRecurring && !isDayChanged && !isRecurringChanged
+        let finalRequest = EditScheduleRequestDTO(
+            name: titleTextField.text ?? "",
+            isRecurring: isRecurring,
+            startTime: startTimeStr,
+            endTime: endTimeStr,
+            scheduleColor: colorCode,
+            dayOfWeek: dayOfWeekStr,
+            dates: datesStr,
+            isIncludeFollowing: true
+        )
         
-        if shouldShowDialog {
-            let dialog = DialogBox()
-            dialog.configure(state: .editSchedule(title: titleTextField.text ?? schedule.name, isRecurring: wasRecurring))
-            
-            dialog.onTapCancel = { [weak self] in
-                self?.dismiss(animated: false)
-            }
-            
-            dialog.onTapClose = { [weak self] in
-                self?.dismiss(animated: false)
-            }
-            
-            dialog.onTapConfirm = { [weak self] in
-                guard let self = self else { return }
-                self.dismiss(animated: false)
-                
-                let isIncludeFollowing: Bool? = dialog.isFollowingSelected
-                
-                let finalRequest = EditScheduleRequestDTO(
-                    name: self.titleTextField.text ?? "",
-                    isRecurring: isRecurring,
-                    startTime: startTimeStr,
-                    endTime: endTimeStr,
-                    scheduleColor: colorCode,
-                    dayOfWeek: dayOfWeekStr,
-                    dates: datesStr,
-                    isIncludeFollowing: isIncludeFollowing
-                )
-                
-                self.onEditConfirmed?(finalRequest, isIncludeFollowing ?? false) { success in
-                    if success { self.dismiss(animated: true) }
-                }
-            }
-            
-            dialog.show(in: self)
-            
-        } else {
-            if !isRecurring {
-                let calendar = Calendar.current
-                let today = calendar.startOfDay(for: Date())
-                let now = Date()
-                let currentTimeMin = calendar.component(.hour, from: now) * 60 + calendar.component(.minute, from: now)
-                let startMin = calendar.component(.hour, from: currentStartTime ?? now) * 60 + calendar.component(.minute, from: currentStartTime ?? now)
-                
-                let hasPastDate = selectedIndices.contains { index in
-                    let date = weekDates[index]
-                    let dateStart = calendar.startOfDay(for: date)
-                    if dateStart < today { return true }
-                    if dateStart == today && startMin < currentTimeMin { return true }
-                    return false
-                }
-                
-                if hasPastDate {
-                    Toast.show(message: "과거 날짜에는 일정을 등록할 수 없습니다.")
-                    return
-                }
-            }
-            
-            let finalRequest = EditScheduleRequestDTO(
-                name: self.titleTextField.text ?? "",
-                isRecurring: isRecurring,
-                startTime: startTimeStr,
-                endTime: endTimeStr,
-                scheduleColor: colorCode,
-                dayOfWeek: dayOfWeekStr,
-                dates: datesStr,
-                isIncludeFollowing: nil
-            )
-            
-            self.onEditConfirmed?(finalRequest, false) { success in
-                if success { self.dismiss(animated: true) }
-            }
+        self.onEditConfirmed?(finalRequest, true) { success in
+            if success { self.dismiss(animated: true) }
         }
     }
 }

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewModel.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewModel.swift
@@ -35,7 +35,11 @@ final class AddScheduleViewModel: BaseViewModel {
                     
                     switch error {
                     case .codeError(let message):
-                        self.errorMessage.send(message)
+                        if message.contains("불 피우기") {
+                            self.errorMessage.send("오늘 일정이 마감되어, 일정을 추가할 수 없어요.")
+                        } else {
+                            self.errorMessage.send(message)
+                        }
                     case .clientError(let code) where code == 400:
                         self.errorMessage.send("기존의 일정과 시간이 중복됩니다.")
                     default:

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/WeekdaySelectionView.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/WeekdaySelectionView.swift
@@ -14,9 +14,15 @@ final class WeekdaySelectionView: UIView {
     
     // MARK: - Properties
     
+    enum SelectionMode {
+        case normal
+        case single
+        case edit
+    }
+    
     private let days = ["월", "화", "수", "목", "금", "토", "일"]
     private var dayButtons: [UIButton] = []
-    var isSingleSelectionMode: Bool = false
+    var selectionMode: SelectionMode = .normal
     
     private(set) var selectedIndices = Set<Int>()
     
@@ -95,40 +101,45 @@ final class WeekdaySelectionView: UIView {
         
         indices.forEach { index in
             guard index < dayButtons.count else { return }
-            dayButtons[index].isSelected = true
-            dayButtons[index].layer.borderWidth = 1.0
+            
+            if selectionMode == .edit {
+                dayButtons[index].setTitleColor(.white, for: .normal)
+                dayButtons[index].setTypo(.body1_18_R, text: days[index], for: .normal)
+                dayButtons[index].layer.borderColor = UIColor.white.cgColor
+                dayButtons[index].layer.borderWidth = 1.0
+            }
             selectedIndices.insert(index)
         }
         
         everyDayButton.isSelected = (selectedIndices.count == 7)
-        everyDayButton.isHidden = isSingleSelectionMode
+        everyDayButton.isHidden = selectionMode != .normal
     }
     
     @objc
     private func dayButtonTapped(_ sender: UIButton) {
-        if isSingleSelectionMode {
+        switch selectionMode {
+        case .edit:
+            Toast.show(message: "요일은 수정할 수 없어요. 삭제 후 등록해주세요.")
+            return
+        case .single:
             dayButtons.forEach {
                 $0.isSelected = false
                 $0.layer.borderWidth = 0
             }
             selectedIndices.removeAll()
-            
             sender.isSelected = true
             sender.layer.borderWidth = 1.0
             selectedIndices.insert(sender.tag)
-            return
+        case .normal:
+            sender.isSelected.toggle()
+            sender.layer.borderWidth = sender.isSelected ? 1.0 : 0
+            if sender.isSelected {
+                selectedIndices.insert(sender.tag)
+            } else {
+                selectedIndices.remove(sender.tag)
+            }
+            everyDayButton.isSelected = (selectedIndices.count == 7)
         }
-        
-        sender.isSelected.toggle()
-        sender.layer.borderWidth = sender.isSelected ? 1.0 : 0
-        
-        if sender.isSelected {
-            selectedIndices.insert(sender.tag)
-        } else {
-            selectedIndices.remove(sender.tag)
-        }
-        
-        everyDayButton.isSelected = (selectedIndices.count == 7)
     }
     
     @objc

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewController.swift
@@ -78,7 +78,11 @@ class ScheduleViewController: BaseViewController<ScheduleViewModel> {
     
     private func presentAddSchedule() {
         guard let viewModel = self.viewModel else { return }
-        guard let addScheduleVC = AppDIContainer.shared.makeAddScheduleViewController() as? AddScheduleViewController else { return }
+        
+        let addScheduleVC = AppDIContainer.shared.makeAddScheduleViewController(
+            isFireLit: viewModel.isFireLit,
+            scheduleList: viewModel.scheduleList.value
+        )
         
         let calendar = Calendar.current
         let now = Date()
@@ -91,8 +95,6 @@ class ScheduleViewController: BaseViewController<ScheduleViewModel> {
         
         let targetDate: Date = (startOfReferenceWeek < startOfCurrentWeek) ? now : viewModel.currentReferenceDate.value
         
-        addScheduleVC.viewModel?.scheduleList = viewModel.scheduleList.value
-        addScheduleVC.viewModel?.isFireLit = viewModel.isFireLit
         addScheduleVC.baseDate = targetDate
         
         addScheduleVC.onScheduleAdded = { [weak self] (newSchedule: Schedule, targetDate: Date) in

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewModel.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewModel.swift
@@ -128,24 +128,6 @@ final class ScheduleViewModel: BaseViewModel, ViewModelType {
                     if schedule.isRecurring {
                         let isViewingCurrentWeek = calendar.isDate(refDate, inSameDayAs: now) ||
                                                   (currentWeekRange.first! <= now && currentWeekRange.last! >= now)
-                        
-                        if isViewingCurrentWeek {
-                            let scheduleIndices = schedule.dayIndices
-                            
-                            let isAllPast = scheduleIndices.allSatisfy { dayIndex in
-                                if dayIndex < currentWeekDayIndex { return true }
-                                if dayIndex == currentWeekDayIndex {
-                                    if let scheduleTime = schedule.startTime.toDate(format: "HH:mm:ss") {
-                                        let nowMin = calendar.component(.hour, from: now) * 60 + calendar.component(.minute, from: now)
-                                        let scheduleMin = calendar.component(.hour, from: scheduleTime) * 60 + calendar.component(.minute, from: scheduleTime)
-                                        return scheduleMin < nowMin
-                                    }
-                                }
-                                return false
-                            }
-                            
-                            if isAllPast { return false }
-                        }
                         return true
                     } else {
                         guard let dateStr = schedule.date else { return false }

--- a/Kiero/Kiero/Presentation/Schedule/WeeklyTimeTable/WeeklyTimeTableView.swift
+++ b/Kiero/Kiero/Presentation/Schedule/WeeklyTimeTable/WeeklyTimeTableView.swift
@@ -80,6 +80,9 @@ final class WeeklyTimeTableView: BaseUIView {
         gridBackgroundView.addSubviews(emptyView, cardContainerView)
         emptyView.addSubviews(emptyImageView, emptyTitleLabel, emptySubLabel)
         
+        scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 190, right: 0)
+        scrollView.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: 190, right: 0)
+        
         self.daysDates = Date().daysOfWeek
         updateHeaderLabels()
         setTimeLabel()
@@ -96,7 +99,7 @@ final class WeeklyTimeTableView: BaseUIView {
         scrollView.snp.makeConstraints {
             $0.top.equalTo(headerStackView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalToSuperview().inset(100)
+            $0.bottom.equalToSuperview()
         }
         
         let totalGridHeight = CGFloat(endHour - startHour + 1) * hourHeight
@@ -104,7 +107,7 @@ final class WeeklyTimeTableView: BaseUIView {
         gridContainer.snp.makeConstraints {
             $0.edges.equalTo(scrollView.contentLayoutGuide)
             $0.width.equalTo(scrollView.frameLayoutGuide)
-            $0.height.equalTo(totalGridHeight + (verticalPadding * 2) + 20)
+            $0.height.equalTo(totalGridHeight + (verticalPadding * 2))
         }
         
         gridBackgroundView.snp.makeConstraints {


### PR DESCRIPTION
## 📟 연결된 이슈
closed #262 
<br>

## 🍎 작업 내용
- 일정 등록 단건/중복 로직을 리팩토링하였습니다.
- 일정 삭제 Dialog 추가하였습니다.
- 일정 수정 UI 변경 및 로직 변경하였습니다.
- 부모 일정/미션/보상 플로팅 버튼 하단 스크롤 영역을 확장하였습니다.
- 부모 미션/ 보상 emptyView 위치를 통일하였습니다.
- 수정/삭제 버튼X DetailBottomSheet의 높이를 디자인 가이드에 따라 변경하였습니다.
<br>

## 📸 스크린샷
| 기능/화면 | 하단 스크롤 여백 | 일정 수정 UI |
|:---------:|:-------------:|:-------------:|
| 리팩토링 | <img src="https://github.com/user-attachments/assets/9ada4c83-f384-4c74-a986-8281b933116f" width="250"> | <img src="https://github.com/user-attachments/assets/754dae34-e042-4770-afb6-649c16921db0" width="250"> |
<br>

## 💬 리뷰 코멘트
부모 일정 파트 내에서 API 작업은 4/12(일)에 전달받고 4/19(일)까지 반영될 예정입니다. 
현재 로직에서는 일정 등록 > 불피우기 완료 > 반복 일정에서의 
아래 case를 제외하고 잘 작동됩니다. UI 리팩토링 위주로 확인해주세요 !
```
- 오늘의 여정 완료 검사(불피우기 완료)
    - 예시1) 현재 4/1(수) 14시인데 4/1(수) 17시 -19시 일정 반복 ON 저장하려고 한다. 
    근데 아이가 불피우기를 완료했다. → 4/1(수)는 저장안되고 그 다음주 수요일부터 등록
```