### PR TITLE
[hotfix] #270 QA 반영

### DIFF
--- a/Kiero/Kiero/Presentation/CoinMission/CoinMissionView.swift
+++ b/Kiero/Kiero/Presentation/CoinMission/CoinMissionView.swift
@@ -59,7 +59,7 @@ final class CoinMissionView: BaseUIView {
     private let emptyView = ContentEmptyView(
         title: "아직 등록된 미션이 없어!",
         description: "부모님과 함께 나만의 미션을 정해볼까?",
-        topOffset: 100
+        topOffset: 353
     ).then {
         $0.isHidden = true
     }
@@ -69,13 +69,13 @@ final class CoinMissionView: BaseUIView {
     override func setUI() {
         nameStack.addArrangedSubviews(iconImage, nameLabel)
         addSubviews(
+            emptyView,
             nameStack,
             coinChip,
             characterImg,
             speechField,
             missionLabel,
-            missionCollectionView,
-            emptyView
+            missionCollectionView
         )
     }
     
@@ -102,7 +102,7 @@ final class CoinMissionView: BaseUIView {
         }
         
         speechField.snp.makeConstraints {
-            $0.top.equalTo(nameStack.snp.bottom).offset(82)
+            $0.top.equalToSuperview().offset(171)
             $0.horizontalEdges.equalToSuperview()
         }
         
@@ -118,7 +118,7 @@ final class CoinMissionView: BaseUIView {
         }
         
         emptyView.snp.makeConstraints {
-            $0.top.equalTo(speechField.snp.bottom)
+            $0.top.equalToSuperview()
             $0.horizontalEdges.bottom.equalToSuperview()
         }
     }

--- a/Kiero/Kiero/Presentation/CoinMission/CoinMissionViewController.swift
+++ b/Kiero/Kiero/Presentation/CoinMission/CoinMissionViewController.swift
@@ -103,7 +103,7 @@ extension CoinMissionViewController: UICollectionViewDataSource {
 
 extension CoinMissionViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width = (collectionView.bounds.width - 31)
+        let width = (collectionView.bounds.width)
         return CGSize(width: width, height: 10)
     }
 }

