### PR TITLE
[network] #315 자녀 API 연결

### DIFF
--- a/Kiero/Kiero/Network/Base/EndPoint.swift
+++ b/Kiero/Kiero/Network/Base/EndPoint.swift
@@ -44,7 +44,7 @@ enum EndPoint {
     case fetchDefaultColor(childId: Int)
     case editSchedule(scheduleId: Int, selectedDate: String, startDate: String?, endDate: String?)
     case deleteSchedule(scheduleId: Int, selectedDate: String?, startDate: String?, endDate: String?)
-
+    
     // Mission
     case fetchMissions(childId: Int?)
     case updateMission(missionId: Int, request: WriteMissionRequestDTO)
@@ -75,7 +75,7 @@ enum EndPoint {
         switch self {
         case .kakaoLogin, .kakaoAccessToken, .reissueAccessToken, .reissueAllTokens:
             return .none
-        case .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .purchaseCoupon, .completeMission, .fireLit, .fetchJourneyList, .childSignup:
+        case .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .purchaseCoupon, .completeMission, .fireLit, .fetchJourneyList, .childSignup, .fetchChildTerms:
             return .child
         default:
             return .parent
@@ -92,6 +92,9 @@ enum EndPoint {
     
     // MissionComplete
     case completeSchedule(scheduleDetailId: Int)
+    
+    // Terms
+    case fetchChildTerms
     
     // GiveFireStone
     case fireLit
@@ -154,6 +157,8 @@ enum EndPoint {
             return "/api/v1/presigned-url/schedules"
         case .completeSchedule(let scheduleDetailId):
             return "/api/v1/schedules/verify/\(scheduleDetailId)"
+        case .fetchChildTerms:
+            return "/api/v1/terms/children"
         case .fireLit:
             return "/api/v1/schedules/fire-lit"
         case .fetchDefaultColor(let childId):
@@ -194,7 +199,7 @@ enum EndPoint {
     
     var method: String {
         switch self {
-        case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor, .fetchJourneyList, .fetchCoupons, .fetchTodayStatus, .fetchUnreadFeed:
+        case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor, .fetchJourneyList, .fetchCoupons, .fetchTodayStatus, .fetchUnreadFeed, .fetchChildTerms:
             return "GET"
         case .updateDailyJourney, .skipJourney, .completeSchedule, .fireLit, .completeMission, .editSchedule, .updateMission, .updateCoupon, .postImageRead, .fetchFeeds:
             return "PATCH"

--- a/Kiero/Kiero/Network/Base/EndPoint.swift
+++ b/Kiero/Kiero/Network/Base/EndPoint.swift
@@ -75,7 +75,7 @@ enum EndPoint {
         switch self {
         case .kakaoLogin, .kakaoAccessToken, .reissueAccessToken, .reissueAllTokens:
             return .none
-        case .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .purchaseCoupon, .completeMission, .fireLit, .fetchJourneyList, .childSignup, .fetchChildTerms:
+        case .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .purchaseCoupon, .completeMission, .fireLit, .fetchJourneyList, .childSignup, .fetchChildTerms, .checkParentWithdrawalStatus:
             return .child
         default:
             return .parent
@@ -95,6 +95,9 @@ enum EndPoint {
     
     // Terms
     case fetchChildTerms
+
+    // Parent Withdrawal
+    case checkParentWithdrawalStatus
     
     // GiveFireStone
     case fireLit
@@ -159,6 +162,8 @@ enum EndPoint {
             return "/api/v1/schedules/verify/\(scheduleDetailId)"
         case .fetchChildTerms:
             return "/api/v1/terms/children"
+        case .checkParentWithdrawalStatus:
+            return "/api/v1/children/parent-withdrawal-status"
         case .fireLit:
             return "/api/v1/schedules/fire-lit"
         case .fetchDefaultColor(let childId):
@@ -199,7 +204,7 @@ enum EndPoint {
     
     var method: String {
         switch self {
-        case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor, .fetchJourneyList, .fetchCoupons, .fetchTodayStatus, .fetchUnreadFeed, .fetchChildTerms:
+        case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor, .fetchJourneyList, .fetchCoupons, .fetchTodayStatus, .fetchUnreadFeed, .fetchChildTerms, .checkParentWithdrawalStatus:
             return "GET"
         case .updateDailyJourney, .skipJourney, .completeSchedule, .fireLit, .completeMission, .editSchedule, .updateMission, .updateCoupon, .postImageRead, .fetchFeeds:
             return "PATCH"

--- a/Kiero/Kiero/Network/MyPage/ChildTermsDTO.swift
+++ b/Kiero/Kiero/Network/MyPage/ChildTermsDTO.swift
@@ -1,0 +1,13 @@
+//
+//  ChildTermsDTO.swift
+//  Kiero
+//
+//  Created by Hyunseo Han on 5/27/26.
+//
+
+import Foundation
+
+struct ChildTermsDTO: Decodable {
+    let linkType: String
+    let link: String
+}

--- a/Kiero/Kiero/Network/MyPage/ChildTermsService.swift
+++ b/Kiero/Kiero/Network/MyPage/ChildTermsService.swift
@@ -1,0 +1,30 @@
+//
+//  ChildTermsService.swift
+//  Kiero
+//
+//  Created by Hyunseo Han on 5/27/26.
+//
+
+import Combine
+import Foundation
+
+final class ChildTermsService {
+    static let shared = ChildTermsService()
+    private init() {}
+    
+    func fetchTerms() -> AnyPublisher<[ChildTermsDTO], NetworkError> {
+        return Future<[ChildTermsDTO], NetworkError> { promise in
+            Task {
+                do {
+                    let dtos: [ChildTermsDTO] = try await BaseService.shared.request(endPoint: .fetchChildTerms)
+                    promise(.success(dtos))
+                } catch let error as NetworkError {
+                    promise(.failure(error))
+                } catch {
+                    promise(.failure(.unknownError))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+}

--- a/Kiero/Kiero/Network/MyPage/ParentWithdrawalStatusDTO.swift
+++ b/Kiero/Kiero/Network/MyPage/ParentWithdrawalStatusDTO.swift
@@ -1,0 +1,12 @@
+//
+//  ParentWithdrawalStatusDTO.swift
+//  Kiero
+//
+//  Created by Hyunseo Han on 5/27/26.
+//
+
+import Foundation
+
+struct ParentWithdrawalStatusDTO: Decodable {
+    let isParentWithdrawn: Bool
+}

--- a/Kiero/Kiero/Network/WishWell/DTO/ChildrenInfoDTO.swift
+++ b/Kiero/Kiero/Network/WishWell/DTO/ChildrenInfoDTO.swift
@@ -12,12 +12,14 @@ struct ChildrenInfoResponseDTO: Decodable {
     let lastName: String
     let coinAmount: Int
     let today: String
+    let pushNotificationEnabled: Bool?
 }
 
 struct ChildrenInfo {
     let firstName: String
     let coinAmount: Int
     let today: String
+    let pushNotificationEnabled: Bool
 }
 
 extension ChildrenInfoResponseDTO {
@@ -25,7 +27,8 @@ extension ChildrenInfoResponseDTO {
         .init(
             firstName: firstName,
             coinAmount: coinAmount,
-            today: today
+            today: today,
+            pushNotificationEnabled: pushNotificationEnabled ?? false
         )
     }
 }

--- a/Kiero/Kiero/Presentation/CoinMission/CoinMissionViewModel.swift
+++ b/Kiero/Kiero/Presentation/CoinMission/CoinMissionViewModel.swift
@@ -25,7 +25,7 @@ final class CoinMissionViewModel: BaseViewModel, ViewModelType {
     private let missionService: MissionServiceType
     private let coinMissionService: CoinMissionServiceType
     private let userInfoSubject = CurrentValueSubject<ChildrenInfo, Never>(
-        .init(firstName: "", coinAmount: 0, today: "")
+        .init(firstName: "", coinAmount: 0, today: "", pushNotificationEnabled: false)
     )
     private let missionsSubject = CurrentValueSubject<[MissionGroupDTO], Never>([])
     private var sseStarted = false
@@ -135,7 +135,8 @@ final class CoinMissionViewModel: BaseViewModel, ViewModelType {
         user = ChildrenInfo(
             firstName: user.firstName,
             coinAmount: user.coinAmount + dto.reward,
-            today: user.today
+            today: user.today,
+            pushNotificationEnabled: user.pushNotificationEnabled
         )
         userInfoSubject.send(user)
     }

--- a/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewModel.swift
+++ b/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewModel.swift
@@ -36,13 +36,34 @@ final class AuthGateViewModel {
         }
         
         if role.contains("child") {
-            routeSubject.send(.childTab)
+            decideChildRoute()
             return
         }
         
         routeSubject.send(.pickRole)
     }
     
+    private func decideChildRoute() {
+        Task {
+            do {
+                let status: ParentWithdrawalStatusDTO = try await BaseService.shared.request(
+                    endPoint: .checkParentWithdrawalStatus
+                )
+                await MainActor.run {
+                    if status.isParentWithdrawn {
+                        LogoutHelper.logoutToPickRole()
+                    } else {
+                        self.routeSubject.send(.childTab)
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    self.routeSubject.send(.childTab)
+                }
+            }
+        }
+    }
+
     private func decideParentRoute() {
         Task {
             do {

--- a/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
+++ b/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
@@ -511,6 +511,11 @@ private extension TabBarViewController {
                 guard let self else { return }
                 print("📡 TabBar received SSE:", payload.eventType)
                 
+                if !self.isParent && payload.eventType == "PARENT_WITHDRAWN" {
+                    LogoutHelper.logoutToPickRole()
+                    return
+                }
+
                 guard payload.eventType == "FEED_ITEM_CREATED" else { return }
                 
                 NotificationCenter.default.post(

--- a/Kiero/Kiero/Presentation/MySpace/MySpaceHostingController.swift
+++ b/Kiero/Kiero/Presentation/MySpace/MySpaceHostingController.swift
@@ -11,6 +11,12 @@ final class MySpaceHostingController: UIHostingController<MySpaceView> {
     
     init() {
         super.init(rootView: MySpaceView())
+        
+        rootView.onNavigateToWishRoom = { [weak self] in
+            let vc = WishRoomHostingController()
+            vc.hidesBottomBarWhenPushed = true
+            self?.navigationController?.pushViewController(vc, animated: true)
+        }
     }
     
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {

--- a/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
+++ b/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
@@ -14,7 +14,7 @@ struct MySpaceView: View {
     @State private var showNotificationDialog = false
     @State private var showLogoutDialog = false
     @State private var showTerms = false
-    @State private var showWishRoom = false
+    var onNavigateToWishRoom: (() -> Void)?
     
     private let userName = TokenManager.shared.getFirstName() ?? "꾸비"
     var isPreview = false
@@ -42,7 +42,7 @@ struct MySpaceView: View {
                     .padding(.horizontal, 16)
                     
                     WishSpaceCardView {
-                        showWishRoom = true
+                        onNavigateToWishRoom?()
                     }
                     .padding(.horizontal, 16)
                     .padding(.top, 20)
@@ -126,9 +126,6 @@ struct MySpaceView: View {
             }
             .navigationDestination(isPresented: $showTerms) {
                 TermsView()
-            }
-            .navigationDestination(isPresented: $showWishRoom) {
-                WishRoomView(viewModel: WishRoomViewModel())
             }
             .navigationBarHidden(true)
             .onAppear { fetchProfile() }

--- a/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
+++ b/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
@@ -14,6 +14,7 @@ struct MySpaceView: View {
     @State private var showNotificationDialog = false
     @State private var showLogoutDialog = false
     @State private var showTerms = false
+    @State private var showWishRoom = false
     
     private let userName = TokenManager.shared.getFirstName() ?? "꾸비"
     var isPreview = false
@@ -41,7 +42,7 @@ struct MySpaceView: View {
                     .padding(.horizontal, 16)
                     
                     WishSpaceCardView {
-                        // TODO: 소원의 공간으로 이동
+                        showWishRoom = true
                     }
                     .padding(.horizontal, 16)
                     .padding(.top, 20)
@@ -125,6 +126,9 @@ struct MySpaceView: View {
             }
             .navigationDestination(isPresented: $showTerms) {
                 TermsView()
+            }
+            .navigationDestination(isPresented: $showWishRoom) {
+                WishRoomView(viewModel: WishRoomViewModel())
             }
             .navigationBarHidden(true)
             .onAppear { refreshNotificationStatus() }

--- a/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
+++ b/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
@@ -131,9 +131,9 @@ struct MySpaceView: View {
                 WishRoomView(viewModel: WishRoomViewModel())
             }
             .navigationBarHidden(true)
-            .onAppear { refreshNotificationStatus() }
+            .onAppear { fetchProfile() }
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
-                refreshNotificationStatus()
+                fetchProfile()
             }
         }
     }
@@ -164,13 +164,13 @@ private extension MySpaceView {
         }
     }
     
-    func refreshNotificationStatus() {
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
-            DispatchQueue.main.async {
-                isAlarmOn = settings.authorizationStatus == .authorized
-                || settings.authorizationStatus == .provisional
+    func fetchProfile() {
+        WishWellService().fetchMyInfo()
+            .receive(on: DispatchQueue.main)
+            .sink { _ in } receiveValue: { info in
+                isAlarmOn = info.pushNotificationEnabled
             }
-        }
+            .store(in: &StaticCancellables.bag)
     }
     
     func openAppSettings() {

--- a/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
+++ b/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
@@ -39,7 +39,6 @@ struct MySpaceView: View {
                             .foregroundStyle(.white)
                     }
                     .padding(.horizontal, 16)
-                    .padding(.top, 15)
                     
                     WishSpaceCardView {
                         // TODO: 소원의 공간으로 이동
@@ -87,6 +86,8 @@ struct MySpaceView: View {
                     
                     Spacer()
                 }
+                .padding(.top, 59)
+                .ignoresSafeArea(edges: .top)
                 
                 if showNotificationDialog {
                     Color.kBlack.opacity(0.75)

--- a/Kiero/Kiero/Presentation/MySpace/TermsView.swift
+++ b/Kiero/Kiero/Presentation/MySpace/TermsView.swift
@@ -5,58 +5,85 @@
 //  Created by Hyunseo Han on 5/21/26.
 //
 
+import Combine
 import SwiftUI
 
 struct TermsView: View {
     @Environment(\.dismiss) private var dismiss
-
+    @State private var serviceTermsURL: String?
+    @State private var privacyPolicyURL: String?
+    @State private var cancellables = Set<AnyCancellable>()
+    
     var body: some View {
         ZStack {
             Color.kBlack.ignoresSafeArea()
-
+            
             VStack(alignment: .leading, spacing: 0) {
-
+                
                 HStack {
                     Button { dismiss() } label: {
                         Image(.icLeft)
                     }
-
+                    
                     Spacer()
-
+                    
                     Text("키어로 이용 약속")
                         .font(Font(UIFont.head2_20_B))
                         .foregroundStyle(.white)
-
+                    
                     Spacer()
-
+                    
                     Color.clear.frame(width: 24, height: 24)
                 }
                 .padding(.horizontal, 8)
                 .padding(.vertical, 4)
-
+                
                 Text("약관 및 정책")
                     .font(Font(UIFont.body4_12_R))
                     .foregroundStyle(.gray300)
                     .padding(.leading, 16)
                     .padding(.top, 24)
-
+                
                 VStack(spacing: 0) {
                     MenuListItem(title: "서비스 이용약관") {
-                        // TODO: 외부 링크로 이동
+                        openURL(serviceTermsURL)
                     }
                     MenuListItem(title: "개인정보 처리방침") {
-                        // TODO: 외부 링크로 이동
-                    }
-                    MenuListItem(title: "오픈소스 라이선스") {
-                        // TODO: 피그마에 '안드만 해당' 이라고 나와있어서 기획한테 문의 넣은 상태
+                        openURL(privacyPolicyURL)
                     }
                 }
                 .padding(.horizontal, 16)
                 .padding(.top, 8)
-
+                
                 Spacer()
             }
         }
         .navigationBarHidden(true)
+        .onAppear { fetchTerms() }
+    }
+}
+
+private extension TermsView {
+    func fetchTerms() {
+        ChildTermsService.shared.fetchTerms()
+            .receive(on: DispatchQueue.main)
+            .sink { _ in } receiveValue: { dtos in
+                for dto in dtos {
+                    switch dto.linkType {
+                    case "SERVICE_TERMS":
+                        serviceTermsURL = dto.link
+                    case "PRIVACY_POLICY":
+                        privacyPolicyURL = dto.link
+                    default:
+                        break
+                    }
+                }
+            }
+            .store(in: &cancellables)
+    }
+    
+    func openURL(_ urlString: String?) {
+        guard let urlString, let url = URL(string: urlString) else { return }
+        UIApplication.shared.open(url)
     }
 }

--- a/Kiero/Kiero/Presentation/WishWell/WishWellViewModel.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellViewModel.swift
@@ -111,7 +111,7 @@ final class WishWellViewModel: BaseViewModel, ViewModelType {
         let me = self.service.fetchMyInfo()
             .catch { [weak self] err -> Just<ChildrenInfo> in
                 self?.errorMessageSubject.send(err.errorDescription)
-                return Just(ChildrenInfo(firstName: "", coinAmount: 0, today: ""))
+                return Just(ChildrenInfo(firstName: "", coinAmount: 0, today: "", pushNotificationEnabled: false))
             }
         
         let coupons = self.service.fetchCoupons()


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #315
<br>

## 🍎 작업 내용
- 나의 공간 헤더 위치를 다른 자녀 탭과 동일하게 조정
- 소원의 공간 카드 탭 시 WishRoomView로 이동 연결
- 이용 약관 외부 링크 조회 API 연결 (`GET /api/v1/terms/children`) 및 오픈소스 라이선스 행 제거
- 프로필 조회 API의 `pushNotificationEnabled` 응답으로 알림 토글 상태 반영
- 자녀 로그아웃 
- 부모 탈퇴 시 자녀 강제 로그아웃
    - 앱 사용 중: SSE `PARENT_WITHDRAWN` 이벤트 수신 시 즉시 로그아웃
    - 앱 재진입 시: `GET /api/v1/children/parent-withdrawal-status` API 호출하여 탈퇴 여부 확인 후 로그아웃

<br>



## 📸 스크린샷
| 나의 공간 이름 위치 조정 | 소원의 공간으로 이동 | 이용 약관 외부 링크 연결 |
|:---------:|:-------------:|:-------------:|
| <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-05-27 at 15 00 29" src="https://github.com/user-attachments/assets/f0272b6b-d767-494c-a862-f211f765f9b9" /> | <img width="295" height="640" alt="소원의공간으로이동" src="https://github.com/user-attachments/assets/753d7286-234b-488f-87fd-e094e7fca4ad" /> | <img width="295" height="640" alt="외부링크" src="https://github.com/user-attachments/assets/bf316777-c604-480a-96eb-1f491393116a" /> |

| 프로필 조회 API의 `pushNotificationEnabled` 응답 | 
|:---------:|
| <img width="438" height="304" alt="image" src="https://github.com/user-attachments/assets/60712f9a-dae7-4bce-9b42-c6c5aecc5652" /> | 

|자녀 로그아웃 |
|:-------------:| 
|<img width="700" alt="Screen Recording 2026-05-27 at 3 06 46 PM" src="https://github.com/user-attachments/assets/b647ccbf-1f1c-43b4-b8d9-7aac3f1d81d9" /> | 

<br>



## 💬 리뷰 코멘트
- `AuthGateViewModel.decideChildRoute()`에서 부모 탈퇴 여부 API 실패 시 fail-open 처리했습니다 (정상 진입 후 SSE가 백업)
- `TabBarViewController.bindSSEEvents()`에 자녀용 `PARENT_WITHDRAWN` 이벤트 핸들러를 추가했는데, 기존 부모용 `FEED_ITEM_CREATED` 로직과 함께 있으니 흐름 확인 부탁드립니다
- `ChildrenInfoResponseDTO`에 `pushNotificationEnabled` 필드를 `Bool?`로 추가하여 기존 API 호환성 유지했습니다
- 자녀 강제 로그아웃은 부모의 탈퇴 기능이 완성되어야 테스트 해볼수 있어서 관련 PR 머지 되면 자체 QA 하며 테스트 예정입니다