### PR TITLE
[refactor] #278 부모 일정 및 미션 이름 리팩토링

### DIFF
--- a/Kiero/Kiero/Presentation/Mission/AIMission/View/AIMissionResultView.swift
+++ b/Kiero/Kiero/Presentation/Mission/AIMission/View/AIMissionResultView.swift
@@ -102,6 +102,7 @@ final class AIMissionResultView: BaseUIView {
     
     private func setDelegate() {
         nameTextField.delegate = self
+        nameTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         
         let backgroundTap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         self.addGestureRecognizer(backgroundTap)
@@ -134,19 +135,24 @@ final class AIMissionResultView: BaseUIView {
         self.endEditing(true)
     }
     
+    @objc
+    private func textFieldDidChange(_ textField: UITextField) {
+        guard textField.markedTextRange == nil else { return }
+        guard let text = textField.text else { return }
+        
+        if text.count > 15 {
+            textField.text = String(text.prefix(15))
+            let endPosition = textField.endOfDocument
+            textField.selectedTextRange = textField.textRange(from: endPosition, to: endPosition)
+        }
+    }
+    
     func updateReward(to value: Int) {
         rewardView.selectReward(value)
     }
 }
 
 extension AIMissionResultView: UITextFieldDelegate {
-    
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        guard let text = textField.text else { return true }
-        let newLength = text.count + string.count - range.length
-        return newLength <= 15
-    }
-    
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true

--- a/Kiero/Kiero/Presentation/Mission/WriteMission/WriteMissionViewController.swift
+++ b/Kiero/Kiero/Presentation/Mission/WriteMission/WriteMissionViewController.swift
@@ -159,12 +159,13 @@ final class WriteMissionViewController: BaseViewController<WriteMissionViewModel
     
     @objc
     private func textFieldDidChange(_ textField: UITextField) {
+        guard textField.markedTextRange == nil else { return }
         guard let text = textField.text else { return }
         
         if text.count > 15 {
-            let index = text.index(text.startIndex, offsetBy: 15)
-            let newString = String(text[..<index])
-            textField.text = newString
+            textField.text = String(text.prefix(15))
+            let endPosition = textField.endOfDocument
+            textField.selectedTextRange = textField.textRange(from: endPosition, to: endPosition)
             Toast.show(message: "미션이 최대 글자수 15자를 초과하였습니다.")
         }
     }
@@ -203,18 +204,6 @@ final class WriteMissionViewController: BaseViewController<WriteMissionViewModel
 }
 
 extension WriteMissionViewController: UITextFieldDelegate {
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        guard let text = textField.text else { return true }
-        
-        let newLength = text.count + string.count - range.length
-        
-        if newLength > 15 {
-            Toast.show(message: "미션이 최대 글자수 15자를 초과하였습니다.")
-            return false
-        }
-        return true
-    }
-    
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -610,13 +610,15 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
     
     @objc
     private func textFieldDidChange(_ textField: UITextField) {
+        guard textField.markedTextRange == nil else { return }
         guard let text = textField.text else { return }
-        
-        if text.count > 8 {
-            let index = text.index(text.startIndex, offsetBy: 8)
-            let newString = String(text[..<index])
-            textField.text = newString
-        }
+        guard text.count > 8 else { return }
+
+        let truncated = String(text.prefix(8))
+        textField.text = truncated
+
+        let endPosition = textField.endOfDocument
+        textField.selectedTextRange = textField.textRange(from: endPosition, to: endPosition)
     }
     
     @objc
@@ -768,12 +770,6 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
 }
 
 extension AddScheduleViewController: UITextFieldDelegate {
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        guard let text = textField.text else { return true }
-        let newLength = text.count + string.count - range.length
-        return newLength <= 8
-    }
-    
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true


### PR DESCRIPTION
## 📟 연결된 이슈
closed #278 
<br>

## 🍎 작업 내용
- 부모 일정 및 미션 이름 입력 시에 종성까지 기입할 수 없는 문제를 해결했습니다. 
기존 방식에서 `shouldChangeCharactersIn` 메서드가 글자가 입력되기 전에 호출되어 한글 종성 입력 시 iOS가 이미 `markedTextRange = nil`로 확정 처리하고 들어오는 경우가 있어서, 8자 체크에서 차단되는 문제였습니다. 해당 문제를 `textFieldDidChange`에서 글자를 조합하는 중이면 그대로 두고, prefix(8)로 처리하도록 로직을 수정해 해결하였습니다.
<br>

## 📸 스크린샷
| 기능/화면 | 일정 | 미션 | Ai미션 |
|:---------:|:-------------:|:-------------:| :-------------:|
| 기능1 | <img src="https://github.com/user-attachments/assets/6c309dc2-da5d-4f0f-936c-b9d7239f83b4" width="250"> | <img src="https://github.com/user-attachments/assets/e43e8447-4557-4090-8b34-a478e17eab35" width="250"> | <img src="https://github.com/user-attachments/assets/5a003d7c-5a9b-4a04-a1fb-e2755adce7bf" width="250"> |
<br>

## 💬 리뷰 코멘트
빠른 어푸 부탁드립니다 !
