### PR TITLE
[hotfix] #294 sse 수신시 childId 저장 로직 구현

### DIFF
--- a/Kiero/Kiero/Presentation/Onboarding/View/ParentInviteViewController.swift
+++ b/Kiero/Kiero/Presentation/Onboarding/View/ParentInviteViewController.swift
@@ -128,8 +128,15 @@ final class ParentInviteViewController: BaseViewController<ParentInviteViewModel
             .compactMap { $0.object as? SseEventPayload }
             .filter { $0.eventType == "CHILD_JOINED" }
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] payload in
                 guard let self else { return }
+                
+                if let id = payload.childId, id != 0 {
+                    UserDefaults.standard.set(id, forKey: "selectedChildId")
+                    print("✅ selectedChildId saved from SSE:", id)
+                } else {
+                    print("⚠️ childId 없음, fallback 필요")
+                }
                 self.isChildJoined = true
                 
                 let expired = viewModel.isExpiredValue


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #294 
<br>

## 🍎 작업 내용
메인 기능
`data:{"eventType":"CHILD_JOINED","childId":393}`
SSE Event가 이런식으로 오면 childId를 바로 저장하여 아이정보가 누락되는 경우가 없게끔 하였습니다!!

<br>

## 💬 리뷰 코멘트
리뷰어가 신경써서 봐줄 부분을 알려주세요.