### PR TITLE
[feat] #297 부모 미션 완료여부 UI 추가

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/MissionBox/MissionBoxParent.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/MissionBox/MissionBoxParent.swift
@@ -63,8 +63,6 @@ final class MissionBoxParent: UIView {
         $0.isHidden = true
     }
     
-    private let rewardBadge = UIView()
-    
     private let spacer = UIView()
     
     override init(frame: CGRect) {

--- a/Kiero/Kiero/Presentation/Common/Components/MissionBox/MissionBoxParent.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/MissionBox/MissionBoxParent.swift
@@ -12,6 +12,13 @@ import Then
 
 final class MissionBoxParent: UIView {
     
+    // MARK: - State
+    
+    enum State {
+        case inProgress
+        case completed
+    }
+    
     // MARK: - UI Components
     
     private let titleLabel = UILabel().then {
@@ -24,6 +31,10 @@ final class MissionBoxParent: UIView {
     }
     
     private let rewardLabel = UILabel().then {
+        $0.textColor = .gray400
+    }
+
+    private let badgeRewardLabel = UILabel().then {
         $0.textColor = .gray500
     }
     
@@ -35,10 +46,26 @@ final class MissionBoxParent: UIView {
         $0.alignment = .center
     }
     
+    private let titleStack = UIStackView().then {
+        $0.axis = .vertical
+        $0.alignment = .leading
+        $0.spacing = 4
+    }
+    
     private let missionBox = UIStackView().then {
         $0.axis = .horizontal
         $0.alignment = .center
     }
+    
+    private let successLabel = UILabel().then {
+        $0.setTypo(.title4_14_SB, text: "성공!")
+        $0.textColor = .white.withAlphaComponent(0.5)
+        $0.isHidden = true
+    }
+    
+    private let rewardBadge = UIView()
+    
+    private let spacer = UIView()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -67,15 +94,24 @@ final class MissionBoxParent: UIView {
     
     private func setUI() {
         addSubview(missionBox)
-        missionBox.addArrangedSubviews(titleLabel, rewardStackView)
-        rewardStackView.addArrangedSubviews(rewardIcon, rewardLabel)
+        titleStack.addArrangedSubviews(rewardLabel, titleLabel)
+        missionBox.addArrangedSubviews(titleStack, spacer, rewardStackView, successLabel)
+        rewardStackView.addArrangedSubviews(rewardIcon, badgeRewardLabel)
     }
     
     private func setLayout() {
         missionBox.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(13)
             $0.trailing.equalToSuperview().inset(13)
-            $0.verticalEdges.equalToSuperview().inset(20.5)
+            $0.verticalEdges.equalToSuperview().inset(0)
+        }
+        
+        snp.makeConstraints {
+            $0.height.equalTo(64)
+        }
+        
+        spacer.snp.makeConstraints {
+            $0.width.greaterThanOrEqualTo(10)
         }
         
         rewardStackView.snp.makeConstraints {
@@ -89,8 +125,42 @@ final class MissionBoxParent: UIView {
     
     // MARK: - Configuration
     
-    func configure(name: String, reward: Int) {
-        titleLabel.setTypo(.title3_16_SB, text: name)
-        rewardLabel.setTypo(.body6_10_R, text: "\(reward) 개")
+    func configure(name: String, reward: Int, isCompleted: Bool = false) {
+        rewardLabel.setTypo(.body4_12_R, text: "금화 \(reward) 개")
+        badgeRewardLabel.setTypo(.body6_10_R, text: "\(reward) 개")
+        apply(state: isCompleted ? .completed : .inProgress)
+        
+        if isCompleted {
+            titleLabel.setTypo(.body2_16_R, text: name)
+            titleLabel.textColor = .white.withAlphaComponent(0.5)
+        } else {
+            titleLabel.setTypo(.title3_16_SB, text: name)
+            titleLabel.textColor = .white
+        }
+    }
+    
+    private func apply(state: State) {
+        switch state {
+        case .inProgress:
+            backgroundColor = .gray900
+            titleLabel.textColor = .white
+            rewardLabel.isHidden = true
+            rewardStackView.isHidden = false
+            successLabel.isHidden = true
+            missionBox.snp.updateConstraints {
+                $0.trailing.equalToSuperview().inset(13)
+            }
+
+        case .completed:
+            backgroundColor = .gray900.withAlphaComponent(0.5)
+            titleLabel.textColor = .white.withAlphaComponent(0.5)
+            rewardLabel.textColor = .gray400.withAlphaComponent(0.5)
+            rewardLabel.isHidden = false
+            rewardStackView.isHidden = true
+            successLabel.isHidden = false
+            missionBox.snp.updateConstraints {
+                $0.trailing.equalToSuperview().inset(32)
+            }
+        }
     }
 }

--- a/Kiero/Kiero/Presentation/Mission/Mission/MissionTableViewCell.swift
+++ b/Kiero/Kiero/Presentation/Mission/Mission/MissionTableViewCell.swift
@@ -42,7 +42,7 @@ final class MissionTableViewCell: UITableViewCell {
         }
     }
     
-    func configure(name: String, reward: Int) {
-        missionBox.configure(name: name, reward: reward)
+    func configure(name: String, reward: Int, isCompleted: Bool = false) {
+        missionBox.configure(name: name, reward: reward, isCompleted: isCompleted)
     }
 }

--- a/Kiero/Kiero/Presentation/Mission/Mission/MissionView.swift
+++ b/Kiero/Kiero/Presentation/Mission/Mission/MissionView.swift
@@ -92,7 +92,7 @@ extension MissionView: UITableViewDataSource {
         }
         
         let mission = missionGroups[indexPath.section].missions[indexPath.row]
-        cell.configure(name: mission.name, reward: mission.reward)
+        cell.configure(name: mission.name, reward: mission.reward, isCompleted: mission.isCompleted)
         
         return cell
     }

--- a/Kiero/Kiero/Presentation/Mission/Mission/MissionViewModel.swift
+++ b/Kiero/Kiero/Presentation/Mission/Mission/MissionViewModel.swift
@@ -42,14 +42,20 @@ final class MissionViewModel: BaseViewModel {
                 let finalGroups = response.missionsByDate
                     .sorted { $0.dueAt < $1.dueAt }
                     .map { group -> MissionGroupDTO in
-                        let sortedMissions = group.missions.sorted { m1, m2 in
+                        let sortedMissions = group.missions.sorted { (m1: MissionItemDTO, m2: MissionItemDTO) in
+                            if m1.isCompleted != m2.isCompleted {
+                                return !m1.isCompleted
+                            }
+                            
+                            if m1.isCompleted && m2.isCompleted {
+                                return m1.id > m2.id
+                            }
+                            
                             let o1 = activityOrderMap[m1.id]
                             let o2 = activityOrderMap[m2.id]
-
                             guard o1 != nil || o2 != nil else { return m1.id > m2.id }
                             if o1 == nil { return false }
                             if o2 == nil { return true }
-
                             return o1! > o2!
                         }
                         return MissionGroupDTO(dueAt: group.dueAt, dayOfWeek: group.dayOfWeek, missions: sortedMissions)


### PR DESCRIPTION
## 📟 연결된 이슈
closed #297 
<br>

## 🍎 작업 내용
- 부모 미션 화면에서 완료된 미션 UI를 추가하였습니다.
- MissionBoxParent에 State enum 추가하여 상태에 따라 UI 세팅이 변경되도록 하였습니다. (inProgress / completed)
- 동일 날짜 그룹 내 정렬 로직 추가하였습니다.
  - 완료 여부 (미완료 미션 → 완료 미션 순서)
  - 완료 미션 정렬 (완료일시 기준 내림차순, 최근 완료한 미션 상단으로) 
  **→ ⚠️서버 필드가 추가 되어야, 완료 일시에 따른 정렬을 수행할 수 있습니다.**
     **→ [26.05.20 회의 기준] 서버 측에서 로직 구현해서 내려준다고 합니다.**
<br>

## 📸 스크린샷
| 기능/화면 | 부모 미션 |
|:---------:|:-------------:|
| 미션 완료/미완료 | <img src="https://github.com/user-attachments/assets/ca44dfa0-1155-4c6c-a23e-6e7c60e4cdbf" width="250"> |
<br>


## 💬 리뷰 코멘트
빠리부 ~