### PR TITLE
[refactor] #332 2차 스프린트 | QA 반영

### DIFF
--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -773,4 +773,17 @@ extension AddScheduleViewController: UITextFieldDelegate {
         textField.resignFirstResponder()
         return true
     }
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        if string.isEmpty { return true }
+        
+        if textField.markedTextRange == nil {
+            let currentText = textField.text ?? ""
+            guard let swiftRange = Range(range, in: currentText) else { return true }
+            let newText = currentText.replacingCharacters(in: swiftRange, with: string)
+            return newText.count <= 8
+        }
+        
+        return true
+    }
 }

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -108,7 +108,6 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             viewModel?.fetchDefaultColor()
         }
         
-        addTarget()
         updatePagingTitle()
     }
     
@@ -355,6 +354,15 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         titleTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         colorArrowButton.addTarget(self, action: #selector(didTapColorPicker), for: .touchUpInside)
         repeatSwitch.addTarget(self, action: #selector(repeatSwitchChanged), for: .valueChanged)
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc
+    private func dismissKeyboard() {
+        view.endEditing(true)
     }
     
     func configure(with schedule: Schedule) {
@@ -368,10 +376,6 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             return components[0] * 60 + components[1]
         }
         return 0
-    }
-    
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        self.view.endEditing(true)
     }
     
     override func bindViewModel() {

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewModel.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewModel.swift
@@ -55,6 +55,7 @@ final class AddScheduleViewModel: BaseViewModel {
     
     func fetchDefaultColor() {
         service.fetchDefaultColor(childId: childId)
+            .receive(on: DispatchQueue.main)
             .sink { _ in } receiveValue: { [weak self] response in
                 let colorMapping: [String: UIColor] = [
                     "SCHEDULE1": .schedule1, "SCHEDULE2": .schedule2,


### PR DESCRIPTION
## 📟 연결된 이슈
closed #332 
<br>

## 🍎 작업 내용
- 부모 일정 추가 시 , 텍스트 필드 8자 입력 방식을 개선했습니다.
- 애플로그인에서 받아온 이름 반영과 관련해서는, 이름이 없을 때 이메일로 대체되었던 기존 방식을 유지하는 것으로 기획과 서버와 이야기 나누었습니다.
- 텍스트 필드 활성화 시, 디버그 딜레이가 있어서 로직을 개선하였습니다.
<br>

## 📸 스크린샷
| 기능/화면 | 초성+중성 | 초성 |
|:---------:|:-------------:|:-------------:|
| 부모 일정 추가 | <img src="https://github.com/user-attachments/assets/0083d86d-5834-451c-a5c6-abcae9a48f6a" width="250"> | <img src="https://github.com/user-attachments/assets/1d6e7982-949c-4494-92d5-9a9773279e6f" width="250"> |
<br>

## 💬 리뷰 코멘트
디버그 딜레이와 관련해서 원인을 더 파악해봐야할 것 같습니다.