### PR TITLE
[refactor] #290 부모 일정수정 로직 리팩토링

### DIFF
--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -275,13 +275,21 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 
                 if currentWeekStart == lookingWeekStart {
                     let currentWeekDayIndex = (calendar.component(.weekday, from: now) + 5) % 7
-                    let isTodaySelected = selectedIndices.contains(currentWeekDayIndex)
+                    let currentTimeMin = calendar.component(.hour, from: now) * 60 + calendar.component(.minute, from: now)
                     
-                    if isTodaySelected && (isFireLit || startMin < currentTimeMin) {
-                        if let nextWeekDate = calendar.date(byAdding: .day, value: 7, to: firstDate) {
-                            firstDate = nextWeekDate
-                            Toast.show(message: "일정 등록이 마감된 날이 있어, 다음 주부터 적용돼요.", bottomInset: 88)
+                    let validFirstIndex = selectedIndices.first { index in
+                        if index > currentWeekDayIndex { return true }
+                        if index == currentWeekDayIndex {
+                            return !isFireLit && startMin >= currentTimeMin
                         }
+                        return false
+                    }
+                    
+                    if let validIndex = validFirstIndex {
+                        firstDate = weekDates[validIndex]
+                    } else {
+                        firstDate = calendar.date(byAdding: .day, value: 7, to: weekDates[selectedIndices[0]])!
+                        Toast.show(message: "일정 등록이 마감된 날이 있어, 다음 주부터 적용돼요.", bottomInset: 88)
                     }
                 }
                 
@@ -397,17 +405,25 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                     
                     if currentWeekStart == lookingWeekStart {
                         let currentWeekDayIndex = (calendar.component(.weekday, from: now) + 5) % 7
-                        let isTodaySelected = selectedIndices.contains(currentWeekDayIndex)
                         let isFireLit = self.viewModel?.isFireLit ?? false
+                        let startMin = calendar.component(.hour, from: self.currentStartTime ?? now) * 60
+                                     + calendar.component(.minute, from: self.currentStartTime ?? now)
+                        let currentTimeMin = calendar.component(.hour, from: now) * 60
+                                           + calendar.component(.minute, from: now)
                         
-                        let startMin = calendar.component(.hour, from: self.currentStartTime ?? now) * 60 + calendar.component(.minute, from: self.currentStartTime ?? now)
-                        let currentTimeMin = calendar.component(.hour, from: now) * 60 + calendar.component(.minute, from: now)
-                        
-                        if isTodaySelected && (isFireLit || startMin < currentTimeMin) {
-                            if let nextWeek = calendar.date(byAdding: .day, value: 7, to: finalTargetDate) {
-                                finalTargetDate = nextWeek
-                                wasWarningShown = true
+                        let validFirstIndex = selectedIndices.first { index in
+                            if index > currentWeekDayIndex { return true }
+                            if index == currentWeekDayIndex {
+                                return !isFireLit && startMin >= currentTimeMin
                             }
+                            return false
+                        }
+                        
+                        if let validIndex = validFirstIndex {
+                            finalTargetDate = weekDates[validIndex]
+                        } else {
+                            finalTargetDate = calendar.date(byAdding: .day, value: 7, to: weekDates[selectedIndices[0]])!
+                            wasWarningShown = true
                         }
                     }
                 }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #290 
<br>

## 🍎 작업 내용
<img width="937" height="151" alt="image" src="https://github.com/user-attachments/assets/ef281bc2-4e7c-46eb-b8c7-cda9b51c7a1d" />
<br>

#### 💬 상세 내용
반복일정 등록 시, 오늘 이후로 유효한 요일이 있음에도 다음주부터 일정이 등록되는 버그를 수정했습니다.
기존에는 선택된 요일 중 오늘이 포함된 경우, 시간 조건과 무관하게 selectedIndices[0](첫 번째 선택 요일)에 7일을 더해 무조건 다음주 해당 요일을 firstOrderDate로 설정하고 있었습니다. 아마 다른 제한로직을 설정해주면서 아예 다음주로 넘어가게 설정했던 게 꼬인 것 같았습니다. 

그리하여 서버요청 부분과 UI설정 부분에서 선택된 요일을 순서대로 순회하며 
오늘 이후 혹은 오늘이지만 아직 시간이 지나지 않은 첫 번째 유효한 요일을 firstOrderDate로 설정하도록 변경했습니다.