### PR TITLE
[network] #280 부모 일정 수정 및 삭제 API 수정

### DIFF
--- a/Kiero/Kiero/Network/Base/EndPoint.swift
+++ b/Kiero/Kiero/Network/Base/EndPoint.swift
@@ -42,9 +42,9 @@ enum EndPoint {
     case fetchSchedules(childId: Int, startDate: String, endDate: String)
     case postSchedule(childId: Int, request: AddScheduleRequestDTO)
     case fetchDefaultColor(childId: Int)
-    case editSchedule(scheduleId: Int, selectedDate: String)
-    case deleteSchedule(scheduleId: Int, selectedDate: String)
-    
+    case editSchedule(scheduleId: Int, selectedDate: String, startDate: String?, endDate: String?)
+    case deleteSchedule(scheduleId: Int, selectedDate: String?, startDate: String?, endDate: String?)
+
     // Mission
     case fetchMissions(childId: Int?)
     case updateMission(missionId: Int, request: WriteMissionRequestDTO)
@@ -170,10 +170,19 @@ enum EndPoint {
             return "/api/v1/feeds/unread"
         case .completeMission(let missionId):
             return "/api/v1/missions/\(missionId)/complete"
-        case .deleteSchedule(let scheduleId, let selectedDate):
-            return "/api/v1/schedules/\(scheduleId)?selectedDate=\(selectedDate)"
-        case .editSchedule(let scheduleId, let selectedDate):
-            return "/api/v1/schedules/\(scheduleId)?selectedDate=\(selectedDate)"
+        case .deleteSchedule(let scheduleId, let selectedDate, let startDate, let endDate):
+            if let selectedDate = selectedDate {
+                return "/api/v1/schedules/\(scheduleId)?selectedDate=\(selectedDate)"
+            } else if let start = startDate, let end = endDate {
+                return "/api/v1/schedules/\(scheduleId)?startDate=\(start)&endDate=\(end)"
+            }
+            return "/api/v1/schedules/\(scheduleId)"
+        case .editSchedule(let scheduleId, let selectedDate, let startDate, let endDate):
+            if let start = startDate, let end = endDate {
+                return "/api/v1/schedules/\(scheduleId)?startDate=\(start)&endDate=\(end)"
+            } else {
+                return "/api/v1/schedules/\(scheduleId)?selectedDate=\(selectedDate)"
+            }
         case .updateMission(let missionId, _), .deleteMission(let missionId):
             return "/api/v1/missions/\(missionId)"
         case .fetchTodayStatus(let childId):

--- a/Kiero/Kiero/Network/Schedule/Schedule/ScheduleDTO.swift
+++ b/Kiero/Kiero/Network/Schedule/Schedule/ScheduleDTO.swift
@@ -36,13 +36,9 @@ struct DeleteScheduleRequestDTO: Encodable {
 
 struct EditScheduleRequestDTO: Encodable {
     let name: String
-    let isRecurring: Bool
     let startTime: String
     let endTime: String
     let scheduleColor: String
-    let dayOfWeek: String?
-    let dates: String?
-    let isIncludeFollowing: Bool?
 }
 
 extension ScheduleResponseDTO {

--- a/Kiero/Kiero/Network/Schedule/Schedule/ScheduleService.swift
+++ b/Kiero/Kiero/Network/Schedule/Schedule/ScheduleService.swift
@@ -13,8 +13,8 @@ protocol ScheduleServiceType {
     func fetchSchedules(childId: Int, startDate: Date, endDate: Date) -> AnyPublisher<(isFireLit: Bool, schedules: [Schedule]), NetworkError>
     func deleteChildDummyData() -> AnyPublisher<Void, NetworkError>
     func logout() -> AnyPublisher<Void, NetworkError>
-    func deleteSchedule(scheduleId: Int, selectedDate: String, isIncludeFollowing: Bool) -> AnyPublisher<Void, NetworkError>
-    func editSchedule(scheduleId: Int, selectedDate: String, request: EditScheduleRequestDTO) -> AnyPublisher<Void, NetworkError>
+    func deleteSchedule(scheduleId: Int, selectedDate: String?, startDate: String?, endDate: String?, isIncludeFollowing: Bool) -> AnyPublisher<Void, NetworkError>
+    func editSchedule(scheduleId: Int, selectedDate: String, startDate: String?, endDate: String?, request: EditScheduleRequestDTO) -> AnyPublisher<Void, NetworkError>
 }
 
 final class ScheduleService: ScheduleServiceType {
@@ -81,20 +81,28 @@ final class ScheduleService: ScheduleServiceType {
         }.eraseToAnyPublisher()
     }
     
-    func deleteSchedule(scheduleId: Int, selectedDate: String, isIncludeFollowing: Bool) -> AnyPublisher<Void, NetworkError> {
+    func deleteSchedule(scheduleId: Int, selectedDate: String?, startDate: String?, endDate: String?, isIncludeFollowing: Bool) -> AnyPublisher<Void, NetworkError> {
         let endPoint = EndPoint.deleteSchedule(
             scheduleId: scheduleId,
-            selectedDate: selectedDate
+            selectedDate: selectedDate,
+            startDate: startDate,
+            endDate: endDate
         )
-        let requestBody = DeleteScheduleRequestDTO(isIncludeFollowing: isIncludeFollowing)
         
         return Future<Void, NetworkError> { promise in
             Task {
                 do {
-                    let _: EmptyResponse = try await BaseService.shared.request(
-                        endPoint: endPoint,
-                        body: requestBody
-                    )
+                    if let _ = startDate {
+                        let requestBody = DeleteScheduleRequestDTO(isIncludeFollowing: isIncludeFollowing)
+                        let _: EmptyResponse = try await BaseService.shared.request(
+                            endPoint: endPoint,
+                            body: requestBody
+                        )
+                    } else {
+                        let _: EmptyResponse = try await BaseService.shared.request(
+                            endPoint: endPoint
+                        )
+                    }
                     promise(.success(()))
                 } catch {
                     promise(.failure(error as? NetworkError ?? .unknownError))
@@ -103,8 +111,13 @@ final class ScheduleService: ScheduleServiceType {
         }.eraseToAnyPublisher()
     }
     
-    func editSchedule(scheduleId: Int, selectedDate: String, request: EditScheduleRequestDTO) -> AnyPublisher<Void, NetworkError> {
-        let endPoint = EndPoint.editSchedule(scheduleId: scheduleId, selectedDate: selectedDate)
+    func editSchedule(scheduleId: Int, selectedDate: String, startDate: String?, endDate: String?, request: EditScheduleRequestDTO) -> AnyPublisher<Void, NetworkError> {
+        let endPoint = EndPoint.editSchedule(
+            scheduleId: scheduleId,
+            selectedDate: selectedDate,
+            startDate: startDate,
+            endDate: endDate
+        )
         return Future<Void, NetworkError> { promise in
             Task {
                 do {

--- a/Kiero/Kiero/Presentation/Common/Splash/GradientDimView.swift
+++ b/Kiero/Kiero/Presentation/Common/Splash/GradientDimView.swift
@@ -37,7 +37,7 @@ final class GradientDimView: UIView {
     private func updateGradient() {
         let h = max(bounds.height, 1)
 
-        var l1 = clamp(fadeStartY / h)
+        let l1 = clamp(fadeStartY / h)
         var l2 = clamp(solidStartY / h)
 
         if l2 < l1 { l2 = l1 }

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -266,17 +266,17 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 
                 if hasToday {
                     if startMin < currentTimeMin {
-                        Toast.show(message: "이미 지난 시간에는 일정을 등록할 수 없어요.", bottomInset: 88)
+                        Toast.show(message: "이미 지난 시간에는 일정을 등록할 수 없어요.", bottomInset: 65)
                         return
                     }
                     
                     if isFireLit {
-                        Toast.show(message: "오늘 일정이 마감되어, 일정을 추가할 수 없어요.", bottomInset: 88)
+                        Toast.show(message: "오늘 일정이 마감되어, 일정을 추가할 수 없어요.", bottomInset: 65)
                         return
                     }
                     
                     if hasActedLaterSchedule(endMin: endMin, now: now) {
-                        Toast.show(message: "이후의 일정이 이미 시작되어, 일정을 추가할 수 없어요.", bottomInset: 88)
+                        Toast.show(message: "이후의 일정이 이미 시작되어, 일정을 추가할 수 없어요.", bottomInset: 65)
                         return
                     }
                 }

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -236,13 +236,19 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 return
             }
             
+            let calendar = Calendar.current
+            let now = Date()
+            let today = calendar.startOfDay(for: now)
+            
             let start = self.currentStartTime ?? Date()
             let end = self.currentEndTime ?? Date()
-            let startMin = Calendar.current.component(.hour, from: start) * 60 + Calendar.current.component(.minute, from: start)
-            let endMin = Calendar.current.component(.hour, from: end) * 60 + Calendar.current.component(.minute, from: end)
+            
+            let startMin = calendar.component(.hour, from: start) * 60 + calendar.component(.minute, from: start)
+            let endMin = calendar.component(.hour, from: end) * 60 + calendar.component(.minute, from: end)
+            let currentTimeMin = calendar.component(.hour, from: now) * 60 + calendar.component(.minute, from: now)
             
             if startMin >= endMin {
-                Toast.show(message: "종료시간은 시작시간보다 늦어야 합니다.", bottomInset: 88)
+                Toast.show(message: "종료시간은 시작시간보다 늦어야 합니다.", bottomInset: 65)
                 return
             }
             
@@ -251,15 +257,46 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 return
             }
             
-            let calendar = Calendar.current
-            let now = Date()
-            let today = calendar.startOfDay(for: now)
             let weekDates = self.baseDate.daysOfWeek
             let isRecurring = self.repeatSwitch.isOn
             let isFireLit = self.viewModel?.isFireLit ?? false
-            let currentTimeMin = calendar.component(.hour, from: now) * 60 + calendar.component(.minute, from: now)
+            let colorCode = self.colorMapping[self.currentSelectedColor ?? .schedule1] ?? "SCHEDULE1"
+            let startTimeStr = start.toString(format: "HH:mm:ss")
+            let endTimeStr = end.toString(format: "HH:mm:ss")
             
-            if !isRecurring {
+            let requestDTO: AddScheduleRequestDTO
+
+            if isRecurring {
+                let dayLabels = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
+                let dayOfWeekStr = selectedIndices.map { dayLabels[$0] }.joined(separator: ", ")
+                var firstDate = weekDates[selectedIndices[0]]
+                let currentWeekStart = calendar.startOfDay(for: Date().daysOfWeek.first!)
+                let lookingWeekStart = calendar.startOfDay(for: weekDates.first!)
+                
+                if currentWeekStart == lookingWeekStart {
+                    let currentWeekDayIndex = (calendar.component(.weekday, from: now) + 5) % 7
+                    let isTodaySelected = selectedIndices.contains(currentWeekDayIndex)
+                    
+                    if isTodaySelected && (isFireLit || startMin < currentTimeMin) {
+                        if let nextWeekDate = calendar.date(byAdding: .day, value: 7, to: firstDate) {
+                            firstDate = nextWeekDate
+                            Toast.show(message: "일정 등록이 마감된 날이 있어, 다음 주부터 적용돼요.", bottomInset: 88)
+                        }
+                    }
+                }
+                
+                requestDTO = AddScheduleRequestDTO(
+                    name: title,
+                    isRecurring: true,
+                    firstOrderDate: firstDate.toString(format: "yyyy-MM-dd"),
+                    startTime: startTimeStr,
+                    endTime: endTimeStr,
+                    scheduleColor: colorCode,
+                    dayOfWeek: dayOfWeekStr,
+                    dates: nil
+                )
+                
+            } else {
                 let hasToday = selectedIndices.contains { index in
                     calendar.isDate(weekDates[index], inSameDayAs: today)
                 }
@@ -269,12 +306,10 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                         Toast.show(message: "이미 지난 시간에는 일정을 등록할 수 없어요.", bottomInset: 65)
                         return
                     }
-                    
                     if isFireLit {
                         Toast.show(message: "오늘 일정이 마감되어, 일정을 추가할 수 없어요.", bottomInset: 65)
                         return
                     }
-                    
                     if hasActedLaterSchedule(endMin: endMin, now: now) {
                         Toast.show(message: "이후의 일정이 이미 시작되어, 일정을 추가할 수 없어요.", bottomInset: 65)
                         return
@@ -284,39 +319,13 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 let hasPastDate = selectedIndices.contains { index in
                     calendar.startOfDay(for: weekDates[index]) < today
                 }
-                
                 if hasPastDate {
                     Toast.show(message: "이미 지난 시간에는 일정을 등록할 수 없어요.", bottomInset: 88)
                     return
                 }
-            }
-            
-            self.navigationBar.isRightButtonEnabled = false
-            
-            let colorCode = self.colorMapping[self.currentSelectedColor ?? .schedule1] ?? "SCHEDULE1"
-            let startTimeStr = start.toString(format: "HH:mm:ss")
-            let endTimeStr = end.toString(format: "HH:mm:ss")
-            
-            if isRecurring {
-                let dayLabels = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
-                let dayOfWeekStr = selectedIndices.map { dayLabels[$0] }.joined(separator: ", ")
-                let firstOrderDate = weekDates[selectedIndices[0]].toString(format: "yyyy-MM-dd")
                 
-                let requestDTO = AddScheduleRequestDTO(
-                    name: title,
-                    isRecurring: true,
-                    firstOrderDate: firstOrderDate,
-                    startTime: startTimeStr,
-                    endTime: endTimeStr,
-                    scheduleColor: colorCode,
-                    dayOfWeek: dayOfWeekStr,
-                    dates: nil
-                )
-                viewModel?.addSchedule(request: requestDTO)
-            } else {
                 let datesStr = selectedIndices.map { weekDates[$0].toString(format: "yyyy-MM-dd") }.joined(separator: ", ")
-                
-                let requestDTO = AddScheduleRequestDTO(
+                requestDTO = AddScheduleRequestDTO(
                     name: title,
                     isRecurring: false,
                     firstOrderDate: nil,
@@ -326,9 +335,10 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                     dayOfWeek: nil,
                     dates: datesStr
                 )
-                viewModel?.addSchedule(request: requestDTO)
             }
             
+            self.navigationBar.isRightButtonEnabled = false
+            viewModel?.addSchedule(request: requestDTO)
             self.view.endEditing(true)
         }
         
@@ -376,77 +386,52 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 
                 let calendar = Calendar.current
                 let now = Date()
-                let today = calendar.startOfDay(for: now)
-                let currentTimeMin = calendar.component(.hour, from: now) * 60 + calendar.component(.minute, from: now)
-                let currentWeekDayIndex = (calendar.component(.weekday, from: now) + 5) % 7
-                let isCurrentWeek = weekDates.first! <= today && weekDates.last! >= today
-                let startMin = calendar.component(.hour, from: self.currentStartTime ?? now) * 60
-                + calendar.component(.minute, from: self.currentStartTime ?? now)
-                let endMin = calendar.component(.hour, from: self.currentEndTime ?? now) * 60
-                + calendar.component(.minute, from: self.currentEndTime ?? now)
+                _ = calendar.startOfDay(for: now)
                 
-                var shouldShowWarning = false
+                var finalTargetDate = weekDates[selectedIndices.first ?? 0]
+                var wasWarningShown = false
                 
                 if isRecurring {
-                    let hasPastDayInWeek = selectedIndices.contains { $0 < currentWeekDayIndex }
-                    let isTodaySelected = selectedIndices.contains(currentWeekDayIndex)
-                    let isTodayTimePast = isTodaySelected && (startMin < currentTimeMin)
-                    let isFireLit = self.viewModel?.isFireLit ?? false
-                    let hasActedLater = isTodaySelected && hasActedLaterSchedule(endMin: endMin, now: now)
-
-                    shouldShowWarning = isCurrentWeek && (
-                        hasPastDayInWeek ||
-                        isTodayTimePast ||
-                        (isTodaySelected && isFireLit) ||
-                        hasActedLater
-                    )
+                    let currentWeekStart = calendar.startOfDay(for: now.daysOfWeek.first!)
+                    let lookingWeekStart = calendar.startOfDay(for: weekDates.first!)
                     
-                    if shouldShowWarning {
-                        Toast.show(message: "일정 등록이 마감된 날이 있어, 오늘 이후부터 적용돼요.", bottomInset: 88)
-                    } else {
-                        Toast.show(message: "일정이 등록되었어요.", bottomInset: 88)
+                    if currentWeekStart == lookingWeekStart {
+                        let currentWeekDayIndex = (calendar.component(.weekday, from: now) + 5) % 7
+                        let isTodaySelected = selectedIndices.contains(currentWeekDayIndex)
+                        let isFireLit = self.viewModel?.isFireLit ?? false
+                        
+                        let startMin = calendar.component(.hour, from: self.currentStartTime ?? now) * 60 + calendar.component(.minute, from: self.currentStartTime ?? now)
+                        let currentTimeMin = calendar.component(.hour, from: now) * 60 + calendar.component(.minute, from: now)
+                        
+                        if isTodaySelected && (isFireLit || startMin < currentTimeMin) {
+                            if let nextWeek = calendar.date(byAdding: .day, value: 7, to: finalTargetDate) {
+                                finalTargetDate = nextWeek
+                                wasWarningShown = true
+                            }
+                        }
                     }
+                }
+                
+                if isRecurring && wasWarningShown {
+                    Toast.show(message: "일정 등록이 마감된 날이 있어, 다음 주부터 적용돼요.", bottomInset: 88)
                 } else {
                     Toast.show(message: "일정이 등록되었어요.", bottomInset: 88)
                 }
                 
-                if isRecurring && shouldShowWarning {
-                    guard let nextWeekDate = calendar.date(byAdding: .weekOfYear, value: 1, to: weekDates[selectedIndices[0]]) else {
-                        self.dismiss(animated: true)
-                        return
-                    }
-                    
-                    let actualSchedule = Schedule(
-                        id: Int(Date().timeIntervalSince1970 * 1000),
-                        name: name,
-                        isRecurring: true,
-                        startTime: startTime,
-                        endTime: endTime,
-                        scheduleColor: colorName,
-                        colorCode: hexCode,
-                        dayOfWeek: selectedIndices.map { ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"][$0] }.joined(separator: ", "),
-                        date: nil,
-                        scheduleStatus: nil
-                    )
-                    self.onScheduleAdded?(actualSchedule, nextWeekDate)
-                    
-                } else if let firstIndex = selectedIndices.first {
-                    let targetDate = weekDates[firstIndex]
-                    
-                    let actualSchedule = Schedule(
-                        id: Int(Date().timeIntervalSince1970 * 1000),
-                        name: name,
-                        isRecurring: isRecurring,
-                        startTime: startTime,
-                        endTime: endTime,
-                        scheduleColor: colorName,
-                        colorCode: hexCode,
-                        dayOfWeek: isRecurring ? selectedIndices.map { ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"][$0] }.joined(separator: ", ") : nil,
-                        date: isRecurring ? nil : targetDate.toString(format: "yyyy-MM-dd"),
-                        scheduleStatus: nil
-                    )
-                    self.onScheduleAdded?(actualSchedule, targetDate)
-                }
+                let actualSchedule = Schedule(
+                    id: Int(Date().timeIntervalSince1970 * 1000),
+                    name: name,
+                    isRecurring: isRecurring,
+                    startTime: startTime,
+                    endTime: endTime,
+                    scheduleColor: colorName,
+                    colorCode: hexCode,
+                    dayOfWeek: isRecurring ? selectedIndices.map { ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"][$0] }.joined(separator: ", ") : nil,
+                    date: isRecurring ? nil : finalTargetDate.toString(format: "yyyy-MM-dd"),
+                    scheduleStatus: nil
+                )
+                
+                self.onScheduleAdded?(actualSchedule, finalTargetDate)
                 
                 self.dismiss(animated: true)
             }

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -26,7 +26,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
     
     var isEditMode: Bool = false
     var editingSchedule: Schedule?
-    var onEditConfirmed: ((EditScheduleRequestDTO, Bool, @escaping (Bool) -> Void) -> Void)?
+    var onEditConfirmed: ((EditScheduleRequestDTO, String, Bool, @escaping (Bool) -> Void) -> Void)?
     
     private let colorReverseMapping: [String: UIColor] = [
         "SCHEDULE1": .schedule1, "SCHEDULE2": .schedule2,
@@ -713,13 +713,9 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         let colorCode = colorMapping[currentSelectedColor ?? .schedule1] ?? "SCHEDULE1"
         let startTimeStr = (currentStartTime ?? Date()).toString(format: "HH:mm:ss")
         let endTimeStr = (currentEndTime ?? Date()).toString(format: "HH:mm:ss")
-        let isRecurring = repeatSwitch.isOn
+        let isRecurring = schedule.isRecurring
         let weekDates = baseDate.daysOfWeek
         let selectedIndices = weekdaySelectionView.selectedIndices.sorted()
-        
-        let dayLabels = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
-        let dayOfWeekStr: String? = isRecurring ? selectedIndices.map { dayLabels[$0] }.joined(separator: ", ") : nil
-        let datesStr: String? = isRecurring ? nil : selectedIndices.map { weekDates[$0].toString(format: "yyyy-MM-dd") }.joined(separator: ", ")
 
         let isSameName = (titleTextField.text ?? "") == schedule.name
         let isSameStart = startTimeStr == schedule.startTime
@@ -752,18 +748,22 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             }
         }
         
+        let selectedDate: String
+        if isRecurring {
+            let firstIndex = selectedIndices.first ?? 0
+            selectedDate = weekDates[firstIndex].toString(format: "yyyy-MM-dd")
+        } else {
+            selectedDate = schedule.date ?? weekDates[selectedIndices.first ?? 0].toString(format: "yyyy-MM-dd")
+        }
+        
         let finalRequest = EditScheduleRequestDTO(
             name: titleTextField.text ?? "",
-            isRecurring: isRecurring,
             startTime: startTimeStr,
             endTime: endTimeStr,
-            scheduleColor: colorCode,
-            dayOfWeek: dayOfWeekStr,
-            dates: datesStr,
-            isIncludeFollowing: true
+            scheduleColor: colorCode
         )
         
-        self.onEditConfirmed?(finalRequest, true) { success in
+        self.onEditConfirmed?(finalRequest, selectedDate, true) { success in
             if success { self.dismiss(animated: true) }
         }
     }

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -748,13 +748,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             }
         }
         
-        let selectedDate: String
-        if isRecurring {
-            let firstIndex = selectedIndices.first ?? 0
-            selectedDate = weekDates[firstIndex].toString(format: "yyyy-MM-dd")
-        } else {
-            selectedDate = schedule.date ?? weekDates[selectedIndices.first ?? 0].toString(format: "yyyy-MM-dd")
-        }
+        let selectedDate = schedule.date ?? weekDates[selectedIndices.first ?? 0].toString(format: "yyyy-MM-dd")
         
         let finalRequest = EditScheduleRequestDTO(
             name: titleTextField.text ?? "",

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -176,7 +176,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         
         weekdaySelectionView.snp.makeConstraints {
             $0.top.equalTo(daySectionTitle.snp.bottom).offset(17)
-            $0.horizontalEdges.equalToSuperview().inset(19)
+            $0.horizontalEdges.equalToSuperview().inset(25)
         }
         
         timeSectionTitle.snp.makeConstraints {
@@ -651,7 +651,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             
             repeatLabel.snp.remakeConstraints {
                 $0.centerY.equalTo(daySectionTitle)
-                $0.trailing.equalToSuperview().inset(27)
+                $0.trailing.equalToSuperview().inset(25)
             }
         } else {
             repeatLabel.isHidden = true
@@ -723,7 +723,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         let isSameColor = colorCode == schedule.scheduleColor
 
         if isSameName && isSameStart && isSameEnd && isSameColor {
-            Toast.show(message: "변경사항이 없어요.", bottomInset: 88)
+            Toast.show(message: "변경사항이 없어요.", bottomInset: 65)
             return
         }
         

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/WeekdaySelectionView.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/WeekdaySelectionView.swift
@@ -119,7 +119,7 @@ final class WeekdaySelectionView: UIView {
     private func dayButtonTapped(_ sender: UIButton) {
         switch selectionMode {
         case .edit:
-            Toast.show(message: "요일은 수정할 수 없어요. 삭제 후 등록해주세요.")
+            Toast.show(message: "요일은 수정할 수 없어요. 삭제 후 등록해주세요.", bottomInset: 65)
             return
         case .single:
             dayButtons.forEach {

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewModel.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewModel.swift
@@ -190,10 +190,28 @@ final class ScheduleViewModel: BaseViewModel, ViewModelType {
             .store(in: &cancellables)
     }
     
-    func deleteSchedule(scheduleId: Int, selectedDate: String, isIncludeFollowing: Bool) {
+    func deleteSchedule(scheduleId: Int, selectedDate: String, isRecurring: Bool, isIncludeFollowing: Bool) {
+        var startDate: String? = nil
+        var endDate: String? = nil
+        var selDate: String? = nil
+        
+        if isRecurring {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd"
+            if let date = formatter.date(from: selectedDate) {
+                let days = date.daysOfWeek
+                startDate = days.first?.toString(format: "yyyy-MM-dd")
+                endDate = days.last?.toString(format: "yyyy-MM-dd")
+            }
+        } else {
+            selDate = selectedDate
+        }
+        
         service.deleteSchedule(
             scheduleId: scheduleId,
-            selectedDate: selectedDate,
+            selectedDate: selDate,
+            startDate: startDate,
+            endDate: endDate,
             isIncludeFollowing: isIncludeFollowing
         )
         .receive(on: RunLoop.main)
@@ -207,26 +225,45 @@ final class ScheduleViewModel: BaseViewModel, ViewModelType {
         .store(in: &cancellables)
     }
     
-    func editSchedule(scheduleId: Int, selectedDate: String, request: EditScheduleRequestDTO, completion: @escaping (Bool) -> Void) {
-        service.editSchedule(scheduleId: scheduleId, selectedDate: selectedDate, request: request)
-            .receive(on: RunLoop.main)
-            .sink(receiveCompletion: { [weak self] result in
-                if case .failure(let error) = result {
-                    switch error {
-                    case .codeError(let message):
-                        self?.editErrorMessage.send(message)
-                    case .clientError(let code) where code == 400:
-                        self?.editErrorMessage.send("기존의 일정과 시간이 중복됩니다.")
-                    default:
-                        self?.editErrorMessage.send("일정 수정에 실패했어요. 잠시 후 다시 시도해주세요.")
-                    }
-                    completion(false)
+    func editSchedule(scheduleId: Int, selectedDate: String, isRecurring: Bool, request: EditScheduleRequestDTO, completion: @escaping (Bool) -> Void) {
+        var startDate: String? = nil
+        var endDate: String? = nil
+        
+        if isRecurring {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy-MM-dd"
+            if let date = formatter.date(from: selectedDate) {
+                let days = date.daysOfWeek
+                startDate = days.first?.toString(format: "yyyy-MM-dd")
+                endDate = days.last?.toString(format: "yyyy-MM-dd")
+            }
+        }
+        
+        service.editSchedule(
+            scheduleId: scheduleId,
+            selectedDate: selectedDate,
+            startDate: startDate,
+            endDate: endDate,
+            request: request
+        )
+        .receive(on: RunLoop.main)
+        .sink(receiveCompletion: { [weak self] result in
+            if case .failure(let error) = result {
+                switch error {
+                case .codeError(let message):
+                    self?.editErrorMessage.send(message)
+                case .clientError(let code) where code == 400:
+                    self?.editErrorMessage.send("기존의 일정과 시간이 중복됩니다.")
+                default:
+                    self?.editErrorMessage.send("일정 수정에 실패했어요. 잠시 후 다시 시도해주세요.")
                 }
-            }, receiveValue: { [weak self] in
-                self?.isEditSuccess.send(())
-                self?.currentReferenceDate.send(self?.currentReferenceDate.value ?? Date())
-                completion(true)
-            })
-            .store(in: &cancellables)
+                completion(false)
+            }
+        }, receiveValue: { [weak self] in
+            self?.isEditSuccess.send(())
+            self?.currentReferenceDate.send(self?.currentReferenceDate.value ?? Date())
+            completion(true)
+        })
+        .store(in: &cancellables)
     }
 }

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewModel.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/ScheduleViewModel.swift
@@ -122,11 +122,11 @@ final class ScheduleViewModel: BaseViewModel, ViewModelType {
                 let calendar = Calendar.current
                 let now = Date()
                 let currentWeekRange = refDate.daysOfWeek
-                let currentWeekDayIndex = (calendar.component(.weekday, from: now) + 5) % 7
+                _ = (calendar.component(.weekday, from: now) + 5) % 7
 
                 return schedules.filter { schedule in
                     if schedule.isRecurring {
-                        let isViewingCurrentWeek = calendar.isDate(refDate, inSameDayAs: now) ||
+                        _ = calendar.isDate(refDate, inSameDayAs: now) ||
                                                   (currentWeekRange.first! <= now && currentWeekRange.last! >= now)
                         return true
                     } else {

--- a/Kiero/Kiero/Presentation/Schedule/Schedule/TimeTableViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/Schedule/TimeTableViewController.swift
@@ -92,14 +92,14 @@ final class TimeTableViewController: BaseViewController<ScheduleViewModel> {
         viewModel.editErrorMessage
             .receive(on: RunLoop.main)
             .sink { message in
-                Toast.show(message: message)
+                Toast.show(message: message, bottomInset: 88)
             }
             .store(in: &cancellables)
         
         viewModel.isEditSuccess
             .receive(on: RunLoop.main)
             .sink {
-                Toast.show(message: "일정이 수정되었어요.")
+                Toast.show(message: "일정이 수정되었어요.", bottomInset: 88)
             }
             .store(in: &cancellables)
     }
@@ -188,12 +188,12 @@ final class TimeTableViewController: BaseViewController<ScheduleViewModel> {
                 let editVC = AppDIContainer.shared.makeEditScheduleViewController(schedule: schedule)
                 editVC.modalPresentationStyle = .overFullScreen
                 
-                editVC.onEditConfirmed = { [weak self] request, _, completion in
-                    guard let self = self,
-                          let selectedDate = schedule.date else { return }
+                editVC.onEditConfirmed = { [weak self] request, selectedDate, _, completion in
+                    guard let self = self else { return }
                     self.viewModel?.editSchedule(
                         scheduleId: schedule.id,
                         selectedDate: selectedDate,
+                        isRecurring: schedule.isRecurring,
                         request: request,
                         completion: completion
                     )
@@ -221,13 +221,14 @@ final class TimeTableViewController: BaseViewController<ScheduleViewModel> {
                 }
                 dialog.onTapConfirm = { [weak self] in
                     guard let self else { return }
+                    let isIncludeFollowing: Bool = schedule.isRecurring ? dialog.isFollowingSelected : false
                     dialog.dismiss()
                     
                     guard let selectedDate = schedule.date else { return }
-                    let isIncludeFollowing: Bool = schedule.isRecurring ? dialog.isFollowingSelected : false
                     self.viewModel?.deleteSchedule(
                         scheduleId: schedule.id,
                         selectedDate: selectedDate,
+                        isRecurring: schedule.isRecurring,
                         isIncludeFollowing: isIncludeFollowing
                     )
                 }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #280 
<br>

## 🍎 작업 내용
#### 💬 Before
기존에는 일정 수정/삭제 시 반복 여부와 관계없이 selectedDate 하나만 쿼리 파라미터로 전송했고, 
`EditScheduleRequestDTO`에 isRecurring, dayOfWeek, dates, isIncludeFollowing 등의 필드가 포함되어 있었습니다.

#### ⛳️ After
- **수정 API**: 
반복 일정일 경우 selectedDate 대신 해당 주의 startDate/endDate를 쿼리 파라미터로 전송하도록 변경하였습다. `EditScheduleRequestDTO`를 name, startTime, endTime, scheduleColor 4개의 필드로 수정하였습니다.
- **삭제 API**: 
단일 일정은 기존과 동일하게 selectedDate만 전송, 반복 일정은 selectedDate 없이 startDate/endDate를 전송하고 body에 isIncludeFollowing을 포함하도록 변경하였습니다. 또한 단일 일정 삭제 시에는 body를 전송하지 않도록 분기 처리하였습니다.
- `EndPoint`, `ScheduleService`, `ScheduleViewModel`에서 isRecurring(반복) 여부에 따라 쿼리 파라미터를 동적으로 구성하도록 수정하였습니다.
- 그 외 경고 수정 및 토스트 위치 조정의 작업을 진행하였습니다. 
<br>

## 💬 리뷰 코멘트
해당 브랜치로 이동해 단일, 반복 일정을 생성한 뒤 수정/삭제 테스트를 해주시소 〰️
