### PR TITLE
[refactor] #272 백그라운드 복귀 시 SSE 재연결 로직 추가

### DIFF
--- a/Kiero/Kiero/Application/SceneDelegate.swift
+++ b/Kiero/Kiero/Application/SceneDelegate.swift
@@ -69,14 +69,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
+        SseStreamManager.shared.resume()
     }
 
     func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
+        SseStreamManager.shared.pause()
     }
 
 

--- a/Kiero/Kiero/Network/Login/SseStreamManager.swift
+++ b/Kiero/Kiero/Network/Login/SseStreamManager.swift
@@ -22,6 +22,7 @@ final class SseStreamManager {
     private var isRunning = false
     
     private var isConnecting = false
+    private var storedOnEvent: ((SseEventPayload) -> Void)?
     
     init(sseURL: URL) {
         self.sseURL = sseURL
@@ -39,6 +40,7 @@ final class SseStreamManager {
         }
         isRunning = true
         sseAccessToken = initialToken
+        storedOnEvent = onEvent
         
         // 최초 연결
         Task { @MainActor [weak self] in
@@ -116,6 +118,23 @@ final class SseStreamManager {
         client?.connect()
     }
     
+    func resume() {
+        guard !isRunning, let onEvent = storedOnEvent else { return }
+        isRunning = true
+
+        Task {
+            do {
+                let newToken = try await TokenRefresher.shared.reissueSseAccessToken()
+                self.sseAccessToken = newToken
+                await MainActor.run { [weak self] in
+                    self?.connect(onEvent: onEvent)
+                }
+            } catch {
+                print("❌ [SSEManager] resume failed:", error)
+            }
+        }
+    }
+
     func pause() {
         client?.disconnect()
         client = nil


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #272 
<br>

## 🍎 작업 내용
- 백그라운드 복귀 시 SSE 재연결 로직 추가
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 화면2 |
|:---------:|:-------------:|:-------------:|
| 기능1 | <img src="" width="250"> | <img src="" width="250"> |
<br>

## 💬 리뷰 코멘트
  ### 문제                                                                                                             
  - 앱이 백그라운드로 전환되면 iOS가 앱을 suspend시켜 SSE 연결이 끊김
  - 포그라운드 복귀 시 재연결 로직이 없어 SSE가 죽은 상태로 방치됨

  ### 해결
  - SceneDelegate에서 백그라운드 진입 시 `pause()`, 포그라운드 복귀 시 `resume()` 호출
  - SseStreamManager에 `resume()` 메서드 추가 (새 토큰 발급 → SSE 재연결)

  ### 변경 파일
  - `SseStreamManager.swift`: `storedOnEvent` 프로퍼티, `resume()` 메서드 추가
  - `SceneDelegate.swift`: `sceneWillEnterForeground`, `sceneDidEnterBackground` 구현