### PR TITLE
[hotfix] #287 오늘의 현황 인증 사진 확인 시 red dot 로직 변경

### DIFF
--- a/Kiero/Kiero/Network/NotificationFeed/NotificationBadgeCenter.swift
+++ b/Kiero/Kiero/Network/NotificationFeed/NotificationBadgeCenter.swift
@@ -10,15 +10,16 @@ import Foundation
 
 extension Notification.Name {
     static let feedItemCreated = Notification.Name("feedItemCreated")
-    static let sseEventReceived = Notification.Name("sseEventReceived") 
+    static let sseEventReceived = Notification.Name("sseEventReceived")
+    static let refreshUnreadBadge = Notification.Name("refreshUnreadBadge")
 }
 
 final class NotificationBadgeCenter {
     static let shared = NotificationBadgeCenter()
     private init() {}
-
+    
     let hasUnreadSubject = CurrentValueSubject<Bool, Never>(false)
-
+    
     func setUnread(_ value: Bool) {
         hasUnreadSubject.send(value)
     }

--- a/Kiero/Kiero/Network/NotificationFeed/NotificationFeedDTO.swift
+++ b/Kiero/Kiero/Network/NotificationFeed/NotificationFeedDTO.swift
@@ -33,8 +33,8 @@ struct FeedMetadataDTO: Decodable {
 }
 
 struct UnreadNotificationDTO: Decodable {
-    let unreadChildIds: [Int]
     let hasUnread: Bool
+    let unreadChildIds: [Int]
 }
 
 extension FeedResponseDTO {

--- a/Kiero/Kiero/Network/NotificationFeed/NotificationFeedDTO.swift
+++ b/Kiero/Kiero/Network/NotificationFeed/NotificationFeedDTO.swift
@@ -33,8 +33,8 @@ struct FeedMetadataDTO: Decodable {
 }
 
 struct UnreadNotificationDTO: Decodable {
-    let hasUnread: Bool
     let unreadChildIds: [Int]
+    let hasUnread: Bool
 }
 
 extension FeedResponseDTO {

--- a/Kiero/Kiero/Network/NotificationFeed/NotificationFeedService.swift
+++ b/Kiero/Kiero/Network/NotificationFeed/NotificationFeedService.swift
@@ -34,18 +34,12 @@ final class FeedService: FeedServiceType {
     
     func fetchUnreadFeed() -> AnyPublisher<UnreadNotificationDTO, NetworkError> {
         let endPoint = EndPoint.fetchUnreadFeed
-
+        
         return Future<UnreadNotificationDTO, NetworkError> { promise in
             Task {
                 do {
-                    let response: BaseResponse<UnreadNotificationDTO> = try await BaseService.shared.request(endPoint: endPoint)
-
-                    guard let data = response.data else {
-                        promise(.failure(.unknownError))
-                        return
-                    }
-
-                    promise(.success(data))
+                    let response: UnreadNotificationDTO = try await BaseService.shared.request(endPoint: endPoint)
+                    promise(.success(response))
                 } catch let error as NetworkError {
                     promise(.failure(error))
                 } catch {

--- a/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
+++ b/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
@@ -247,6 +247,13 @@ private extension TabBarViewController {
             name: .hideNavigationBar,
             object: nil
         )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleRefreshUnreadBadge(_:)),
+            name: .refreshUnreadBadge,
+            object: nil
+        )
     }
     
     func updateCustomTabBarSelection() {
@@ -351,6 +358,11 @@ private extension TabBarViewController {
             self.customNavigationBar.isUserInteractionEnabled = !isHidden
         }
     }
+    
+    @objc
+    private func handleRefreshUnreadBadge(_ notification: Notification) {
+        fetchInitialUnreadStatus()
+    }
 }
 
 // MARK: - UITabBarControllerDelegate
@@ -444,6 +456,8 @@ private extension TabBarViewController {
                 guard let self else { return }
                 self.hasUnreadNotification = hasUnread
                 self.customNavigationBar.isNotificationActive = hasUnread
+                
+                self.updateNavigationBar()
             }
             .store(in: &cancellables)
     }

--- a/Kiero/Kiero/Presentation/TodayStatus/TodayStatusHostingController.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/TodayStatusHostingController.swift
@@ -18,7 +18,8 @@ final class TodayStatusHostingController: UIHostingController<TodayStatusView> {
         super.init(
             rootView: TodayStatusView(
                 viewModel: viewModel,
-                onMissionSheetRequested: { _ in }
+                onMissionSheetRequested: { _ in },
+                onScheduleOverlayRequested: { _ in }
             )
         )
         
@@ -26,6 +27,9 @@ final class TodayStatusHostingController: UIHostingController<TodayStatusView> {
             viewModel: viewModel,
             onMissionSheetRequested: { [weak self] selectedTab in
                 self?.presentMissionBottomSheet(selectedTab: selectedTab)
+            },
+            onScheduleOverlayRequested: { [weak self] schedule in
+                self?.presentScheduleImageOverlay(for: schedule)
             }
         )
     }
@@ -66,6 +70,21 @@ private extension TodayStatusHostingController {
         vc.view.backgroundColor = .clear
         vc.modalPresentationStyle = .overFullScreen
         vc.modalTransitionStyle = .crossDissolve
+        
+        present(vc, animated: false)
+    }
+    
+    func presentScheduleImageOverlay(for schedule: ScheduleItem) {
+        NotificationCenter.default.post(name: .dimNavigationBar, object: true)
+        
+        let overlayView = ScheduleImageOverlayContainerView(
+            schedule: schedule,
+            viewModel: viewModel
+        )
+        
+        let vc = UIHostingController(rootView: overlayView)
+        vc.view.backgroundColor = .clear
+        vc.modalPresentationStyle = .overFullScreen
         
         present(vc, animated: false)
     }

--- a/Kiero/Kiero/Presentation/TodayStatus/TodayStatusView.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/TodayStatusView.swift
@@ -17,16 +17,13 @@ struct TodayStatusView: View {
     @ObservedObject var viewModel: TodayStatusViewModel
     
     let onMissionSheetRequested: (MissionTab) -> Void
-    
-    @State private var selectedSchedule: ScheduleItem?
+    let onScheduleOverlayRequested: (ScheduleItem) -> Void
     
     var body: some View {
         ZStack {
             backgroundView
             mainContent
-            popupOverlay
         }
-        .animation(.easeInOut(duration: 0.25), value: selectedSchedule != nil)
     }
 }
 
@@ -54,41 +51,13 @@ private extension TodayStatusView {
                     schedules: viewModel.schedules,
                     isFireLitToday: viewModel.isFireLitToday,
                     onTapSchedule: { schedule in
-                        selectedSchedule = schedule
-                        viewModel.didTapScheduleCard(schedule)
+                        onScheduleOverlayRequested(schedule)
                     }
                 )
                 .padding(.top, 18)
                 .padding(.bottom, 100)
             }
             .scrollIndicators(.hidden)
-        }
-        .onChange(of: selectedSchedule != nil) { value in
-            NotificationCenter.default.post(name: .dimNavigationBar, object: value)
-        }
-    }
-    
-    @ViewBuilder
-    var popupOverlay: some View {
-        if let selectedSchedule {
-            Color.kBlack.opacity(0.75)
-                .ignoresSafeArea()
-                .onTapGesture {
-                    self.selectedSchedule = nil
-                    viewModel.selectedScheduleImageURL = nil
-                }
-            
-            ScheduleImageOverlayView(
-                title: selectedSchedule.title,
-                imageURL: viewModel.selectedScheduleImageURL,
-                onClose: {
-                    self.selectedSchedule = nil
-                    viewModel.selectedScheduleImageURL = nil
-                }
-            )
-            .padding(.horizontal, 16)
-            .transition(.scale.combined(with: .opacity))
-            .zIndex(2)
         }
     }
     

