### PR TITLE
[feat] #300 오늘의 여정 끝내기 & 알림 권한 팝업 UI

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -24,7 +24,8 @@ final class DialogBox: UIView {
         case deleteMission(title: String, coin: String)
         case childNotification
         case childLogout
-        
+        case endJourney
+
         var title: String {
             switch self {
             case .missionComplete(let title):
@@ -35,6 +36,8 @@ final class DialogBox: UIView {
                 return title
             case .nextJourney:
                 return "다음 여정으로 갈거야?"
+            case .endJourney:
+                return "오늘의 여정을 끝낼거야?"
             case .deleteSchedule(let title, _):
                 return title
             case .deleteReward(let title, _):
@@ -58,6 +61,8 @@ final class DialogBox: UIView {
                 return "금화를 사용해 소원을 빌까?"
             case .nextJourney:
                 return "한번 다음 여정으로 넘어가면\n다시 지금 여정으로 돌아올 수 없어!"
+            case .endJourney:
+                return "한 번 오늘 여정을 끝내면\n다시 오늘의 여정으로 돌아올 수 없어!"
             case .deleteSchedule, .deleteReward, .deleteMission:
                 return "삭제하시겠습니까?"
             case .childNotification:
@@ -93,6 +98,8 @@ final class DialogBox: UIView {
                 return "설정으로 이동"
             case .childLogout:
                 return "나가기"
+            case .endJourney:
+                return "끝내기"
             default:
                 return "확인"
             }

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -23,6 +23,7 @@ final class DialogBox: UIView {
         case deleteReward(title: String, coin: String)
         case deleteMission(title: String, coin: String)
         case childNotification
+        case notificationRequest
         case childLogout
         case endJourney
 
@@ -46,11 +47,13 @@ final class DialogBox: UIView {
                 return title
             case .childNotification:
                 return "설정에서 알림을 켜줘!"
+            case .notificationRequest:
+                return "오늘의 여정을 놓치지 않게 해줄게!"
             case .childLogout:
                 return "키어로에서 나갈 거야?"
             }
         }
-        
+
         var message: String {
             switch self {
             case .missionComplete:
@@ -67,6 +70,8 @@ final class DialogBox: UIView {
                 return "삭제하시겠습니까?"
             case .childNotification:
                 return "알림을 받으려면 설정에서 키어로 알림을 허용해줘!"
+            case .notificationRequest:
+                return "여정의 중요한 알림을 받아볼 수 있어."
             case .childLogout:
                 return "다시 들어오려면 초대코드가 필요해!"
             }
@@ -90,12 +95,23 @@ final class DialogBox: UIView {
             }
         }
 
+        var isCancelButtonHidden: Bool {
+            switch self {
+            case .notificationRequest:
+                return true
+            default:
+                return false
+            }
+        }
+
         var cancelButtonTitle: String { "취소" }
 
         var confirmButtonTitle: String {
             switch self {
             case .childNotification:
                 return "설정으로 이동"
+            case .notificationRequest:
+                return "알림받기"
             case .childLogout:
                 return "나가기"
             case .endJourney:
@@ -325,6 +341,7 @@ final class DialogBox: UIView {
         cancelButton.setTypo(.title3_16_SB, text: state.cancelButtonTitle, for: .normal)
         confirmButton.setTypo(.title3_16_SB, text: state.confirmButtonTitle, for: .normal)
         closeButton.isHidden = state.isCloseButtonHidden
+        cancelButton.isHidden = state.isCancelButtonHidden
         
         if let coin = state.coinText {
             coinStack.isHidden = false

--- a/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/SpeechField.swift
@@ -16,18 +16,19 @@ final class SpeechField: UIView {
         case no
         case gray
         case main
-        
+        case endJourney
+
         var textColor: UIColor {
             switch self {
             case .no:
                 return .clear
-            case .gray:
+            case .gray, .endJourney:
                 return .gray600
             case .main:
                 return .main
             }
         }
-        
+
         var buttonTitle: String {
             switch self {
             case .no:
@@ -36,6 +37,8 @@ final class SpeechField: UIView {
                 return "다음 여정으로"
             case .main:
                 return "다음"
+            case .endJourney:
+                return "여정 끝내기"
             }
         }
     }
@@ -166,7 +169,7 @@ final class SpeechField: UIView {
         case .main:
             addGestureRecognizer(tap)
             buttonContainerView.isUserInteractionEnabled = false
-        case .gray:
+        case .gray, .endJourney:
             buttonContainerView.addGestureRecognizer(tap)
             buttonContainerView.isUserInteractionEnabled = true
         case .no:

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import Combine
+import UserNotifications
 
 final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel> {
     
@@ -19,6 +20,7 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
     private let verifyButtonTapSubject = PassthroughSubject<Void, Never>()
     private let skipConfirmSubject = PassthroughSubject<Void, Never>()
     private var previousHasSchedule: Bool?
+    private var hasCheckedNotification = false
     
     // MARK: - Life Cycle
     
@@ -33,6 +35,7 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         viewWillAppearSubject.send(())
+        checkNotificationPermissionIfNeeded()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -141,7 +144,29 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
         }
         dialogBox.show(in: self)
     }
-    
+
+    private func checkNotificationPermissionIfNeeded() {
+        guard !hasCheckedNotification else { return }
+        hasCheckedNotification = true
+
+        UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
+            guard settings.authorizationStatus == .notDetermined else { return }
+            DispatchQueue.main.async {
+                self?.showNotificationRequestDialog()
+            }
+        }
+    }
+
+    private func showNotificationRequestDialog() {
+        let dialogBox = DialogBox()
+        dialogBox.configure(state: .notificationRequest)
+        dialogBox.onTapConfirm = {
+            dialogBox.dismiss()
+            UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { _, _ in }
+        }
+        dialogBox.show(in: self)
+    }
+
     private func openCamera() {
         guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
             print("카메라를 사용할 수 없습니다.")

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
@@ -104,7 +104,10 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
         switch route {
         case .showNextJourneyDialogBox:
             showNextJourneyDialog()
-            
+
+        case .showEndJourneyDialogBox:
+            showEndJourneyDialog()
+
         case .showCamera:
             openCamera()
             
@@ -122,6 +125,16 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
     private func showNextJourneyDialog() {
         let dialogBox = DialogBox()
         dialogBox.configure(state: .nextJourney)
+        dialogBox.onTapConfirm = { [weak self] in
+            dialogBox.dismiss()
+            self?.skipConfirmSubject.send(())
+        }
+        dialogBox.show(in: self)
+    }
+
+    private func showEndJourneyDialog() {
+        let dialogBox = DialogBox()
+        dialogBox.configure(state: .endJourney)
         dialogBox.onTapConfirm = { [weak self] in
             dialogBox.dismiss()
             self?.skipConfirmSubject.send(())

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -10,6 +10,7 @@ import UIKit
 
 enum DailyJourneyRoute {
     case showNextJourneyDialogBox
+    case showEndJourneyDialogBox
     case showCamera
     case tryLightFire
 }
@@ -21,6 +22,7 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
     private(set) var currentStoneType: StoneType?
     private var currentButtonType: DailyJourneyModel.ActionButtonType = .hidden
     public var currentEarnedStoneCount: Int = 0
+    private var isCurrentlyLastJourney = false
     
     // MARK: - Input & Output
     
@@ -53,7 +55,13 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
             .store(in: &cancellables)
         
         input.nextJourneyButtonTap
-            .sink { [weak self] in self?.routeSubject.send(.showNextJourneyDialogBox) }
+            .sink { [weak self] in
+                if self?.isCurrentlyLastJourney == true {
+                    self?.routeSubject.send(.showEndJourneyDialogBox)
+                } else {
+                    self?.routeSubject.send(.showNextJourneyDialogBox)
+                }
+            }
             .store(in: &cancellables)
         
         input.verifyButtonTap
@@ -182,7 +190,8 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         let isTimeViewActive = (timeText != "-")
         
         let isLastJourney = (schedule.scheduleOrder > 0 && totalSchedule == 1)
-        
+        self.isCurrentlyLastJourney = isLastJourney
+
         let isCurrentTimeMatched = isCurrentTimeInSchedule(start: schedule.startTime, end: schedule.endTime)
         
         let buttonType: DailyJourneyModel.ActionButtonType
@@ -231,7 +240,7 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                 maxFireStoneCount: totalSchedule,
                 scheduleOrder: schedule.scheduleOrder,
                 scheduleOrderText: orderText,
-                speechFieldType: isLastJourney ? .no : .gray,
+                speechFieldType: isLastJourney ? .endJourney : .gray,
                 chipItemType: .inProgressChip,
                 isTimeViewActive: isTimeViewActive,
                 actionButtonType: buttonType


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #300
<br>

## 🍎 작업 내용
### 1. 여정 끝내기                                                                                                         
- 마지막 여정에서 "다음 여정으로" 대신 "여정 끝내기" 버튼 노출
- "여정 끝내기" 탭 시 확인 팝업("오늘의 여정을 끝낼거야?") 표시
- 확인 시 기존 skipJourney API 호출 → fireNotLit 상태로 전환

  ### 2. 최초 알림 권한 요청 팝업
- 오늘의 여정 최초 진입 시 OS 알림 권한이 `.notDetermined`이면 팝업 노출
- "알림받기" 탭 → OS 알림 권한 요청
-  X/딤 영역 탭 → 팝업 닫힘 (알림 OFF)
- DialogBox에 `isCancelButtonHidden` 추가하여 단일 버튼 팝업 지원
<br>

## 📸 스크린샷
| 최초 알림 권한 요청 팝업 | 여정 끝내기 |
|:-------------:|:-------------:|
| <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-05-24 at 15 12 32" src="https://github.com/user-attachments/assets/1017daa3-0e4e-4ed2-a415-e50feb8ea0d9" /> | <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-05-24 at 15 15 30" src="https://github.com/user-attachments/assets/aec65adf-cfcf-4018-ad88-a545aef2d011" />
<br>

## 💬 리뷰 코멘트
- `DialogBox`에 `isCancelButtonHidden` 프로퍼티를 추가해서 취소 버튼 없는 단일 버튼 팝업을 지원합니다 (알림 권한 요청
  팝업용)
- 여정 끝내기는 기존 `skipJourney` API를 재사용합니다
- 알림 권한 체크는 `viewWillAppear`에서 1회만 실행됩니다 (`hasCheckedNotification` 플래그)