### PR TITLE
[refactor] 2차 스프린트 | 1차 자체 QA

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/CustomScrollView.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/CustomScrollView.swift
@@ -44,14 +44,11 @@ struct CustomScrollView: View {
                         }()
                         
                         let effectiveStatus: String = {
-                            if schedule.status == .VERIFIED && schedule.isOngoing { return schedule.status.rawValue }
-                            if isFireLit && schedule.status == .VERIFIED { return "COMPLETED" }
-                            if isFireNotLit && schedule.status == .VERIFIED && !isTimeNotStarted { return "COMPLETED" }
+                            if schedule.status == .VERIFIED { return "COMPLETED" }
                             return schedule.status.rawValue
                         }()
                         let effectiveIsOngoing: Bool = {
-                            if schedule.status == .VERIFIED && schedule.isOngoing { return true }
-                            return (isFireLit || isFireNotLit) ? false : schedule.isOngoing
+                            return (isFireLit || isFireNotLit || schedule.status == .VERIFIED) ? false : schedule.isOngoing
                         }()
                         
                         let hasOngoing = data.schedules.contains { ($0.isOngoing && $0.status != .COMPLETED) || $0.status == .VERIFIED }

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
@@ -169,6 +169,13 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
                 DispatchQueue.main.async {
                     UIApplication.shared.registerForRemoteNotifications()
                 }
+                Task {
+                    let body = NotificationSettingsRequest(pushNotificationEnabled: true)
+                    let _: EmptyResponse? = try? await BaseService.shared.request(
+                        endPoint: .updateNotificationSettings,
+                        body: body
+                    )
+                }
             }
         }
         dialogBox.show(in: self)

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -189,7 +189,8 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         let timeText = formatTimeRange(start: schedule.startTime, end: schedule.endTime)
         let isTimeViewActive = (timeText != "-")
         
-        let isLastJourney = (schedule.scheduleOrder > 0 && totalSchedule == 1)
+        let isLastJourney = (schedule.scheduleOrder > 0 && schedule.scheduleOrder == totalSchedule)
+
         self.isCurrentlyLastJourney = isLastJourney
 
         let isCurrentTimeMatched = isCurrentTimeInSchedule(start: schedule.startTime, end: schedule.endTime)

--- a/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
+++ b/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
@@ -174,11 +174,9 @@ private extension MySpaceView {
                 let osEnabled = settings.authorizationStatus == .authorized
                     || settings.authorizationStatus == .provisional
 
-                let shouldEnable = isAlarmOn && osEnabled
-
-                if isAlarmOn != shouldEnable {
-                    isAlarmOn = shouldEnable
-                    updateNotificationSettings(enabled: false)
+                if isAlarmOn != osEnabled {
+                    isAlarmOn = osEnabled
+                    updateNotificationSettings(enabled: osEnabled)
                 }
             }
         }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #323 
<br>

## 🍎 작업 내용
- 아이 앱 알림 권한 허용 시 서버 알림 설정 동기화
    - 오늘의 여정 알림 팝업에서 OS 권한 허용 시 서버에도 pushNotificationEnabled: true 반영
    - 나의 공간 알림 토글이 OS 권한 상태와 서버 값을 양방향 동기화하도록 수정
- 인증 완료된 일정이 여정 지도에서 완료 상태로 표시되도록 수정
    - 진행 중(isOngoing)이더라도 VERIFIED 상태이면 COMPLETED로 표시
<br>

## 📸 스크린샷
| 자녀 오늘의 여정 QA 시트 | 자녀 나의 공간 QA 시트 |
|:-------------:|:-------------:|
| <img width="1393" height="673" alt="image" src="https://github.com/user-attachments/assets/a5427b71-4333-4785-88e7-b584b4ac7828" /> | <img width="1390" height="615" alt="image" src="https://github.com/user-attachments/assets/c01d8c96-23d6-4658-88c3-096cf0d6d9d4" /> |
<br>

## 💬 리뷰 코멘트
- DailyJourneyViewController.swift: 알림 허용 후 registerForRemoteNotifications()만 호출하던 부분에 서버 API 호출을 추가했습니다.
- MySpaceView.swift: refreshNotificationStatus()에서 기존에는 서버 ON + OS OFF일 때만 서버를 OFF로 변경(단방향)했는데 OS 상태 기준으로 양방향 동기화하도록 변경했습니다.
- CustomScrollView.swift: effectiveStatus 분기에서 VERIFIED && isOngoing일 때 완료 처리하지 않던 로직을 VERIFIED이면 무조건 COMPLETED로 통일했습니다.