### PR TITLE
[refactor] #328 QA 수정사항 반영

### DIFF
--- a/Kiero/Kiero/Network/FCM/FCMTokenManager.swift
+++ b/Kiero/Kiero/Network/FCM/FCMTokenManager.swift
@@ -12,24 +12,34 @@ final class FCMTokenManager {
     private init() {}
     
     func saveToken(_ token: String) {
-        let isNewToken = UserDefaults.standard.string(forKey: "fcmToken") != token
-        UserDefaults.standard.set(token, forKey: "fcmToken")
-        
-        guard TokenManager.shared.getAccessToken() != nil else {
-            return
-        }
-        
-        if isNewToken {
-            print("📱 FCM 토큰 새로 발급 → 서버 전송")
-            Task {
-                await sendTokenToServer(token)
+            let isNewToken = UserDefaults.standard.string(forKey: "fcmToken") != token
+            UserDefaults.standard.set(token, forKey: "fcmToken")
+            
+            guard TokenManager.shared.getAccessToken() != nil else {
+                print("📱 [FCM] 토큰 수신 및 로컬 저장 완료")
+                return
+            }
+            
+            if isNewToken {
+                print("📱 [FCM] 로그인 상태에서 새 토큰 발급 → 서버 전송")
+                Task {
+                    await sendTokenToServer(token)
+                }
             }
         }
-    }
     
     func getToken() -> String? {
         UserDefaults.standard.string(forKey: "fcmToken")
     }
+    
+    func sendCurrentTokenToServer() async {
+            guard let token = getToken() else {
+                print("❌ [FCM] 서버에 보낼 로컬 저장된 토큰이 없습니다.")
+                return
+            }
+            print("📱 [FCM] 로그인 성공 확인 → 현재 토큰 서버 전송 시작")
+            await sendTokenToServer(token)
+        }
     
     func sendTokenToServer(_ token: String) async {
         do {

--- a/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
+++ b/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
@@ -274,6 +274,13 @@ private extension TabBarViewController {
             name: .deepLinkReceived,
             object: nil
         )
+        
+        NotificationCenter.default.addObserver(
+            self,
+                selector: #selector(handleNavigateToWishWell),
+                name: .navigateToWishWell,
+                object: nil
+            )
     }
     
     func updateCustomTabBarSelection() {
@@ -393,6 +400,14 @@ private extension TabBarViewController {
         } else {
             handleChildDeepLink(type: type)
         }
+    }
+    
+    @objc
+    func handleNavigateToWishWell() {
+        if let nav = viewControllers?[3] as? UINavigationController {
+            nav.popToRootViewController(animated: false)
+        }
+        selectedIndex = 2
     }
     
     private func handleParentDeepLink(type: String) {

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/ConfirmBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/ConfirmBox.swift
@@ -109,8 +109,7 @@ final class ConfirmBox: UIView {
     
     private func setLayout() {
         container.snp.makeConstraints {
-            $0.edges.equalToSuperview().inset(16)
-            $0.height.equalTo(248)
+            $0.edges.equalToSuperview()
         }
         
         characterImage.snp.makeConstraints {

--- a/Kiero/Kiero/Presentation/Common/Extensions/Notification+.swift
+++ b/Kiero/Kiero/Presentation/Common/Extensions/Notification+.swift
@@ -12,4 +12,5 @@ extension Notification.Name {
     static let hideTabBar = Notification.Name("hideTabBar")
     static let dimNavigationBar = Notification.Name("dimNavigationBar")
     static let hideNavigationBar = Notification.Name("hideNavigationBar")
+    static let navigateToWishWell = Notification.Name("navigateToWishWell")
 }

--- a/Kiero/Kiero/Presentation/Login/ViewModel/ChildrenLoginViewModel.swift
+++ b/Kiero/Kiero/Presentation/Login/ViewModel/ChildrenLoginViewModel.swift
@@ -68,6 +68,8 @@ final class ChildrenLoginViewModel: BaseViewModel {
                 TokenManager.shared.saveUserRole(data.role)
                 TokenManager.shared.saveUserName("\(data.lastName)\(data.firstName)")
                 TokenManager.shared.saveFirstName(data.firstName)
+                
+                await FCMTokenManager.shared.sendCurrentTokenToServer()
 
                 await MainActor.run {
                     self.stateSubject.send(.idle)

--- a/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
+++ b/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
@@ -75,6 +75,8 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
                 TokenManager.shared.saveUserName(loginData.name)
                 TokenManager.shared.saveUserRole(loginData.role)
                 
+                await FCMTokenManager.shared.sendCurrentTokenToServer()
+                
                 if try await routeRequiredTermsIfNeeded() {
                     return
                 }
@@ -140,6 +142,8 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
                 }
                 TokenManager.shared.saveUserName(loginData.name)
                 TokenManager.shared.saveUserRole(loginData.role)
+                
+                await FCMTokenManager.shared.sendCurrentTokenToServer()
                 
                 if try await routeRequiredTermsIfNeeded() {
                     return

--- a/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
+++ b/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
@@ -40,24 +40,27 @@ struct WishRoomView: View {
                 }
             }
             
-            LinearGradient(
-                colors: [.kBlack.opacity(0), .kBlack],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-            .frame(height: 156)
+            VStack(spacing: 0) {
+                LinearGradient(
+                    colors: [.kBlack.opacity(0), .kBlack],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .frame(height: 80)
+                .allowsHitTesting(false)
+                
+                CTAButtonWrapper(
+                    title: "확인",
+                    style: .main,
+                    size: .h49,
+                    onTap: { dismiss() }
+                )
+                .padding(.horizontal, 20)
+                .padding(.bottom, 32)
+                .frame(maxWidth: .infinity)
+                .background(.kBlack)
+            }
             .ignoresSafeArea(edges: .bottom)
-            .allowsHitTesting(false)
-            
-            CTAButtonWrapper(
-                title: "확인",
-                style: .main,
-                size: .h49,
-                onTap: { dismiss() }
-            )
-            .padding(.horizontal, 20)
-            .padding(.bottom, 19)
-            .background(.kBlack)
         }
         .navigationBarHidden(true)
     }

--- a/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
+++ b/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
@@ -22,11 +22,12 @@ struct WishRoomView: View {
                 )
                 .frame(height: 37)
                 
+                totalCountBanner
+                    .padding(.top, 25)
+                    .padding(.horizontal, 16)
+                
                 ScrollView(showsIndicators: false) {
                     VStack(spacing: 0) {
-                        totalCountBanner
-                            .padding(.top, 25)
-                        
                         todaySection
                             .padding(.top, 24)
                         

--- a/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
+++ b/Kiero/Kiero/Presentation/WishRoom/WishRoomView.swift
@@ -95,7 +95,12 @@ struct WishRoomView: View {
                 WishRoomBox(
                     type: .empty,
                     isToday: true,
-                    onEmptyTapped: { viewModel.navigateToMakeWish() }
+                    onEmptyTapped: {
+                        dismiss()
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            NotificationCenter.default.post(name: .navigateToWishWell, object: nil)
+                        }
+                    }
                 )
             }
         }

--- a/Kiero/Kiero/Presentation/WishWell/WishWellViewController.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellViewController.swift
@@ -89,6 +89,7 @@ final class WishWellViewController: BaseViewController<WishWellViewModel>{
     
     @objc private func didTapGoToWishRoom() {
         let wishRoomVC = diContainer.makeWishRoomViewController()
+        wishRoomVC.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(wishRoomVC, animated: true)
     }
 }


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #328 
<br>

## 🍎 작업 내용
- 소원 획득과 금화 획득시의 dialog 크기를 수정하였습니다. 
- 소원의 공간 페이지 진입시 탭바를 숨깁니다
- 나의 공간 -> 소원의 공간 -> 소원의 우물 이동시 탭바 역시 소원의 우물을 가리킵니다.
- 소원의 공간 스크롤 영역을 수정합니다. 
- 소원의 공간 하단 그라데이션을 수정합니다. 
- 로그인 시 마다 fcm 토큰을 서버로 전송하도록합니다. 
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 화면2 | 화면3 |
|:---------:|:-------------:|:-------------:|:-------------:|
| 기능1 | <img width="500" alt="Simulator Screenshot - iPhone 12 - 2026-06-06 at 01 21 55" src="https://github.com/user-attachments/assets/00cef64a-e7ae-44cd-868e-967225af83e6" /> | <img width="500" alt="Simulator Screenshot - iPhone 12 - 2026-06-06 at 01 21 45" src="https://github.com/user-attachments/assets/1c988b31-917b-4ca3-8fd5-a9402a6f32f2" /> | <img width="500" alt="IMG_7337" src="https://github.com/user-attachments/assets/cf99029e-e4d0-4365-9fea-c9df047d7587" /> |
<br>

## 💬 리뷰 코멘트
지난번에 로그인시에 saveFCMToken 로직이 중복되는 것 같아 해당 로직을 삭제했었는데요, 이 로직을 삭제하면 계정을 삭제하고 다시 들어왔을 때 userdefault에는 토큰이 남아있어 서버로 토큰이 전송되지는 않지만 정작 서버에는 토큰이 저장되지 않는 이슈가 생겼습니다. 따라서 토큰의 저장 여부와 관계 없이, 로그인시 현재 토큰 정보를 서버로 보내는 로직을 추가했습니다. 
추가로 firebase 콘솔에 프로덕션 용 p8 파일도 업로드 하니 이제 시뮬-테플도 푸시 알림 테스트가 가능하더라고요! 이걸로 테스트했을 때 잘 되는 것을 확인했습니다. 제발 잘 되었으면 좋겠네요.....

이거 확인하려고 db도 걍 연결해버렸습니다.... 앞으로 db 지울일 있으면 저한테 말씀하셔도 됩니다....
