### PR TITLE
[refactor] #282 SSE 재연결 로직 수정

### DIFF
--- a/Kiero/Kiero/Network/Login/SseStreamManager.swift
+++ b/Kiero/Kiero/Network/Login/SseStreamManager.swift
@@ -478,9 +478,7 @@ final class SseStreamManager {
         let digest = SHA256.hash(data: Data(raw.utf8))
         return digest.map { String(format: "%02x", $0) }.joined()
     }
-    
-    // MARK: - Lock Helper
-    
+
     @discardableResult
     private func withLock<T>(_ work: () -> T) -> T {
         lock.lock()

--- a/Kiero/Kiero/Network/Login/SseStreamManager.swift
+++ b/Kiero/Kiero/Network/Login/SseStreamManager.swift
@@ -31,6 +31,7 @@ final class SseStreamManager {
     
     private var isRunning = false
     private var isRefreshing = false
+    private var isRecoveringActive = false
     
     private var storedOnEvent: EventHandler?
     
@@ -111,6 +112,7 @@ final class SseStreamManager {
             
             isRunning = false
             isRefreshing = false
+            isRecoveringActive = false
             
             return (active, candidate, task)
         }
@@ -198,6 +200,14 @@ final class SseStreamManager {
         token: String,
         onEvent: @escaping EventHandler
     ) {
+        let oldActive = withLock { () -> SseClient? in
+            let old = activeClient
+            activeClient = nil
+            activeClientID = nil
+            return old
+        }
+        oldActive?.disconnect()
+        
         let clientID = UUID()
         
         let client = makeClient(
@@ -283,7 +293,7 @@ final class SseStreamManager {
                 self?.handleConnected(clientID: id, role: role)
             },
             onError: { [weak self] error in
-                self?.handleError(error, clientID: id, role: role)
+                self?.handleError(error, clientID: id, role: role, onEvent: onEvent)
             }
         )
     }
@@ -291,9 +301,21 @@ final class SseStreamManager {
     private func handleConnected(clientID: UUID, role: ClientRole) {
         switch role {
         case .active:
-            let isValid = withLock { activeClientID == clientID && isRunning }
-            guard isValid else { return }
-            print("✅ [SSEManager] active connected")
+            let shouldNotifyReconnect = withLock { () -> Bool in
+                guard activeClientID == clientID, isRunning else { return false }
+                
+                let wasRecovering = isRecoveringActive
+                isRecoveringActive = false
+                
+                print("✅ [SSEManager] active connected")
+                return wasRecovering
+            }
+            
+            if shouldNotifyReconnect {
+                DispatchQueue.main.async { [weak self] in
+                    self?.onReconnected?()
+                }
+            }
             
         case .candidate:
             let previousActive: SseClient? = withLock {
@@ -326,14 +348,47 @@ final class SseStreamManager {
     private func handleError(
         _ error: Error,
         clientID: UUID,
-        role: ClientRole
+        role: ClientRole,
+        onEvent: @escaping EventHandler
     ) {
         print("❌ [SSEManager] \(role) error:", error)
         
         switch role {
         case .active:
-            let isValid = withLock { activeClientID == clientID }
-            guard isValid else { return }
+            let recoveryContext: ActiveRecoveryContext? = withLock {
+                guard activeClientID == clientID else { return nil }
+                guard isRunning else { return nil }
+                
+                if isRefreshing {
+                    print("⚠️ [SSEManager] active error while refresh in progress, skip immediate recovery")
+                    return nil
+                }
+                
+                if isRecoveringActive {
+                    print("⚠️ [SSEManager] active recovery already in progress")
+                    return nil
+                }
+                
+                isRecoveringActive = true
+                
+                let currentToken = sseAccessToken
+                let oldActive = activeClient
+                activeClient = nil
+                activeClientID = nil
+                
+                return ActiveRecoveryContext(
+                    currentToken: currentToken,
+                    onEvent: onEvent,
+                    oldClient: oldActive
+                )
+            }
+            
+            guard let recoveryContext else { return }
+            recoveryContext.oldClient?.disconnect()
+            
+            Task { [weak self] in
+                await self?.recoverActiveConnection(using: recoveryContext)
+            }
         case .candidate:
             let candidateToDisconnect: SseClient? = withLock {
                 guard candidateClientID == clientID else { return nil }
@@ -348,6 +403,52 @@ final class SseStreamManager {
             
             candidateToDisconnect?.disconnect()
             print("⚠️ [SSEManager] candidate failed, keep existing active connection")
+        }
+    }
+
+    private func recoverActiveConnection(using context: ActiveRecoveryContext) async {
+        guard let onEvent = context.onEvent else {
+            withLock { isRecoveringActive = false }
+            return
+        }
+        
+        if let currentToken = context.currentToken, !currentToken.isEmpty {
+            let shouldReconnect = withLock { () -> Bool in
+                guard isRunning else {
+                    isRecoveringActive = false
+                    return false
+                }
+                return true
+            }
+            
+            if shouldReconnect {
+                print("🔄 [SSEManager] recover active with existing token")
+                connectActive(token: currentToken, onEvent: onEvent)
+                return
+            }
+        }
+        
+        do {
+            print("🔄 [SSEManager] recover active with reissued token")
+            let newToken = try await TokenRefresher.shared.reissueSseAccessToken()
+            
+            let shouldReconnect = withLock { () -> Bool in
+                guard isRunning else {
+                    isRecoveringActive = false
+                    return false
+                }
+                
+                sseAccessToken = newToken
+                return true
+            }
+            
+            guard shouldReconnect else { return }
+            connectActive(token: newToken, onEvent: onEvent)
+        } catch {
+            withLock {
+                isRecoveringActive = false
+            }
+            print("❌ [SSEManager] active recovery failed:", error)
         }
     }
 
@@ -377,7 +478,9 @@ final class SseStreamManager {
         let digest = SHA256.hash(data: Data(raw.utf8))
         return digest.map { String(format: "%02x", $0) }.joined()
     }
-
+    
+    // MARK: - Lock Helper
+    
     @discardableResult
     private func withLock<T>(_ work: () -> T) -> T {
         lock.lock()
@@ -397,5 +500,11 @@ private extension SseStreamManager {
             case .candidate: return "candidate"
             }
         }
+    }
+    
+    struct ActiveRecoveryContext {
+        let currentToken: String?
+        let onEvent: EventHandler?
+        let oldClient: SseClient?
     }
 }

--- a/Kiero/Kiero/Network/Login/SseStreamManager.swift
+++ b/Kiero/Kiero/Network/Login/SseStreamManager.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
+import CryptoKit
+
 final class SseStreamManager {
+    
+    typealias EventHandler = (SseEventPayload) -> Void
     
     var onRefreshWillStart: (() -> Void)?
     var onReconnected: (() -> Void)?
@@ -15,137 +19,384 @@ final class SseStreamManager {
     static let shared = SseStreamManager(sseURL: Config.sseURL)
     
     private let sseURL: URL
-    private var client: SseClient?
+    private let lock = NSLock()
+    
+    private var activeClient: SseClient?
+    private var candidateClient: SseClient?
+    
+    private var activeClientID: UUID?
+    private var candidateClientID: UUID?
     
     private var sseAccessToken: String?
     private var refreshTask: Task<Void, Never>?
-    private var isRunning = false
     
-    private var isConnecting = false
-    private var storedOnEvent: ((SseEventPayload) -> Void)?
+    private var isRunning = false
+    private var isRefreshing = false
+    
+    private var storedOnEvent: EventHandler?
+    
+    private var recentEventHashes: [String: Date] = [:]
+    private let dedupeWindow: TimeInterval = 10
+    private let refreshIntervalNanoseconds: UInt64 = 270 * 1_000_000_000
     
     init(sseURL: URL) {
         self.sseURL = sseURL
     }
     
-    /// 최초 토큰으로 즉시 연결 + 이후 5분마다 토큰 재발급/재연결
     func startIfNeeded(
         initialToken: String,
-        onEvent: @escaping (SseEventPayload) -> Void
+        onEvent: @escaping EventHandler
     ) {
-        print("✅ [SSEManager] startIfNeeded called, isRunning:", isRunning)
-        guard !isRunning else {
-            print("⚠️ [SSEManager] already running")
-            return
-        }
-        isRunning = true
-        sseAccessToken = initialToken
-        storedOnEvent = onEvent
-        
-        // 최초 연결
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            print("✅ [SSEManager] connect() will be called (initial)")
-            self.connect(onEvent: onEvent)
-        }
-        
-        // 5분마다 토큰 갱신 + 재연결
-        refreshTask?.cancel()
-        refreshTask = Task { [weak self] in
-            guard let self else { return }
+        let shouldStart: Bool = withLock {
+            guard !isRunning else {
+                print("⚠️ [SSEManager] already running")
+                return false
+            }
             
-            while !Task.isCancelled {
-                // ✅ 서버 스펙: 5분마다 재발급 필요
-                try? await Task.sleep(nanoseconds: 5 * 60 * 1_000_000_000)
-                
-                // ✅ (3번 방식) 재발급 시작 훅 — “공백 중 이벤트 유실” 대비 조회를 여기서 1회
-                self.onRefreshWillStart?()
-                
-                do {
-                    let newToken = try await TokenRefresher.shared.reissueSseAccessToken()
-                    self.sseAccessToken = newToken
-                    
-                    await MainActor.run { [weak self] in
-                        guard let self else { return }
-                        print("✅ [SSEManager] connect() will be called (refresh)")
-                        self.connect(onEvent: onEvent)
-                    }
-                } catch {
-                    // 재발급 실패 정책: 로그/재시도/stop 등
-                    // 여기서는 다음 루프에서 다시 시도
-                    print("❌ [SSEManager] refresh token failed:", error)
-                }
-            }
+            isRunning = true
+            sseAccessToken = initialToken
+            storedOnEvent = onEvent
+            return true
         }
-    }
-    
-    @MainActor
-    private func connect(onEvent: @escaping (SseEventPayload) -> Void) {
-        guard isRunning else { return }
-        guard isConnecting == false else {
-            print("⚠️ [SSEManager] connect skipped (already connecting)")
-            return
-        }
-        isConnecting = true
-
-        client?.disconnect()
-
-        client = SseClient(
-            url: sseURL,
-            tokenProvider: { [weak self] in
-                return self?.sseAccessToken
-            },
-            onEvent: { payload in
-                NotificationCenter.default.post(
-                    name: .sseEventReceived,
-                    object: nil,
-                    userInfo: ["payload": payload]
-                )
-                onEvent(payload)
-            },
-            onConnected: { [weak self] in
-                guard let self else { return }
-                print("✅ [SSEManager] onConnected -> onReconnected")
-                self.onReconnected?()
-                self.isConnecting = false
-            },
-            onError: { [weak self] error in
-                print("❌ [SSEClient] error:", error)
-                self?.isConnecting = false
-            }
-        )
-
-        client?.connect()
+        
+        guard shouldStart else { return }
+        
+        print("✅ [SSEManager] startIfNeeded")
+        connectActive(token: initialToken, onEvent: onEvent)
+        startRefreshLoop(onEvent: onEvent)
     }
     
     func resume() {
-        guard !isRunning, let onEvent = storedOnEvent else { return }
-        isRunning = true
-
-        Task {
+        let onEvent: EventHandler? = withLock {
+            guard !isRunning else { return nil }
+            guard let storedOnEvent else { return nil }
+            isRunning = true
+            return storedOnEvent
+        }
+        
+        guard let onEvent else { return }
+        
+        Task { [weak self] in
+            guard let self else { return }
+            
             do {
                 let newToken = try await TokenRefresher.shared.reissueSseAccessToken()
-                self.sseAccessToken = newToken
-                await MainActor.run { [weak self] in
-                    self?.connect(onEvent: onEvent)
+                
+                let shouldProceed = self.withLock { () -> Bool in
+                    guard self.isRunning else { return false }
+                    self.sseAccessToken = newToken
+                    return true
                 }
+                
+                guard shouldProceed else { return }
+                
+                self.connectActive(token: newToken, onEvent: onEvent)
+                self.startRefreshLoop(onEvent: onEvent)
             } catch {
                 print("❌ [SSEManager] resume failed:", error)
             }
         }
     }
-
+    
     func pause() {
-        client?.disconnect()
-        client = nil
-        isRunning = false
-        isConnecting = false
+        let clients = withLock { () -> (SseClient?, SseClient?, Task<Void, Never>?) in
+            let active = activeClient
+            let candidate = candidateClient
+            let task = refreshTask
+            
+            activeClient = nil
+            candidateClient = nil
+            activeClientID = nil
+            candidateClientID = nil
+            refreshTask = nil
+            
+            isRunning = false
+            isRefreshing = false
+            
+            return (active, candidate, task)
+        }
+        
+        clients.0?.disconnect()
+        clients.1?.disconnect()
+        clients.2?.cancel()
     }
     
     func stop() {
         pause()
-        refreshTask?.cancel()
-        refreshTask = nil
-        sseAccessToken = nil
+        
+        withLock {
+            sseAccessToken = nil
+            recentEventHashes.removeAll()
+        }
+    }
+    
+    private func startRefreshLoop(onEvent: @escaping EventHandler) {
+        let oldTask = withLock { () -> Task<Void, Never>? in
+            let old = refreshTask
+            refreshTask = nil
+            return old
+        }
+        oldTask?.cancel()
+        
+        let task = Task { [weak self] in
+            guard let self else { return }
+            
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(nanoseconds: self.refreshIntervalNanoseconds)
+                } catch {
+                    return
+                }
+                
+                let canRefresh = self.withLock { () -> Bool in
+                    guard self.isRunning else { return false }
+                    guard self.isRefreshing == false else {
+                        print("⚠️ [SSEManager] refresh skipped (already refreshing)")
+                        return false
+                    }
+                    
+                    self.isRefreshing = true
+                    return true
+                }
+                
+                guard canRefresh else { continue }
+                
+                DispatchQueue.main.async { [weak self] in
+                    self?.onRefreshWillStart?()
+                }
+                
+                do {
+                    let newToken = try await TokenRefresher.shared.reissueSseAccessToken()
+                    
+                    let shouldProceed = self.withLock { () -> Bool in
+                        guard self.isRunning else {
+                            self.isRefreshing = false
+                            return false
+                        }
+                        
+                        self.sseAccessToken = newToken
+                        return true
+                    }
+                    
+                    guard shouldProceed else { continue }
+                    
+                    self.connectCandidate(token: newToken, onEvent: onEvent)
+                } catch {
+                    self.withLock {
+                        self.isRefreshing = false
+                    }
+                    print("❌ [SSEManager] refresh token failed:", error)
+                }
+            }
+        }
+        
+        withLock {
+            refreshTask = task
+        }
+    }
+    
+    private func connectActive(
+        token: String,
+        onEvent: @escaping EventHandler
+    ) {
+        let clientID = UUID()
+        
+        let client = makeClient(
+            id: clientID,
+            token: token,
+            role: .active,
+            onEvent: onEvent
+        )
+        
+        withLock {
+            activeClientID = clientID
+            activeClient = client
+        }
+        
+        client.connect()
+    }
+    
+    private func connectCandidate(
+        token: String,
+        onEvent: @escaping EventHandler
+    ) {
+        let oldCandidate = withLock { () -> SseClient? in
+            guard isRunning else {
+                isRefreshing = false
+                return nil
+            }
+            
+            let old = candidateClient
+            candidateClient = nil
+            candidateClientID = nil
+            return old
+        }
+        oldCandidate?.disconnect()
+        
+        let clientID = UUID()
+        let client = makeClient(
+            id: clientID,
+            token: token,
+            role: .candidate,
+            onEvent: onEvent
+        )
+        
+        withLock {
+            guard isRunning else {
+                isRefreshing = false
+                return
+            }
+            
+            candidateClientID = clientID
+            candidateClient = client
+        }
+        
+        client.connect()
+    }
+    
+    private func makeClient(
+        id: UUID,
+        token: String,
+        role: ClientRole,
+        onEvent: @escaping EventHandler
+    ) -> SseClient {
+        SseClient(
+            url: sseURL,
+            tokenProvider: { token },
+            onEvent: { [weak self] payload in
+                guard let self else { return }
+                
+                if self.shouldSkipDuplicateEvent(payload) {
+                    print("⚠️ [SSEManager] duplicate event skipped")
+                    return
+                }
+                
+                DispatchQueue.main.async {
+                    NotificationCenter.default.post(
+                        name: .sseEventReceived,
+                        object: nil,
+                        userInfo: ["payload": payload]
+                    )
+                    onEvent(payload)
+                }
+            },
+            onConnected: { [weak self] in
+                self?.handleConnected(clientID: id, role: role)
+            },
+            onError: { [weak self] error in
+                self?.handleError(error, clientID: id, role: role)
+            }
+        )
+    }
+    
+    private func handleConnected(clientID: UUID, role: ClientRole) {
+        switch role {
+        case .active:
+            let isValid = withLock { activeClientID == clientID && isRunning }
+            guard isValid else { return }
+            print("✅ [SSEManager] active connected")
+            
+        case .candidate:
+            let previousActive: SseClient? = withLock {
+                guard isRunning else { return nil }
+                guard candidateClientID == clientID else { return nil }
+                
+                print("✅ [SSEManager] candidate connected -> promote to active")
+                
+                let oldActive = activeClient
+                activeClient = candidateClient
+                activeClientID = candidateClientID
+                
+                candidateClient = nil
+                candidateClientID = nil
+                isRefreshing = false
+                
+                return oldActive
+            }
+            
+            guard previousActive != nil else { return }
+            
+            previousActive?.disconnect()
+            
+            DispatchQueue.main.async { [weak self] in
+                self?.onReconnected?()
+            }
+        }
+    }
+    
+    private func handleError(
+        _ error: Error,
+        clientID: UUID,
+        role: ClientRole
+    ) {
+        print("❌ [SSEManager] \(role) error:", error)
+        
+        switch role {
+        case .active:
+            let isValid = withLock { activeClientID == clientID }
+            guard isValid else { return }
+        case .candidate:
+            let candidateToDisconnect: SseClient? = withLock {
+                guard candidateClientID == clientID else { return nil }
+                
+                let client = candidateClient
+                candidateClient = nil
+                candidateClientID = nil
+                isRefreshing = false
+                
+                return client
+            }
+            
+            candidateToDisconnect?.disconnect()
+            print("⚠️ [SSEManager] candidate failed, keep existing active connection")
+        }
+    }
+
+    private func shouldSkipDuplicateEvent(_ payload: SseEventPayload) -> Bool {
+        withLock {
+            cleanupExpiredEventHashesLocked()
+            
+            let hash = makeEventHash(from: payload)
+            if recentEventHashes[hash] != nil {
+                return true
+            }
+            
+            recentEventHashes[hash] = Date()
+            return false
+        }
+    }
+    
+    private func cleanupExpiredEventHashesLocked() {
+        let now = Date()
+        recentEventHashes = recentEventHashes.filter {
+            now.timeIntervalSince($0.value) < dedupeWindow
+        }
+    }
+    
+    private func makeEventHash(from payload: SseEventPayload) -> String {
+        let raw = String(describing: payload)
+        let digest = SHA256.hash(data: Data(raw.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    @discardableResult
+    private func withLock<T>(_ work: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return work()
+    }
+}
+
+private extension SseStreamManager {
+    enum ClientRole: CustomStringConvertible {
+        case active
+        case candidate
+        
+        var description: String {
+            switch self {
+            case .active: return "active"
+            case .candidate: return "candidate"
+            }
+        }
     }
 }

--- a/Kiero/Kiero/Network/Login/SseStreamManager.swift
+++ b/Kiero/Kiero/Network/Login/SseStreamManager.swift
@@ -5,9 +5,8 @@
 //  Created by 안치욱 on 1/22/26.
 //
 
-import Foundation
-
 import CryptoKit
+import Foundation
 
 final class SseStreamManager {
     

--- a/Kiero/Kiero/Network/Login/SseStreamManager.swift
+++ b/Kiero/Kiero/Network/Login/SseStreamManager.swift
@@ -166,27 +166,51 @@ final class SseStreamManager {
                     self?.onRefreshWillStart?()
                 }
                 
-                do {
-                    let newToken = try await TokenRefresher.shared.reissueSseAccessToken()
-                    
-                    let shouldProceed = self.withLock { () -> Bool in
-                        guard self.isRunning else {
-                            self.isRefreshing = false
-                            return false
+                let retryDelays: [UInt64] = [
+                    0,
+                    3 * 1_000_000_000,
+                    5 * 1_000_000_000
+                ]
+                
+                var refreshed = false
+                
+                for (index, delay) in retryDelays.enumerated() {
+                    if delay > 0 {
+                        do {
+                            try await Task.sleep(nanoseconds: delay)
+                        } catch {
+                            return
                         }
-                        
-                        self.sseAccessToken = newToken
-                        return true
                     }
                     
-                    guard shouldProceed else { continue }
-                    
-                    self.connectCandidate(token: newToken, onEvent: onEvent)
-                } catch {
+                    do {
+                        let newToken = try await TokenRefresher.shared.reissueSseAccessToken()
+                        
+                        let shouldProceed = self.withLock { () -> Bool in
+                            guard self.isRunning else {
+                                self.isRefreshing = false
+                                return false
+                            }
+                            
+                            self.sseAccessToken = newToken
+                            return true
+                        }
+                        
+                        guard shouldProceed else { break }
+                        
+                        self.connectCandidate(token: newToken, onEvent: onEvent)
+                        refreshed = true
+                        break
+                    } catch {
+                        print("❌ [SSEManager] refresh retry \(index + 1) failed:", error)
+                    }
+                }
+                
+                if !refreshed {
                     self.withLock {
                         self.isRefreshing = false
                     }
-                    print("❌ [SSEManager] refresh token failed:", error)
+                    print("❌ [SSEManager] refresh failed after retries")
                 }
             }
         }
@@ -405,7 +429,7 @@ final class SseStreamManager {
             print("⚠️ [SSEManager] candidate failed, keep existing active connection")
         }
     }
-
+    
     private func recoverActiveConnection(using context: ActiveRecoveryContext) async {
         guard let onEvent = context.onEvent else {
             withLock { isRecoveringActive = false }
@@ -451,7 +475,7 @@ final class SseStreamManager {
             print("❌ [SSEManager] active recovery failed:", error)
         }
     }
-
+    
     private func shouldSkipDuplicateEvent(_ payload: SseEventPayload) -> Bool {
         withLock {
             cleanupExpiredEventHashesLocked()
@@ -478,7 +502,7 @@ final class SseStreamManager {
         let digest = SHA256.hash(data: Data(raw.utf8))
         return digest.map { String(format: "%02x", $0) }.joined()
     }
-
+    
     @discardableResult
     private func withLock<T>(_ work: () -> T) -> T {
         lock.lock()


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #282 
<br>

## 🍎 작업 내용
메인 기능

기존 SSE 구조는 토큰 만료(5분 주기)에 맞춰
1. 토큰 재발급
2. 기존 SSE 연결 종료
3. 새로운 SSE 연결 생성
순으로 동작했습니다.

이 방식은 연결이 교체되는 순간 공백이 발생하고, 해당 구간에서 이벤트가 발생할 경우 이벤트 유실 가능성이 존재했습니다.

이에 킹 민성님께서 이를 해결하기 위해 Connection Overlap(무중단 교체) 방식을 도입하셨습니다.

변경된 흐름
1. 토큰 만료 이전(4분 30초)에 미리 재발급
2. 기존 연결(active)을 유지한 상태에서
3. 새 토큰으로 candidate SSE 연결 생성
4. candidate 연결이 정상적으로 수립되면
5. 그 시점에 기존 active 연결 종료

이를 통해 연결 공백 없이 SSE를 교체하도록 개선했습니다.

그리고 4분 30초 쯤에 sseManager가 동시에 접근되므로 NSLock 기반 withLock이라는 함수를 통해서 동시성을 제어햇습니다
<br>

## 💬 리뷰 코멘트

SSE So Difficult..