--- a/Kiero/Kiero/Presentation/CoinMission/DailyMissionCell.swift
+++ b/Kiero/Kiero/Presentation/CoinMission/DailyMissionCell.swift
@@ -26,6 +26,7 @@ class DailyMissionCell: UICollectionViewCell {
     private let missionStack = UIStackView().then {
         $0.axis = .vertical
         $0.spacing = 18
+        $0.alignment = .fill
         $0.distribution = .fill
     }
     
@@ -58,7 +59,7 @@ class DailyMissionCell: UICollectionViewCell {
         missionStack.snp.makeConstraints {
             $0.top.equalTo(dateLabel.snp.bottom).offset(18)
             $0.horizontalEdges.equalToSuperview().inset(15.5)
-            $0.bottom.equalToSuperview().priority(.low)
+            $0.bottom.equalToSuperview()
         }
     }
     

--- a/Kiero/Kiero/Presentation/Common/Components/ContentEmptyView.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/ContentEmptyView.swift
@@ -69,7 +69,7 @@ final class ContentEmptyView: BaseUIView {
         
         stackView.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalToSuperview().offset(100)
+            $0.top.equalToSuperview()
         }
         
         stackView.setCustomSpacing(4, after: titleLabel)

--- a/Kiero/Kiero/Presentation/Common/Components/MissionBox/MissionBoxChild.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/MissionBox/MissionBoxChild.swift
@@ -90,6 +90,8 @@ final class MissionBoxChild: UIView {
         $0.alignment = .center
     }
     
+    private let spacer = UIView()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setStyle()
@@ -112,7 +114,7 @@ final class MissionBoxChild: UIView {
     private func setUI() {
         addSubview(missionBox)
         titleStack.addArrangedSubviews(rewardLabel, titleLabel)
-        missionBox.addArrangedSubviews(titleStack, completeButton)
+        missionBox.addArrangedSubviews(titleStack, spacer, completeButton)
         
         completeButton.addTarget(self, action: #selector(didTapComplete), for: .touchUpInside)
     }
@@ -121,7 +123,10 @@ final class MissionBoxChild: UIView {
         missionBox.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(13)
             $0.verticalEdges.equalToSuperview().inset(13.5)
-            $0.width.equalTo(343).priority(.low)
+        }
+        
+        spacer.snp.makeConstraints {
+            $0.width.greaterThanOrEqualTo(10)
         }
         
         completeButton.snp.makeConstraints {

--- a/Kiero/Kiero/Presentation/Common/Components/RewardBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/RewardBox.swift
@@ -15,6 +15,8 @@ struct RewardBox: View {
             Text("\(reward.title)")
                 .font(Font(UIFont.body3_14_R))
                 .foregroundStyle(.white)
+                .lineLimit(1)
+                .truncationMode(.tail)
             
             ChipItemWrapper(
                 style: .usedCoinChip,

--- a/Kiero/Kiero/Presentation/Reward/RewardEditView.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardEditView.swift
@@ -72,7 +72,7 @@ struct RewardEditView: View {
                 HStack(spacing: 4) {
                     Image(.ic3DCoin)
                     
-                    Text("보상")
+                    Text("금화")
                         .font(Font(UIFont.body2_16_R))
                         .foregroundStyle(.white)
                 }

--- a/Kiero/Kiero/Presentation/Reward/RewardEditView.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardEditView.swift
@@ -64,8 +64,8 @@ struct RewardEditView: View {
                 .padding(.vertical, 9)
                 .padding(.bottom, 15)
                 .onChange(of: rewardTitle) { newValue in
-                    if newValue.count > 13 {
-                        rewardTitle = String(newValue.prefix(13))
+                    if newValue.count > 15 {
+                        rewardTitle = String(newValue.prefix(15))
                     }
                 }
                 

--- a/Kiero/Kiero/Presentation/Reward/RewardViewModel.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardViewModel.swift
@@ -24,15 +24,15 @@ final class RewardViewModel: BaseViewModel, ObservableObject {
     @Published var selectedReward: Reward? = nil
     @Published var showDeleteDialog: Bool = false
     
-    var currentChildId: Int = 0
-    
-    let scrollToTop = PassthroughSubject<Void, Never>()
+    var currentChildId: Int {
+        UserDefaults.standard.integer(forKey: "selectedChildId")
+    }
     
     override init() {
         super.init()
-        
-        self.currentChildId = UserDefaults.standard.integer(forKey: "selectedChildId")
     }
+    
+    let scrollToTop = PassthroughSubject<Void, Never>()
     
     func fetchCoupons(childId: Int? = nil) {
         let targetId = childId ?? self.currentChildId

--- a/Kiero/Kiero/Presentation/WishWell/WishWellView.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellView.swift
@@ -17,7 +17,7 @@ final class WishWellView: BaseUIView {
     private let wishEmptyView = ContentEmptyView(
         title: "아직 등록된 보상이 없어!",
         description: "부모님과 함께 나만의 보상을 정해볼까?",
-        topOffset: 76.5
+        topOffset: 353
     )
     
     private let iconImage = UIImageView().then {
@@ -86,7 +86,7 @@ final class WishWellView: BaseUIView {
     // MARK: - Setup Method
     
     override func setUI() {
-        addSubviews(nameStack, coinChip, container, line, wishCollectionView, wishEmptyView)
+        addSubviews(wishEmptyView, nameStack, coinChip, container, line, wishCollectionView)
         nameStack.addArrangedSubviews(iconImage, nameLabel)
         wishWellStack.addArrangedSubviews(wishWellIcon, wishWellLabel)
         totalStack.addArrangedSubviews(wishWellStack, wishMessage)
@@ -137,9 +137,9 @@ final class WishWellView: BaseUIView {
         }
         
         wishEmptyView.snp.makeConstraints {
-                    $0.top.equalTo(line.snp.bottom)
-                    $0.horizontalEdges.bottom.equalToSuperview()
-                }
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.bottom.equalToSuperview()
+        }
     }
     
     // MARK: - Configuration


### PR DESCRIPTION
## 📟 연결된 이슈
closed #270 
<br>

## 🍎 작업 내용
보상 -> 금화 네이밍 변경
금화 미션 미션 cell 레이아웃 변경
보상 이름 2줄 넘어갈 시 1줄 + 말 줄임표로 표시
금화 미션, 소원의 우물 엠티뷰 위치 통일
보상 추가가 첫 로그인히 안되는 오류가 있어서 childId를 받아오는 방식 수정

<br>

## 📸 스크린샷
| 기능/화면 | 보상 | 금화미션 |
|:---------:|:-------------:|:-------------:|
| 기능 | <img width="250" alt="Simulator Screenshot - iPhone 17 - 2026-04-08 at 20 25 33" src="https://github.com/user-attachments/assets/a1cce9bc-c6a3-4fed-898c-3d626d8a2758" /> | <img width="250" alt="Simulator Screenshot - iPhone 12 - 2026-04-08 at 21 50 19" src="https://github.com/user-attachments/assets/dbba5d2b-bfa4-4747-bb5f-cdbe0c382b30" /> |
<br>

## 💬 리뷰 코멘트
리뷰어가 신경써서 봐줄 부분을 알려주세요.
