### PR TITLE
[hotfix] 보상 이름 글자수 제한 변경

### DIFF
--- a/Kiero/Kiero/Presentation/Reward/RewardEditView.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardEditView.swift
@@ -64,8 +64,8 @@ struct RewardEditView: View {
                 .padding(.vertical, 9)
                 .padding(.bottom, 15)
                 .onChange(of: rewardTitle) { newValue in
-                    if newValue.count > 15 {
-                        rewardTitle = String(newValue.prefix(15))
+                    if newValue.count > 13 {
+                        rewardTitle = String(newValue.prefix(13))
                     }
                 }
                 


### PR DESCRIPTION
## 📟 연결된 이슈
closed #268
<br>

## 🍎 작업 내용
보상 이름 글자수를 15에서 13으로 변경하였습니다. 
<br>