--- a/Kiero/Kiero/Presentation/TodayStatus/TodayStatusViewModel.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/TodayStatusViewModel.swift
@@ -90,6 +90,7 @@ final class TodayStatusViewModel: BaseViewModel, ObservableObject {
                 }
                 
                 self.selectedScheduleImageURL = url
+                NotificationCenter.default.post(name: .refreshUnreadBadge, object: nil)
             }
             .store(in: &cancellables)
     }

--- a/Kiero/Kiero/Presentation/TodayStatus/View/ScheduleImageOverlayContainerView.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/View/ScheduleImageOverlayContainerView.swift
@@ -1,0 +1,61 @@
+//
+//  ScheduleImageOverlayContainerView.swift
+//  Kiero
+//
+//  Created by 안치욱 on 4/15/26.
+//
+
+import SwiftUI
+
+struct ScheduleImageOverlayContainerView: View {
+    
+    @Environment(\.dismiss) private var dismiss
+    
+    let schedule: ScheduleItem
+    @ObservedObject var viewModel: TodayStatusViewModel
+    
+    @State private var isVisible = false
+    
+    var body: some View {
+        ZStack {
+            Color.kBlack.opacity(isVisible ? 0.75 : 0)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    close()
+                }
+            
+            ScheduleImageOverlayView(
+                title: schedule.title,
+                imageURL: viewModel.selectedScheduleImageURL,
+                onClose: {
+                    close()
+                }
+            )
+            .padding(.horizontal, 16)
+            .scaleEffect(isVisible ? 1.0 : 0.96)
+            .opacity(isVisible ? 1.0 : 0.0)
+        }
+        .onAppear {
+            viewModel.didTapScheduleCard(schedule)
+            
+            withAnimation(.easeInOut(duration: 0.2)) {
+                isVisible = true
+            }
+        }
+        .onDisappear {
+            viewModel.selectedScheduleImageURL = nil
+        }
+    }
+    
+    private func close() {
+        withAnimation(.easeInOut(duration: 0.18)) {
+            isVisible = false
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+            NotificationCenter.default.post(name: .dimNavigationBar, object: false)
+            viewModel.selectedScheduleImageURL = nil
+            dismiss()
+        }
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
closed #287
<br>

## 🍎 작업 내용
- 오늘의 현황에서 인증 사진 확인시 red dot 비활성화
- 오늘의 현황에서 인증 사진 확인시 다른 알림이 왔다면 red dot 활성화 상태 유지
- 미확인 알람 확인 디코딩 에러 수정
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 기능1 | <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-04-18 at 02 48 44" src="https://github.com/user-attachments/assets/bda59cc2-18a8-42ac-b8fa-5dd75162bc67" />|

아이 화면은 제 핸드폰으로 작동시켰습니다. 
<br>

## 💬 리뷰 코멘트
서버에서 알람의 각 이벤트에 대한 '읽음'처리를 한다고 해서 오늘의 현황 사진 조회시 fetchUnreadStatus를 조회하여 읽지 않은 알람이 있는지 조회를 통해 red dot 활성화 여부를 결정하도록 하였습니다. 
해당 과정에서 feedService에 response를 baseResponse로 한번더 감싸는 오류가 있어서 response 형태 수정하였습니당
