### PR TITLE
[feat] #302 소원의 공간 view 구현

### DIFF
--- a/Kiero/Kiero/Application/AppDIContainer.swift
+++ b/Kiero/Kiero/Application/AppDIContainer.swift
@@ -197,6 +197,15 @@ extension AppDIContainer {
     }
 }
 
+// MARK: - WishRoom
+
+extension AppDIContainer {
+    func makeWishRoomViewController() -> UIViewController {
+        let viewModel = WishRoomViewModel()
+        return WishRoomHostingController(viewModel: viewModel)
+    }
+}
+
 // MARK: - MySpace
 
 extension AppDIContainer {

--- a/Kiero/Kiero/Presentation/Common/Components/WishRoomBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/WishRoomBox.swift
@@ -62,18 +62,18 @@ struct WishRoomBox: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(wish.title)
                     .font(Font(UIFont.title3_16_SB))
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                 
                 HStack(spacing: 4) {
                     Text("획득일")
                         .font(Font(UIFont.body4_12_R))
-                        .foregroundColor(.gray400)
+                        .foregroundStyle(.gray400)
                     Text("|")
                         .font(Font(UIFont.body4_12_R))
-                        .foregroundColor(.gray400)
+                        .foregroundStyle(.gray400)
                     Text(wish.acquiredDate)
                         .font(Font(UIFont.body4_12_R))
-                        .foregroundColor(.gray400)
+                        .foregroundStyle(.gray400)
                 }
             }
             
@@ -87,7 +87,7 @@ struct WishRoomBox: View {
                 
                 Text("\(wish.cost) 사용")
                     .font(Font(UIFont.body6_10_R))
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
@@ -110,11 +110,11 @@ struct WishRoomBox: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("아직 빌었던 소원이 없어!")
                         .font(Font(UIFont.title3_16_SB))
-                        .foregroundColor(.white)
+                        .foregroundStyle(.white)
                     
                     Text("오늘의 소원을 빌어볼까?")
                         .font(Font(UIFont.body4_12_R))
-                        .foregroundColor(.gray400)
+                        .foregroundStyle(.gray400)
                 }
                 
                 Spacer()
@@ -125,7 +125,7 @@ struct WishRoomBox: View {
             } label: {
                 Text("소원 빌러가기")
                     .font(Font(UIFont.title4_14_SB))
-                    .foregroundColor(.black)
+                    .foregroundStyle(.black)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 10)
                     .background(

--- a/Kiero/Kiero/Presentation/Common/Components/WishRoomBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/WishRoomBox.swift
@@ -14,11 +14,44 @@ struct WishItem: Identifiable {
     let cost: Int
 }
 
+enum WishRoomBoxType {
+    case wish(WishItem)
+    case empty
+}
+
 struct WishRoomBox: View {
-    let wish: WishItem
+    let type: WishRoomBoxType
     let isToday: Bool
+    var onEmptyTapped: (() -> Void)? = nil
     
     var body: some View {
+        Group {
+            switch type {
+            case .wish(let wish):
+                wishContent(wish)
+            case .empty:
+                emptyContent()
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 16)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.gray900)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(
+                    isToday ? Color.gray300 : Color.clear,
+                    lineWidth: 1
+                )
+        )
+    }
+    
+    // MARK: - Wish Content
+    
+    @ViewBuilder
+    private func wishContent(_ wish: WishItem) -> some View {
         HStack(alignment: .top, spacing: 10) {
             Image(.icStarRound)
                 .resizable()
@@ -60,18 +93,46 @@ struct WishRoomBox: View {
             .padding(.vertical, 4)
             .background(Capsule().fill(.gray800))
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 16)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color.gray900)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(
-                    isToday ? Color.gray300 : Color.clear,
-                    lineWidth: 1
-                )
-        )
+    }
+    
+    // MARK: - Empty Content
+    
+    @ViewBuilder
+    private func emptyContent() -> some View {
+        VStack(spacing: 17) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(.icStarRound)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 18, height: 18)
+                    .padding(.top, 4)
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("아직 빌었던 소원이 없어!")
+                        .font(Font(UIFont.title3_16_SB))
+                        .foregroundColor(.white)
+                    
+                    Text("오늘의 소원을 빌어볼까?")
+                        .font(Font(UIFont.body4_12_R))
+                        .foregroundColor(.gray400)
+                }
+                
+                Spacer()
+            }
+            
+            Button {
+                onEmptyTapped?()
+            } label: {
+                Text("소원 빌러가기")
+                    .font(Font(UIFont.title4_14_SB))
+                    .foregroundColor(.black)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(.gray100)
+                    )
+            }
+        }
     }
 }

