### PR TITLE
[hotfix] #285 Popup 로직 변경

### DIFF
--- a/Kiero/Kiero/Presentation/TodayStatus/TodayStatusHostingController.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/TodayStatusHostingController.swift
@@ -18,7 +18,8 @@ final class TodayStatusHostingController: UIHostingController<TodayStatusView> {
         super.init(
             rootView: TodayStatusView(
                 viewModel: viewModel,
-                onMissionSheetRequested: { _ in }
+                onMissionSheetRequested: { _ in },
+                onScheduleOverlayRequested: { _ in }
             )
         )
         
@@ -26,6 +27,9 @@ final class TodayStatusHostingController: UIHostingController<TodayStatusView> {
             viewModel: viewModel,
             onMissionSheetRequested: { [weak self] selectedTab in
                 self?.presentMissionBottomSheet(selectedTab: selectedTab)
+            },
+            onScheduleOverlayRequested: { [weak self] schedule in
+                self?.presentScheduleImageOverlay(for: schedule)
             }
         )
     }
@@ -66,6 +70,21 @@ private extension TodayStatusHostingController {
         vc.view.backgroundColor = .clear
         vc.modalPresentationStyle = .overFullScreen
         vc.modalTransitionStyle = .crossDissolve
+        
+        present(vc, animated: false)
+    }
+    
+    func presentScheduleImageOverlay(for schedule: ScheduleItem) {
+        NotificationCenter.default.post(name: .dimNavigationBar, object: true)
+        
+        let overlayView = ScheduleImageOverlayContainerView(
+            schedule: schedule,
+            viewModel: viewModel
+        )
+        
+        let vc = UIHostingController(rootView: overlayView)
+        vc.view.backgroundColor = .clear
+        vc.modalPresentationStyle = .overFullScreen
         
         present(vc, animated: false)
     }

--- a/Kiero/Kiero/Presentation/TodayStatus/TodayStatusView.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/TodayStatusView.swift
@@ -17,16 +17,13 @@ struct TodayStatusView: View {
     @ObservedObject var viewModel: TodayStatusViewModel
     
     let onMissionSheetRequested: (MissionTab) -> Void
-    
-    @State private var selectedSchedule: ScheduleItem?
+    let onScheduleOverlayRequested: (ScheduleItem) -> Void
     
     var body: some View {
         ZStack {
             backgroundView
             mainContent
-            popupOverlay
         }
-        .animation(.easeInOut(duration: 0.25), value: selectedSchedule != nil)
     }
 }
 
@@ -54,41 +51,13 @@ private extension TodayStatusView {
                     schedules: viewModel.schedules,
                     isFireLitToday: viewModel.isFireLitToday,
                     onTapSchedule: { schedule in
-                        selectedSchedule = schedule
-                        viewModel.didTapScheduleCard(schedule)
+                        onScheduleOverlayRequested(schedule)
                     }
                 )
                 .padding(.top, 18)
                 .padding(.bottom, 100)
             }
             .scrollIndicators(.hidden)
-        }
-        .onChange(of: selectedSchedule != nil) { value in
-            NotificationCenter.default.post(name: .dimNavigationBar, object: value)
-        }
-    }
-    
-    @ViewBuilder
-    var popupOverlay: some View {
-        if let selectedSchedule {
-            Color.kBlack.opacity(0.75)
-                .ignoresSafeArea()
-                .onTapGesture {
-                    self.selectedSchedule = nil
-                    viewModel.selectedScheduleImageURL = nil
-                }
-            
-            ScheduleImageOverlayView(
-                title: selectedSchedule.title,
-                imageURL: viewModel.selectedScheduleImageURL,
-                onClose: {
-                    self.selectedSchedule = nil
-                    viewModel.selectedScheduleImageURL = nil
-                }
-            )
-            .padding(.horizontal, 16)
-            .transition(.scale.combined(with: .opacity))
-            .zIndex(2)
         }
     }
     

--- a/Kiero/Kiero/Presentation/TodayStatus/View/ScheduleImageOverlayContainerView.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/View/ScheduleImageOverlayContainerView.swift
@@ -1,0 +1,61 @@
+//
+//  ScheduleImageOverlayContainerView.swift
+//  Kiero
+//
+//  Created by 안치욱 on 4/15/26.
+//
+
+import SwiftUI
+
+struct ScheduleImageOverlayContainerView: View {
+    
+    @Environment(\.dismiss) private var dismiss
+    
+    let schedule: ScheduleItem
+    @ObservedObject var viewModel: TodayStatusViewModel
+    
+    @State private var isVisible = false
+    
+    var body: some View {
+        ZStack {
+            Color.kBlack.opacity(isVisible ? 0.75 : 0)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    close()
+                }
+            
+            ScheduleImageOverlayView(
+                title: schedule.title,
+                imageURL: viewModel.selectedScheduleImageURL,
+                onClose: {
+                    close()
+                }
+            )
+            .padding(.horizontal, 16)
+            .scaleEffect(isVisible ? 1.0 : 0.96)
+            .opacity(isVisible ? 1.0 : 0.0)
+        }
+        .onAppear {
+            viewModel.didTapScheduleCard(schedule)
+            
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isVisible = true
+            }
+        }
+        .onDisappear {
+            viewModel.selectedScheduleImageURL = nil
+        }
+    }
+    
+    private func close() {
+        withAnimation(.easeInOut(duration: 0.18)) {
+            isVisible = false
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+            NotificationCenter.default.post(name: .dimNavigationBar, object: false)
+            viewModel.selectedScheduleImageURL = nil
+            dismiss()
+        }
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #284 
<br>

## 🍎 작업 내용
메인 기능

1차 스프린트 리팩토링 과정에서 View 계층이 SwiftUI + UIKit 혼용 구조로 구성되어 있었고, 특히 커스텀 TabBar + NavigationBar를 통합하는 과정에서 해당 UI들이 최상위 계층으로 고정되는 문제가 발생했습니다.

이로 인해 SwiftUI View 내부에서 .overlay, ZStack 등을 활용해 popup을 띄울 경우 TabBar / NavigationBar보다 아래 계층에 렌더링되는 이슈가 있었습니다.

기존에는 SwiftUI View 내부에서 직접 popup을 띄우는 구조였습니다.

SwiftUI View에서 직접 popup을 띄우는 대신, ContainerView로 감싼 후 UIKit 방식으로 present하도록 구조를 변경했습니다.
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 기능1 | <img src="https://github.com/user-attachments/assets/08eadc70-c20e-49e2-9260-e9a2b4bca595" width="250"> |

<br>

## 💬 리뷰 코멘트
어렵네요 스유와 유킷의 콜라보레이션은..
