### PR TITLE
[refactor] #324 2차 스프린트 | 1차 자체 QA

### DIFF
--- a/Kiero/Kiero/Network/Base/EndPoint.swift
+++ b/Kiero/Kiero/Network/Base/EndPoint.swift
@@ -68,7 +68,7 @@ enum EndPoint {
     case purchaseCoupon(couponId: Int64)
     
     // WishRoom
-    case fetchCouponHistory
+    case fetchCouponHistory(size: Int? = nil, cursor: String? = nil)
     
     // Reward
     case fetchCoupons(childId: Int)
@@ -235,6 +235,12 @@ enum EndPoint {
             return "/api/v1/parents/withdraw"
         case .fetchCouponHistory:
             return "/api/v1/coupons/history"
+        case .fetchCouponHistory(let size, let cursor):
+            var query: [String] = []
+            if let size { query.append("size=\(size)") }
+            if let cursor, !cursor.isEmpty { query.append("cursor=\(cursor)") }
+            let queryString = query.isEmpty ? "" : "?\(query.joined(separator: "&"))"
+            return "/api/v1/coupons/history\(queryString)"
         }
     }
     

--- a/Kiero/Kiero/Network/Base/EndPoint.swift
+++ b/Kiero/Kiero/Network/Base/EndPoint.swift
@@ -67,6 +67,9 @@ enum EndPoint {
     case fetchWishes
     case purchaseCoupon(couponId: Int64)
     
+    // WishRoom
+    case fetchCouponHistory
+    
     // Reward
     case fetchCoupons(childId: Int)
     case addCoupon(childId: Int)
@@ -88,7 +91,7 @@ enum EndPoint {
         switch self {
         case .kakaoLogin, .appleLogin, .kakaoAccessToken, .reissueAccessToken, .reissueAllTokens:
             return .none
-        case .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .purchaseCoupon, .completeMission, .fireLit, .fetchJourneyList, .childSignup, .fetchChildTerms, .checkParentWithdrawalStatus:
+        case .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .purchaseCoupon, .completeMission, .fireLit, .fetchJourneyList, .childSignup, .fetchChildTerms, .checkParentWithdrawalStatus, .fetchCouponHistory:
             return .child
         default:
             return .parent
@@ -230,12 +233,14 @@ enum EndPoint {
             return "/api/v1/terms/parent"
         case .deleteParentAccount:
             return "/api/v1/parents/withdraw"
+        case .fetchCouponHistory:
+            return "/api/v1/coupons/history"
         }
     }
     
     var method: String {
         switch self {
-        case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor, .fetchJourneyList, .fetchCoupons, .fetchTodayStatus, .fetchUnreadFeed, .requiredTerms, .requiredTermsAgreementStatus, .fetchParentInfo, .fetchMyPageLinks, .fetchChildTerms, .checkParentWithdrawalStatus:
+        case .checkConnection, .subscribeConnection, .fetchChildren, .fetchSchedules, .fetchChildrenInfo, .fetchWishes, .fetchMissions, .fetchDefaultColor, .fetchJourneyList, .fetchCoupons, .fetchTodayStatus, .fetchUnreadFeed, .requiredTerms, .requiredTermsAgreementStatus, .fetchParentInfo, .fetchMyPageLinks, .fetchChildTerms, .checkParentWithdrawalStatus, .fetchCouponHistory:
             return "GET"
         case .updateDailyJourney, .skipJourney, .completeSchedule, .fireLit, .completeMission, .editSchedule, .updateMission, .updateCoupon, .postImageRead, .fetchFeeds, .updateFCMToken, .updateNotificationSettings:
             return "PATCH"

--- a/Kiero/Kiero/Network/WishWell/DTO/CouponDTO.swift
+++ b/Kiero/Kiero/Network/WishWell/DTO/CouponDTO.swift
@@ -46,6 +46,11 @@ struct WishItem: Identifiable {
     let cost: Int
 }
 
+struct CouponHistoryResponse: Decodable {
+    let data: [CouponHistoryItem]
+    let nextCursor: String?
+}
+
 extension CouponHistoryItem {
     func toWishItem() -> WishItem {
         let displayDate = formatDate(purchasedAt)

--- a/Kiero/Kiero/Network/WishWell/DTO/CouponDTO.swift
+++ b/Kiero/Kiero/Network/WishWell/DTO/CouponDTO.swift
@@ -30,3 +30,44 @@ extension CouponResponseDTO {
         .init(id: couponId, name: name, price: price)
     }
 }
+
+// MARK: - 소원 이용내역
+
+struct CouponHistoryItem: Decodable {
+    let name: String
+    let price: Int
+    let purchasedAt: String
+}
+
+struct WishItem: Identifiable {
+    let id: String
+    let title: String
+    let acquiredDate: String
+    let cost: Int
+}
+
+extension CouponHistoryItem {
+    func toWishItem() -> WishItem {
+        let displayDate = formatDate(purchasedAt)
+        return WishItem(
+            id: name + purchasedAt + String(price),
+            title: name,
+            acquiredDate: displayDate,
+            cost: price
+        )
+    }
+    
+    private func formatDate(_ dateString: String) -> String {
+        let inputFormatter = DateFormatter()
+        inputFormatter.dateFormat = "yyyy-MM-dd"
+        inputFormatter.locale = Locale(identifier: "ko_KR")
+        
+        guard let date = inputFormatter.date(from: dateString) else { return dateString }
+        
+        let outputFormatter = DateFormatter()
+        outputFormatter.dateFormat = "M월 d일"
+        outputFormatter.locale = Locale(identifier: "ko_KR")
+        
+        return outputFormatter.string(from: date)
+    }
+}

--- a/Kiero/Kiero/Presentation/Common/Components/CustomScrollView.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/CustomScrollView.swift
@@ -44,14 +44,11 @@ struct CustomScrollView: View {
                         }()
                         
                         let effectiveStatus: String = {
-                            if schedule.status == .VERIFIED && schedule.isOngoing { return schedule.status.rawValue }
-                            if isFireLit && schedule.status == .VERIFIED { return "COMPLETED" }
-                            if isFireNotLit && schedule.status == .VERIFIED && !isTimeNotStarted { return "COMPLETED" }
+                            if schedule.status == .VERIFIED { return "COMPLETED" }
                             return schedule.status.rawValue
                         }()
                         let effectiveIsOngoing: Bool = {
-                            if schedule.status == .VERIFIED && schedule.isOngoing { return true }
-                            return (isFireLit || isFireNotLit) ? false : schedule.isOngoing
+                            return (isFireLit || isFireNotLit || schedule.status == .VERIFIED) ? false : schedule.isOngoing
                         }()
                         
                         let hasOngoing = data.schedules.contains { ($0.isOngoing && $0.status != .COMPLETED) || $0.status == .VERIFIED }

--- a/Kiero/Kiero/Presentation/Common/Components/WishRoomBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/WishRoomBox.swift
@@ -7,13 +7,6 @@
 
 import SwiftUI
 
-struct WishItem: Identifiable {
-    let id: Int
-    let title: String
-    let acquiredDate: String
-    let cost: Int
-}
-
 enum WishRoomBoxType {
     case wish(WishItem)
     case empty

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
@@ -169,6 +169,13 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
                 DispatchQueue.main.async {
                     UIApplication.shared.registerForRemoteNotifications()
                 }
+                Task {
+                    let body = NotificationSettingsRequest(pushNotificationEnabled: true)
+                    let _: EmptyResponse? = try? await BaseService.shared.request(
+                        endPoint: .updateNotificationSettings,
+                        body: body
+                    )
+                }
             }
         }
         dialogBox.show(in: self)

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -189,7 +189,8 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
         let timeText = formatTimeRange(start: schedule.startTime, end: schedule.endTime)
         let isTimeViewActive = (timeText != "-")
         
-        let isLastJourney = (schedule.scheduleOrder > 0 && totalSchedule == 1)
+        let isLastJourney = (schedule.scheduleOrder > 0 && schedule.scheduleOrder == totalSchedule)
+
         self.isCurrentlyLastJourney = isLastJourney
 
         let isCurrentTimeMatched = isCurrentTimeInSchedule(start: schedule.startTime, end: schedule.endTime)

--- a/Kiero/Kiero/Presentation/MyPage/View/ChildManageView.swift
+++ b/Kiero/Kiero/Presentation/MyPage/View/ChildManageView.swift
@@ -14,7 +14,15 @@ enum ChildConnectionState {
 
 struct ChildManageView: View {
     @Environment(\.dismiss) private var dismiss
-    @StateObject var viewModel = ChildManageViewModel()
+    @StateObject var viewModel: ChildManageViewModel
+    
+    init(initialConnectionState: ChildConnectionState) {
+        _viewModel = StateObject(
+            wrappedValue: ChildManageViewModel(
+                initialConnectionState: initialConnectionState
+            )
+        )
+    }
     
     var body: some View {
         ZStack {
@@ -61,6 +69,12 @@ struct ChildManageView: View {
             }
         }
         .navigationBarHidden(true)
+        .onReceive(viewModel.route) { route in
+            switch route {
+            case .toast(let message):
+                Toast.show(message: message, bottomInset: 125)
+            }
+        }
     }
 }
 

--- a/Kiero/Kiero/Presentation/MyPage/View/MyPageHostingController.swift
+++ b/Kiero/Kiero/Presentation/MyPage/View/MyPageHostingController.swift
@@ -18,7 +18,7 @@ final class MyPageHostingController: UIHostingController<MyPageView> {
         self.rootView = MyPageView(
             viewModel: viewModel,
             onChildManageTap: { [weak self] in
-                let vc = UIHostingController(rootView: ChildManageView())
+                let vc = UIHostingController(rootView: ChildManageView(initialConnectionState: viewModel.childConnectionState))
                 vc.hidesBottomBarWhenPushed = true
                 self?.navigationController?.pushViewController(vc, animated: true)
             },

--- a/Kiero/Kiero/Presentation/MyPage/View/MyPageView.swift
+++ b/Kiero/Kiero/Presentation/MyPage/View/MyPageView.swift
@@ -148,7 +148,7 @@ struct MyPageView: View {
                     state: .parentNotification,
                     isPresented: $viewModel.showNotificationDialog,
                     onConfirm: {
-                        viewModel.openAppSettings()
+                        viewModel.goToNotificationSettings()
                     }
                 )
                 .frame(width: 327, height: 216)
@@ -184,7 +184,7 @@ struct MyPageView: View {
                 for: UIApplication.willEnterForegroundNotification
             )
         ) { _ in
-            viewModel.refreshNotificationStatus()
+            viewModel.handleForeground()
         }
     }
 }

--- a/Kiero/Kiero/Presentation/MyPage/ViewModel/ChildManageViewModel.swift
+++ b/Kiero/Kiero/Presentation/MyPage/ViewModel/ChildManageViewModel.swift
@@ -8,6 +8,15 @@
 import Combine
 import Foundation
 
+enum ChildManageRoute {
+    case toast(String)
+}
+
+private enum InviteSessionKey {
+    static let code = "pendingInviteCode"
+    static let expiresAt = "pendingInviteExpiresAt"
+}
+
 final class ChildManageViewModel: BaseViewModel, ObservableObject {
     
     @Published var connectionState: ChildConnectionState = .connected
@@ -15,6 +24,11 @@ final class ChildManageViewModel: BaseViewModel, ObservableObject {
     @Published var inviteCode: String = ""
     @Published var remainingText: String = "00:00"
     @Published var isExpired: Bool = false
+    
+    private let routeSubject = PassthroughSubject<ChildManageRoute, Never>()
+    var route: AnyPublisher<ChildManageRoute, Never> {
+        routeSubject.eraseToAnyPublisher()
+    }
     
     private var childLastName: String = ""
     private var childFirstName: String = ""
@@ -24,11 +38,16 @@ final class ChildManageViewModel: BaseViewModel, ObservableObject {
     
     private var timerCancellable: AnyCancellable?
     
-    init(expiresIn: TimeInterval = 10 * 60) {
+    init(
+        initialConnectionState: ChildConnectionState,
+        expiresIn: TimeInterval = 10 * 60
+    ) {
+        self.connectionState = initialConnectionState
         self.expiresIn = expiresIn
         super.init()
-
+        
         fetchChild()
+        restoreInviteSessionIfNeeded()
         bindSSE()
     }
     
@@ -47,7 +66,6 @@ final class ChildManageViewModel: BaseViewModel, ObservableObject {
                     self.childLastName = child.childLastName
                     self.childFirstName = child.childFirstName
                     self.childName = "\(child.childLastName)\(child.childFirstName)"
-                    self.connectionState = .connected
                 }
             } catch {
                 print("자녀 조회 실패:", error)
@@ -75,9 +93,15 @@ final class ChildManageViewModel: BaseViewModel, ObservableObject {
                 )
                 
                 await MainActor.run {
+                    let expiresAt = Date().addingTimeInterval(self.expiresIn)
+
                     self.inviteCode = data.code
                     self.connectionState = .waiting
-                    self.expiresAt = Date().addingTimeInterval(self.expiresIn)
+                    self.expiresAt = expiresAt
+
+                    UserDefaults.standard.set(data.code, forKey: InviteSessionKey.code)
+                    UserDefaults.standard.set(expiresAt.timeIntervalSince1970, forKey: InviteSessionKey.expiresAt)
+
                     self.restartCountdown()
                 }
             } catch {
@@ -121,6 +145,7 @@ final class ChildManageViewModel: BaseViewModel, ObservableObject {
         if remaining <= 0 {
             remainingText = "00:00"
             isExpired = true
+            clearInviteSession()
             timerCancellable?.cancel()
             timerCancellable = nil
             return
@@ -128,6 +153,33 @@ final class ChildManageViewModel: BaseViewModel, ObservableObject {
         
         remainingText = Self.format(seconds: remaining)
         isExpired = false
+    }
+    
+    private func restoreInviteSessionIfNeeded() {
+        guard connectionState == .waiting else { return }
+        
+        guard let code = UserDefaults.standard.string(forKey: InviteSessionKey.code) else { return }
+        
+        let timestamp = UserDefaults.standard.double(forKey: InviteSessionKey.expiresAt)
+        guard timestamp > 0 else { return }
+        
+        let restoredExpiresAt = Date(timeIntervalSince1970: timestamp)
+        
+        guard restoredExpiresAt > Date() else {
+            clearInviteSession()
+            isExpired = true
+            remainingText = "00:00"
+            return
+        }
+        
+        inviteCode = code
+        expiresAt = restoredExpiresAt
+        startCountdown()
+    }
+    
+    private func clearInviteSession() {
+        UserDefaults.standard.removeObject(forKey: InviteSessionKey.code)
+        UserDefaults.standard.removeObject(forKey: InviteSessionKey.expiresAt)
     }
     
     private func bindSSE() {
@@ -141,7 +193,7 @@ final class ChildManageViewModel: BaseViewModel, ObservableObject {
                 print("📩 [ChildManageVM] CHILD_JOINED:", payload.childId ?? 0)
 
                 self.connectionState = .connected
-
+                self.clearInviteSession()
                 self.timerCancellable?.cancel()
                 self.timerCancellable = nil
 
@@ -149,6 +201,7 @@ final class ChildManageViewModel: BaseViewModel, ObservableObject {
                 self.remainingText = "00:00"
                 self.isExpired = false
                 self.expiresAt = nil
+                self.routeSubject.send(.toast("자녀 연결이 완료되었습니다."))
             }
             .store(in: &cancellables)
     }

--- a/Kiero/Kiero/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Kiero/Kiero/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -18,6 +18,8 @@ final class MyPageViewModel: BaseViewModel, ObservableObject {
     @Published var isAlarmOn: Bool = false
     @Published var showNotificationDialog: Bool = false
     
+    private var pendingEnableAfterSettings: Bool = false
+    
     private var externalLinks: [ExternalLinkDTO] = []
     
     let scrollToTop = PassthroughSubject<Void, Never>()
@@ -32,6 +34,10 @@ final class MyPageViewModel: BaseViewModel, ObservableObject {
     }
     
     // MARK: - Notification Settings
+    
+    private func isOSAuthorized(_ status: UNAuthorizationStatus) -> Bool {
+        status == .authorized || status == .provisional || status == .ephemeral
+    }
     
     private func updateNotificationSettings(enabled: Bool) {
         Task {
@@ -72,15 +78,12 @@ final class MyPageViewModel: BaseViewModel, ObservableObject {
                                 self.isAlarmOn = granted
                                 if granted {
                                     self.updateNotificationSettings(enabled: true)
-                                } else {
-                                    self.showNotificationDialog = true
                                 }
                             }
                         }
                     
                 @unknown default:
                     self.isAlarmOn = false
-                    self.showNotificationDialog = true
                 }
             }
         }
@@ -91,8 +94,51 @@ final class MyPageViewModel: BaseViewModel, ObservableObject {
         updateNotificationSettings(enabled: false)
     }
     
+    func goToNotificationSettings() {
+        pendingEnableAfterSettings = true
+        openAppSettings()
+    }
+
+    func handleForeground() {
+        if pendingEnableAfterSettings {
+            resolveReturnFromSettings()
+        } else {
+            refreshNotificationStatus()
+        }
+    }
+
+    private func resolveReturnFromSettings() {
+        pendingEnableAfterSettings = false
+        showNotificationDialog = false
+        
+        UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                if self.isOSAuthorized(settings.authorizationStatus) {
+                    self.isAlarmOn = true
+                    self.updateNotificationSettings(enabled: true)
+                } else {
+                    self.isAlarmOn = false
+                }
+            }
+        }
+    }
+    
     func refreshNotificationStatus() {
+        reconcileWithOSImmediately()
         fetchUserInfo()
+    }
+
+    private func reconcileWithOSImmediately() {
+        UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                let osEnabled = self.isOSAuthorized(settings.authorizationStatus)
+                if self.isAlarmOn && !osEnabled {
+                    self.isAlarmOn = false
+                }
+            }
+        }
     }
     
     // MARK: - Profile & Data
@@ -107,12 +153,7 @@ final class MyPageViewModel: BaseViewModel, ObservableObject {
                 )
                 
                 let settings = await UNUserNotificationCenter.current().notificationSettings()
-                
-                let isAuthorized =
-                settings.authorizationStatus == .authorized ||
-                settings.authorizationStatus == .provisional ||
-                settings.authorizationStatus == .ephemeral
-                
+                let isAuthorized = self.isOSAuthorized(settings.authorizationStatus)
                 let shouldEnable = profile.pushNotificationEnabled && isAuthorized
                 
                 await MainActor.run {
@@ -121,19 +162,19 @@ final class MyPageViewModel: BaseViewModel, ObservableObject {
                     self.childConnectionState =
                     profile.hasPendingChildSession ? .waiting : .connected
                     
-                    if self.isAlarmOn != shouldEnable {
-                        self.isAlarmOn = shouldEnable
-                        
-                        if profile.pushNotificationEnabled && !isAuthorized {
-                            self.updateNotificationSettings(enabled: false)
-                        }
-                    }
+                    self.isAlarmOn = shouldEnable
                 }
                 
             } catch {
+                let settings = await UNUserNotificationCenter.current().notificationSettings()
+                let isAuthorized = self.isOSAuthorized(settings.authorizationStatus)
+                
                 await MainActor.run {
                     self.userName = TokenManager.shared.getUserName() ?? ""
                     self.userImage = TokenManager.shared.getProfile()
+                    if self.isAlarmOn && !isAuthorized {
+                        self.isAlarmOn = false
+                    }
                 }
                 
                 print("프로필 정보 조회 실패:", error)

--- a/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
+++ b/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
@@ -174,11 +174,9 @@ private extension MySpaceView {
                 let osEnabled = settings.authorizationStatus == .authorized
                     || settings.authorizationStatus == .provisional
 
-                let shouldEnable = isAlarmOn && osEnabled
-
-                if isAlarmOn != shouldEnable {
-                    isAlarmOn = shouldEnable
-                    updateNotificationSettings(enabled: false)
+                if isAlarmOn != osEnabled {
+                    isAlarmOn = osEnabled
+                    updateNotificationSettings(enabled: osEnabled)
                 }
             }
         }

--- a/Kiero/Kiero/Presentation/TodayStatus/TodayStatusHostingController.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/TodayStatusHostingController.swift
@@ -117,10 +117,12 @@ private extension TodayStatusHostingController {
             dialogBox.dismiss()
             UNUserNotificationCenter.current().requestAuthorization(
                 options: [.alert, .badge, .sound]
-            ) { granted, _ in
+            ) { [weak self] granted, _ in
                 guard granted else { return }
+                
                 DispatchQueue.main.async {
                     UIApplication.shared.registerForRemoteNotifications()
+                    self?.viewModel.updateNotificationSettings(enabled: true)
                 }
             }
         }

--- a/Kiero/Kiero/Presentation/TodayStatus/TodayStatusViewModel.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/TodayStatusViewModel.swift
@@ -178,6 +178,21 @@ final class TodayStatusViewModel: BaseViewModel, ObservableObject {
         }
     }
     
+    func updateNotificationSettings(enabled: Bool) {
+        Task {
+            do {
+                let body = NotificationSettingsRequest(pushNotificationEnabled: enabled)
+                let _: EmptyResponse = try await BaseService.shared.request(
+                    endPoint: .updateNotificationSettings,
+                    body: body
+                )
+                print("✅ 알림 설정 변경 성공: \(enabled)")
+            } catch {
+                print("❌ 알림 설정 변경 실패: \(error)")
+            }
+        }
+    }
+    
     private func scheduleRefresh() {
         refreshWorkItem?.cancel()
         

--- a/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
+++ b/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
@@ -85,6 +85,11 @@ struct WishRoomView: View {
             if viewModel.hasTodayWishes {
                 ForEach(viewModel.todayWishes) { wish in
                     WishRoomBox(type: .wish(wish), isToday: true)
+                        .onAppear {
+                            if wish.id == viewModel.todayWishes.last?.id {
+                                viewModel.loadMoreIfNeeded()
+                            }
+                        }
                 }
             } else {
                 WishRoomBox(
@@ -104,6 +109,11 @@ struct WishRoomView: View {
             
             ForEach(viewModel.previousWishes) { wish in
                 WishRoomBox(type: .wish(wish), isToday: false)
+                    .onAppear {
+                        if wish.id == viewModel.previousWishes.last?.id {
+                            viewModel.loadMoreIfNeeded()
+                        }
+                    }
             }
         }
     }

--- a/Kiero/Kiero/Presentation/WishRoom/WishRoomViewModel.swift
+++ b/Kiero/Kiero/Presentation/WishRoom/WishRoomViewModel.swift
@@ -11,6 +11,7 @@ final class WishRoomViewModel: ObservableObject {
     
     @Published var todayWishes: [WishItem] = []
     @Published var previousWishes: [WishItem] = []
+    @Published var isLoading: Bool = false
     
     var onNavigateToWishWell: (() -> Void)?
     
@@ -25,30 +26,49 @@ final class WishRoomViewModel: ObservableObject {
     // MARK: - Init
     
     init() {
-        loadMockData()
+        fetchCouponHistory()
     }
     
-    // MARK: - Mock Data
-    
-    // TODO: - Api 연결 후 삭제
-    
-    private func loadMockData() {
-        todayWishes = [
-            WishItem(id: 1, title: "상헌 아트디렉터되기", acquiredDate: "5월 10일", cost: 100),
-            WishItem(id: 2, title: "윤주 데이트하기", acquiredDate: "5월 10일", cost: 100)
-        ]
+    func fetchCouponHistory() {
+        isLoading = true
         
-        previousWishes = [
-            WishItem(id: 3, title: "키어로 여름엠티", acquiredDate: "5월 2일", cost: 100),
-            WishItem(id: 4, title: "포이 숭실대오기", acquiredDate: "5월 2일", cost: 100),
-            WishItem(id: 5, title: "그냥이 건물공동소유", acquiredDate: "5월 2일", cost: 100),
-            WishItem(id: 6, title: "윤주 영화보기", acquiredDate: "5월 2일", cost: 100)
-        ]
+        Task {
+            do {
+                let items: [CouponHistoryItem] = try await BaseService.shared.request(
+                    endPoint: .fetchCouponHistory
+                )
+                
+                let today = todayString()
+                
+                let todayItems = items.filter { $0.purchasedAt == today }
+                let previousItems = items.filter { $0.purchasedAt != today }
+                
+                await MainActor.run {
+                    self.todayWishes = todayItems.map { $0.toWishItem() }
+                    self.previousWishes = previousItems.map { $0.toWishItem() }
+                    self.isLoading = false
+                }
+            } catch {
+                print("❌ 소원 이용내역 조회 실패: \(error)")
+                await MainActor.run {
+                    self.isLoading = false
+                }
+            }
+        }
     }
     
     // MARK: - Actions
     
     func navigateToMakeWish() {
         onNavigateToWishWell?()
+    }
+    
+    // MARK: - Helper
+    
+    private func todayString() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter.string(from: Date())
     }
 }

--- a/Kiero/Kiero/Presentation/WishRoom/WishRoomViewModel.swift
+++ b/Kiero/Kiero/Presentation/WishRoom/WishRoomViewModel.swift
@@ -13,6 +13,9 @@ final class WishRoomViewModel: ObservableObject {
     @Published var previousWishes: [WishItem] = []
     @Published var isLoading: Bool = false
     
+    private var nextCursor: String? = nil
+    private var hasMore: Bool = true
+    
     var onNavigateToWishWell: (() -> Void)?
     
     var totalWishCount: Int {
@@ -30,31 +33,33 @@ final class WishRoomViewModel: ObservableObject {
     }
     
     func fetchCouponHistory() {
+        guard !isLoading, hasMore else { return }
         isLoading = true
         
         Task {
             do {
                 let items: [CouponHistoryItem] = try await BaseService.shared.request(
-                    endPoint: .fetchCouponHistory
+                    endPoint: .fetchCouponHistory()
                 )
                 
                 let today = todayString()
                 
-                let todayItems = items.filter { $0.purchasedAt == today }
-                let previousItems = items.filter { $0.purchasedAt != today }
-                
                 await MainActor.run {
-                    self.todayWishes = todayItems.map { $0.toWishItem() }
-                    self.previousWishes = previousItems.map { $0.toWishItem() }
+                    self.todayWishes = items.filter { $0.purchasedAt == today }.map { $0.toWishItem() }
+                    self.previousWishes = items.filter { $0.purchasedAt != today }.map { $0.toWishItem() }
+                    self.hasMore = false
                     self.isLoading = false
                 }
             } catch {
                 print("❌ 소원 이용내역 조회 실패: \(error)")
-                await MainActor.run {
-                    self.isLoading = false
-                }
+                await MainActor.run { self.isLoading = false }
             }
         }
+    }
+    
+    func loadMoreIfNeeded() {
+        guard hasMore else { return }
+        fetchCouponHistory()
     }
     
     // MARK: - Actions


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #324 
<br>

## 🍎 작업 내용
메인 기능

자녀 관리 뷰에서 초대코드 발급 뒤 마이페이지에 나갔다와도 다시 초대코드와 유효시간이 다시 남도록 저장 후 다시 불러오는 로직을 추가했습니다.

<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 화면2 | 화면3 | 화면4 |
|:---------:|:-------------:|:-------------:|:-------------:|:-------------:|
| QA 시트 | <img src="https://github.com/user-attachments/assets/7a01e0fb-7f56-452e-b09b-5d5a3c8096ba" width="250"> | <img src="https://github.com/user-attachments/assets/3505b1b5-b878-452a-96f6-a58788e9701e" width="250"> | <img src="https://github.com/user-attachments/assets/fc5157b7-22b1-419c-b408-f18d682580fd" width="250"> | <img src="https://github.com/user-attachments/assets/f56a0c0b-be55-4ff2-9d96-1ae5b19f98fa" width="250"> |
<br>

## 💬 리뷰 코멘트
리뷰어가 신경써서 봐줄 부분을 알려주세요.
TodayStatusView에서 알림 허용 후 registerForRemoteNotifications()만 호출하던 부분에 서버 API 호출을 추가했습니다22