### PR TITLE
[refactor] #292 바텀시트 높이 계산 로직 수정

### DIFF
--- a/Kiero/Kiero/Presentation/TodayStatus/View/MissionBottomSheetContainerView.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/View/MissionBottomSheetContainerView.swift
@@ -17,7 +17,7 @@ struct MissionBottomSheetContainerView: View {
     let completeMissions: [MissionItem]
     let incompleteMissions: [MissionItem]
     
-    private let topInsetFromScreen: CGFloat = 105
+    private let topSpacingFromSafeArea: CGFloat = 57
     
     init(
         selectedTab: MissionTab,
@@ -31,35 +31,35 @@ struct MissionBottomSheetContainerView: View {
     
     var body: some View {
         GeometryReader { proxy in
-            let screenHeight = proxy.size.height + proxy.safeAreaInsets.top + proxy.safeAreaInsets.bottom
-            let visibleTopInset = max(topInsetFromScreen - proxy.safeAreaInsets.top, 0)
-            let sheetHeight = screenHeight - topInsetFromScreen
+            let sheetTop = proxy.safeAreaInsets.top + topSpacingFromSafeArea
             
-            ZStack(alignment: .bottom) {
-                Color.kBlack.opacity(isVisible ? 0.75 : 0)
+            ZStack(alignment: .top) {
+                Color.clear
+                    .contentShape(Rectangle())
                     .ignoresSafeArea()
                     .onTapGesture {
                         close()
                     }
                 
-                MissionBottomSheet(
-                    selectedTab: $selectedTab,
-                    completeMissions: completeMissions,
-                    incompleteMissions: incompleteMissions,
-                    onClose: {
-                        close()
-                    }
-                )
-                .frame(
-                    maxWidth: .infinity,
-                    minHeight: sheetHeight,
-                    maxHeight: sheetHeight,
-                    alignment: .top
-                )
-                .offset(y: isVisible ? 0 : sheetHeight + 40)
+                VStack(spacing: 0) {
+                    Color.clear
+                        .frame(height: sheetTop)
+                    
+                    MissionBottomSheet(
+                        selectedTab: $selectedTab,
+                        completeMissions: completeMissions,
+                        incompleteMissions: incompleteMissions,
+                        onClose: {
+                            close()
+                        }
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    .offset(y: isVisible ? 0 : proxy.size.height)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                .ignoresSafeArea(edges: .bottom)
             }
-            .padding(.top, visibleTopInset)
-            .ignoresSafeArea(edges: .bottom)
+            .ignoresSafeArea()
             .onAppear {
                 withAnimation(.easeInOut(duration: 0.25)) {
                     isVisible = true


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #292 
<br>

## 🍎 작업 내용

바텀시트를 기존엔 view의 top을 기준으로 하는 방식이었는데 기기마다 safeArea의 높이가 다른 이슈로 navigationBar의 bottom을 기준으로 57의 inset을 주는 방식으로 로직을 교체하였습니다.


<br>

## 📸 스크린샷
| 기능/화면 | iPhone 12 | iPhone 15 Pro | iPhone 17 Pro |
|:---------:|:-------------:|:-------------:|:-------------:|
| 기능1 | <img src="https://github.com/user-attachments/assets/f8436e94-1b0e-4fbc-927b-aeb1b38c572b" width="250"> | <img src="https://github.com/user-attachments/assets/05346110-d71a-46c0-a1e3-4b7d7778c453" width="250"> | <img src="https://github.com/user-attachments/assets/2b095343-9c42-4aad-9500-763b668c8e3e" width="250"> |
<br>


## 💬 리뷰 코멘트
리뷰어가 신경써서 봐줄 부분을 알려주세요.

이제는 기기에 상관없이 네비바에서 57만큼 떨어지게 올라오도록 변경되었습니다!!