--- a/Kiero/Kiero/Presentation/Common/Factory/ViewControllerFactory.swift
+++ b/Kiero/Kiero/Presentation/Common/Factory/ViewControllerFactory.swift
@@ -30,4 +30,5 @@ public protocol ViewControllerFactory {
     func makeCoinMissionViewController() -> UIViewController
     func makeWishWellViewController() -> UIViewController
     func makeMySpaceViewController() -> UIViewController
+    func makeWishRoomViewController() -> UIViewController
 }

--- a/Kiero/Kiero/Presentation/WishRoom/WishRoomHostingController.swift
+++ b/Kiero/Kiero/Presentation/WishRoom/WishRoomHostingController.swift
@@ -1,0 +1,27 @@
+//
+//  WishRoomHostingController.swift
+//  Kiero
+//
+//  Created by 정윤아 on 5/23/26.
+//
+
+import SwiftUI
+
+final class WishRoomHostingController: UIHostingController<WishRoomView> {
+    
+    private let viewModel: WishRoomViewModel
+    
+    init(viewModel: WishRoomViewModel = WishRoomViewModel()) {
+        self.viewModel = viewModel
+        super.init(rootView: WishRoomView(viewModel: viewModel))
+        
+        self.viewModel.onNavigateToWishWell = { [weak self] in
+            let wishWellVC = AppDIContainer.shared.makeWishWellViewController()
+            self?.navigationController?.pushViewController(wishWellVC, animated: true)
+        }
+    }
+    
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
+++ b/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct WishRoomView: View {
-    @StateObject private var viewModel = WishRoomViewModel()
+    @ObservedObject var viewModel: WishRoomViewModel
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
@@ -59,9 +59,6 @@ struct WishRoomView: View {
             .background(.kBlack)
         }
         .navigationBarHidden(true)
-        .navigationDestination(isPresented: $viewModel.shouldNavigateToWishWell) {
-            // TODO: - 소원의 우물로 이동하기
-        }
     }
     
     private var totalCountBanner: some View {

--- a/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
+++ b/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
@@ -1,0 +1,118 @@
+//
+//  WishRoomView.swift
+//  Kiero
+//
+//  Created by 정윤아 on 5/22/26.
+//
+
+import SwiftUI
+
+struct WishRoomView: View {
+    @StateObject private var viewModel = WishRoomViewModel()
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Color.kBlack.ignoresSafeArea()
+            
+            VStack(spacing: 0) {
+                NavigationBarWrapper(
+                    type: .back(title: "소원의 공간"),
+                    onLeftTap: { dismiss() }
+                )
+                .frame(height: 37)
+                
+                ScrollView(showsIndicators: false) {
+                    VStack(spacing: 0) {
+                        totalCountBanner
+                            .padding(.top, 25)
+                        
+                        todaySection
+                            .padding(.top, 24)
+                        
+                        if !viewModel.previousWishes.isEmpty {
+                            previousSection
+                                .padding(.top, 24)
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                }
+            }
+            
+            LinearGradient(
+                colors: [.kBlack.opacity(0), .kBlack],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .frame(height: 156)
+            .ignoresSafeArea(edges: .bottom)
+            .allowsHitTesting(false)
+            
+            CTAButtonWrapper(
+                title: "확인",
+                style: .main,
+                size: .h49,
+                onTap: { dismiss() }
+            )
+            .padding(.horizontal, 20)
+            .padding(.bottom, 19)
+            .background(.kBlack)
+        }
+        .navigationBarHidden(true)
+        .navigationDestination(isPresented: $viewModel.shouldNavigateToWishWell) {
+            WishWellViewWrapper()
+    }
+    
+    private var totalCountBanner: some View {
+        HStack {
+            Text("지금까지 \(viewModel.totalWishCount)번의 소원을 빌었어!")
+                .font(Font(UIFont.body4_12_R))
+                .foregroundColor(.white)
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.gray900)
+        )
+    }
+    
+    private var todaySection: some View {
+        VStack(alignment: .leading, spacing: 11) {
+            Text("오늘 빌었던 소원")
+                .font(Font(UIFont.body4_12_R))
+                .foregroundColor(.gray200)
+            
+            if viewModel.hasTodayWishes {
+                ForEach(viewModel.todayWishes) { wish in
+                    WishRoomBox(type: .wish(wish), isToday: true)
+                }
+            } else {
+                WishRoomBox(
+                    type: .empty,
+                    isToday: true,
+                    onEmptyTapped: { viewModel.navigateToMakeWish() }
+                )
+            }
+        }
+    }
+    
+    private var previousSection: some View {
+        VStack(alignment: .leading, spacing: 11) {
+            Text("이전 소원")
+                .font(Font(UIFont.body4_12_R))
+                .foregroundColor(.gray200)
+            
+            ForEach(viewModel.previousWishes) { wish in
+                WishRoomBox(type: .wish(wish), isToday: false)
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        WishRoomView()
+    }
+}

--- a/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
+++ b/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
@@ -60,7 +60,8 @@ struct WishRoomView: View {
         }
         .navigationBarHidden(true)
         .navigationDestination(isPresented: $viewModel.shouldNavigateToWishWell) {
-            WishWellViewWrapper()
+            // TODO: - 소원의 우물로 이동하기
+        }
     }
     
     private var totalCountBanner: some View {
@@ -108,11 +109,5 @@ struct WishRoomView: View {
                 WishRoomBox(type: .wish(wish), isToday: false)
             }
         }
-    }
-}
-
-#Preview {
-    NavigationStack {
-        WishRoomView()
     }
 }

--- a/Kiero/Kiero/Presentation/WishRoom/WishRoomViewModel.swift
+++ b/Kiero/Kiero/Presentation/WishRoom/WishRoomViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  WishRoomViewModel.swift
+//  Kiero
+//
+//  Created by 정윤아 on 5/22/26.
+//
+
+import Foundation
+
+final class WishRoomViewModel: ObservableObject {
+    
+    @Published var todayWishes: [WishItem] = []
+    @Published var previousWishes: [WishItem] = []
+    @Published var shouldNavigateToWishWell: Bool = false
+    
+    var totalWishCount: Int {
+        todayWishes.count + previousWishes.count
+    }
+    
+    var hasTodayWishes: Bool {
+        !todayWishes.isEmpty
+    }
+    
+    // MARK: - Init
+    
+    init() {
+        loadMockData()
+    }
+    
+    // MARK: - Mock Data
+    
+    private func loadMockData() {
+        todayWishes = [
+            WishItem(id: 1, title: "상헌 아트디렉터되기", acquiredDate: "5월 10일", cost: 100),
+            WishItem(id: 2, title: "윤주 데이트하기", acquiredDate: "5월 10일", cost: 100)
+        ]
+        
+        previousWishes = [
+            WishItem(id: 3, title: "키어로 여름엠티", acquiredDate: "5월 2일", cost: 100),
+            WishItem(id: 4, title: "포이 숭실대오기", acquiredDate: "5월 2일", cost: 100),
+            WishItem(id: 5, title: "그냥이 건물공동소유", acquiredDate: "5월 2일", cost: 100),
+            WishItem(id: 6, title: "윤주 영화보기", acquiredDate: "5월 2일", cost: 100)
+        ]
+    }
+    
+    // MARK: - Actions
+    
+    func navigateToMakeWish() {
+        shouldNavigateToWishWell = true
+    }
+}

--- a/Kiero/Kiero/Presentation/WishRoom/WishRoomViewModel.swift
+++ b/Kiero/Kiero/Presentation/WishRoom/WishRoomViewModel.swift
@@ -30,6 +30,8 @@ final class WishRoomViewModel: ObservableObject {
     
     // MARK: - Mock Data
     
+    // TODO: - Api 연결 후 삭제
+    
     private func loadMockData() {
         todayWishes = [
             WishItem(id: 1, title: "상헌 아트디렉터되기", acquiredDate: "5월 10일", cost: 100),

--- a/Kiero/Kiero/Presentation/WishRoom/WishRoomViewModel.swift
+++ b/Kiero/Kiero/Presentation/WishRoom/WishRoomViewModel.swift
@@ -11,7 +11,8 @@ final class WishRoomViewModel: ObservableObject {
     
     @Published var todayWishes: [WishItem] = []
     @Published var previousWishes: [WishItem] = []
-    @Published var shouldNavigateToWishWell: Bool = false
+    
+    var onNavigateToWishWell: (() -> Void)?
     
     var totalWishCount: Int {
         todayWishes.count + previousWishes.count
@@ -46,6 +47,6 @@ final class WishRoomViewModel: ObservableObject {
     // MARK: - Actions
     
     func navigateToMakeWish() {
-        shouldNavigateToWishWell = true
+        onNavigateToWishWell?()
     }
 }

--- a/Kiero/Kiero/Presentation/WishWell/WishWellView.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellView.swift
@@ -49,7 +49,7 @@ final class WishWellView: BaseUIView {
     private let wishWellStack = UIStackView().then {
         $0.axis = .vertical
         $0.alignment = .center
-        $0.spacing = 10
+        $0.spacing = 4
     }
     
     private let wishMessage = UILabel().then {
@@ -57,10 +57,21 @@ final class WishWellView: BaseUIView {
         $0.setTypo(.body4_12_R, text: "미션을 통해 얻은 금화로 소원을 살 수 있어!")
     }
     
+    private(set) var goToWishRoom = UILabel().then {
+        $0.textColor = .main
+        $0.setTypo(.body4_12_R, text: "내가 빈 소원 보러가기")
+        $0.isUserInteractionEnabled = true
+        $0.textAlignment = .center
+    }
+    
+    private let underLine = UIView().then {
+        $0.backgroundColor = .main
+    }
+    
     private let totalStack = UIStackView().then {
         $0.axis = .vertical
         $0.alignment = .center
-        $0.spacing = 14
+        $0.spacing = 7
     }
     
     private let container = UIView().then {
@@ -89,7 +100,8 @@ final class WishWellView: BaseUIView {
         addSubviews(wishEmptyView, nameStack, coinChip, container, line, wishCollectionView)
         nameStack.addArrangedSubviews(iconImage, nameLabel)
         wishWellStack.addArrangedSubviews(wishWellIcon, wishWellLabel)
-        totalStack.addArrangedSubviews(wishWellStack, wishMessage)
+        totalStack.addArrangedSubviews(wishWellStack, wishMessage, goToWishRoom, underLine)
+        totalStack.setCustomSpacing(14, after: wishMessage)
         container.addSubview(totalStack)
     }
     
@@ -113,10 +125,15 @@ final class WishWellView: BaseUIView {
             $0.size.equalTo(24)
         }
         
+        underLine.snp.makeConstraints {
+            $0.top.equalTo(goToWishRoom.snp.bottom).offset(3)
+            $0.height.equalTo(1)
+            $0.width.equalTo(108)
+        }
         container.snp.makeConstraints {
             $0.top.equalTo(nameStack.snp.bottom).offset(15)
             $0.horizontalEdges.equalToSuperview().inset(16)
-            $0.height.equalTo(147)
+            $0.height.equalTo(157)
         }
         
         totalStack.snp.makeConstraints {

--- a/Kiero/Kiero/Presentation/WishWell/WishWellView.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellView.swift
@@ -57,15 +57,17 @@ final class WishWellView: BaseUIView {
         $0.setTypo(.body4_12_R, text: "미션을 통해 얻은 금화로 소원을 살 수 있어!")
     }
     
-    private(set) var goToWishRoom = UILabel().then {
-        $0.textColor = .main
-        $0.setTypo(.body4_12_R, text: "내가 빈 소원 보러가기")
-        $0.isUserInteractionEnabled = true
-        $0.textAlignment = .center
-    }
-    
-    private let underLine = UIView().then {
-        $0.backgroundColor = .main
+    private(set) var goToWishRoom = UIButton().then {
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: UIFont.body4_12_R,
+            .foregroundColor: UIColor.main,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+            .underlineColor: UIColor.main,
+            .baselineOffset: 2
+        ]
+        let attributedTitle = NSAttributedString(string: "내가 빈 소원 보러가기", attributes: attributes)
+        $0.setAttributedTitle(attributedTitle, for: .normal)
+        $0.backgroundColor = .gray900
     }
     
     private let totalStack = UIStackView().then {
@@ -100,9 +102,10 @@ final class WishWellView: BaseUIView {
         addSubviews(wishEmptyView, nameStack, coinChip, container, line, wishCollectionView)
         nameStack.addArrangedSubviews(iconImage, nameLabel)
         wishWellStack.addArrangedSubviews(wishWellIcon, wishWellLabel)
-        totalStack.addArrangedSubviews(wishWellStack, wishMessage, goToWishRoom, underLine)
-        totalStack.setCustomSpacing(14, after: wishMessage)
+        totalStack.addArrangedSubviews(wishWellStack, wishMessage, goToWishRoom)
         container.addSubview(totalStack)
+        
+        totalStack.setCustomSpacing(14, after: wishMessage)
     }
     
     override func setLayout() {
@@ -125,11 +128,11 @@ final class WishWellView: BaseUIView {
             $0.size.equalTo(24)
         }
         
-        underLine.snp.makeConstraints {
-            $0.top.equalTo(goToWishRoom.snp.bottom).offset(3)
-            $0.height.equalTo(1)
+        goToWishRoom.snp.makeConstraints {
+            $0.height.equalTo(20)
             $0.width.equalTo(108)
         }
+        
         container.snp.makeConstraints {
             $0.top.equalTo(nameStack.snp.bottom).offset(15)
             $0.horizontalEdges.equalToSuperview().inset(16)

--- a/Kiero/Kiero/Presentation/WishWell/WishWellViewController.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellViewController.swift
@@ -42,8 +42,7 @@ final class WishWellViewController: BaseViewController<WishWellViewModel>{
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let tap = UITapGestureRecognizer(target: self, action: #selector(didTapGoToWishRoom))
-        rootView.goToWishRoom.addGestureRecognizer(tap)
+        rootView.goToWishRoom.addTarget(self, action: #selector(didTapGoToWishRoom), for: .touchUpInside)
     }
     
     // MARK: - Setup Methods

--- a/Kiero/Kiero/Presentation/WishWell/WishWellViewController.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellViewController.swift
@@ -89,7 +89,8 @@ final class WishWellViewController: BaseViewController<WishWellViewModel>{
     }
     
     @objc private func didTapGoToWishRoom() {
-        // TODO: - WishRoomView로 이동
+        let wishRoomVC = diContainer.makeWishRoomViewController()
+        navigationController?.pushViewController(wishRoomVC, animated: true)
     }
 }
 

--- a/Kiero/Kiero/Presentation/WishWell/WishWellViewController.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellViewController.swift
@@ -39,6 +39,13 @@ final class WishWellViewController: BaseViewController<WishWellViewModel>{
         viewWillDisappearSubject.send(())
     }
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        let tap = UITapGestureRecognizer(target: self, action: #selector(didTapGoToWishRoom))
+        rootView.goToWishRoom.addGestureRecognizer(tap)
+    }
+    
     // MARK: - Setup Methods
     
     override func setDelegate() {
@@ -79,6 +86,10 @@ final class WishWellViewController: BaseViewController<WishWellViewModel>{
             .store(in: &cancellables)
         
         viewDidLoadSubject.send(())
+    }
+    
+    @objc private func didTapGoToWishRoom() {
+        // TODO: - WishRoomView로 이동
     }
 }
 


### PR DESCRIPTION
## 📟 연결된 이슈
closed <!-- #302 -->
<br>

## 🍎 작업 내용
- 소원의 공간 view를 구현하였습니다. 
  - 오늘 획득한 소원이 없는 경우 empty 컴포넌트를 반환하여 소원을 빌러 갈 수 있습니다. 
  - 리스트 하단 cta 버튼 근처에 그라데이션이 있길래 추가하였습니다. 
- 저번 컴포넌트 작업시, 오늘 획득한 소원이 없는 경우에 등장하는 컴포넌트를 만들지 않아서 새로 추가해두었습니다. 
- 추가적으로 소원의 우물 view의 UI가 변경된 부분이 있어서 수정하였습니다. 
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 화면2 | 화면3 |
|:---------:|:-------------:|:-------------:|:-------------:|
| 기능1 | <img width="413" height="248" alt="스크린샷 2026-05-22 오전 4 57 12" src="https://github.com/user-attachments/assets/451597a6-6024-41af-86bd-b70b81e3d35d" /> | <img width="350" height="706" alt="스크린샷 2026-05-22 오전 4 58 08" src="https://github.com/user-attachments/assets/15be337e-247b-47c2-a5cb-a0c92dbd0068" /> |<img width="374" height="714" alt="스크린샷 2026-05-22 오전 4 58 37" src="https://github.com/user-attachments/assets/4c7641f0-6016-496a-9d2c-002cf8417566" /> | 
<br>

## 💬 리뷰 코멘트
화면이동하는 로직이 제 화면에도 있더라고요.... 혹시 추가하면 DIContainer 수정에 어려움이 있을 수도 있을 것 같아 일단 TODO로 남겨두었습니다. 
