### PR TITLE
[hotfix] #286 소원 박스 제목 잘림 수정

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/WishBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/WishBox.swift
@@ -44,7 +44,7 @@ final class WishBox: UIView {
     private let wishBox = UIStackView().then {
         $0.axis = .vertical
         $0.alignment = .fill
-        $0.spacing = 14
+        $0.spacing = 12
     }
     
     override init(frame: CGRect) {

--- a/Kiero/Kiero/Presentation/WishWell/WishWellViewController.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellViewController.swift
@@ -108,7 +108,7 @@ extension WishWellViewController: UICollectionViewDataSource {
 extension WishWellViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let width = (collectionView.bounds.width - (16 * 2) - 13) / 2
-        return CGSize(width: width, height: 113)
+        return CGSize(width: width, height: 116)
     }
 }
 


### PR DESCRIPTION
## 📟 연결된 이슈
closed #286 
<br>

## 🍎 작업 내용
소원의 우물 뷰에서 g와 같은 긴 글자가 제목에 들어올 시 밑 부분이 잘리게 되는 이슈가 있었습니다. 
디자인 확인 후 전체 크기를 113->116으로 수정하고 titleLabel과 completeButton 사이 패딩도 12로 조정하였습니다.  
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 기능1 | <img width="250" alt="Simulator Screenshot - iPhone 12 - 2026-04-18 at 00 57 22" src="https://github.com/user-attachments/assets/29c7f00a-e946-4b49-a6cf-9cb794c3576a" />|
<br>
