### PR TITLE
[refactor] #335 레드닷 이슈 수정

### DIFF
--- a/Kiero/Kiero/Network/Login/SseClient.swift
+++ b/Kiero/Kiero/Network/Login/SseClient.swift
@@ -8,17 +8,17 @@
 import Foundation
 
 final class SseClient: NSObject {
-
+    
     private let url: URL
     private let tokenProvider: () -> String?
     private let onEvent: (SseEventPayload) -> Void
     private let onConnected: (() -> Void)?
     private let onError: (Error) -> Void
-
+    
     private var session: URLSession!
     private var task: URLSessionDataTask?
     private var buffer = ""
-
+    
     init(
         url: URL,
         tokenProvider: @escaping () -> String?,
@@ -32,45 +32,45 @@ final class SseClient: NSObject {
         self.onConnected = onConnected
         self.onError = onError
         super.init()
-
+        
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = .infinity
         config.timeoutIntervalForResource = .infinity
         self.session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
     }
-
+    
     func connect() {
         disconnect()
-
+        
         var req = URLRequest(url: url)
         req.httpMethod = "GET"
         req.setValue("text/event-stream", forHTTPHeaderField: "Accept")
         req.setValue("no-cache", forHTTPHeaderField: "Cache-Control")
-
+        
         if let token = tokenProvider() {
             req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
         
         print("🌐 [SSEClient] CONNECT URL:", req.url?.absoluteString ?? "nil")
         print("🌐 [SSEClient] HEADERS:", req.allHTTPHeaderFields ?? [:])
-
+        
         buffer = ""
         task = session.dataTask(with: req)
         task?.resume()
         
         print("🌐 [SSEClient] task resume called")
     }
-
+    
     func disconnect() {
         task?.cancel()
         task = nil
         buffer = ""
     }
-
+    
     private func handleChunk(_ data: Data) {
         guard let chunk = String(data: data, encoding: .utf8) else { return }
         buffer += chunk
-
+        
         while true {
             if let r = buffer.range(of: "\r\n\r\n") {
                 let block = String(buffer[..<r.lowerBound])
@@ -90,10 +90,10 @@ final class SseClient: NSObject {
     
     private func parseEventBlock(_ block: String) {
         let normalized = block.replacingOccurrences(of: "\r\n", with: "\n")
-
+        
         var eventName: String?
         var dataLines: [String] = []
-
+        
         for line in normalized.split(separator: "\n").map(String.init) {
             if line.hasPrefix("event:") {
                 eventName = line.dropFirst("event:".count).trimmingCharacters(in: .whitespaces)
@@ -102,28 +102,28 @@ final class SseClient: NSObject {
                 dataLines.append(v)
             }
         }
-
+        
         guard !dataLines.isEmpty else { return }
-
+        
         let dataString = dataLines.joined(separator: "\n")
         let trimmed = dataString.trimmingCharacters(in: .whitespacesAndNewlines)
-
+        
         if eventName == "connected" {
             print("✅ [SSEClient] CONNECTED event received:", trimmed)
             onConnected?()
             return
         }
-
+        
         if eventName == "heartbeat" {
             print("💓 [SSEClient] heartbeat:", trimmed)
             return
         }
-
+        
         guard trimmed.hasPrefix("{"),
               let jsonData = trimmed.data(using: .utf8) else {
             return
         }
-
+        
         do {
             let payload = try JSONDecoder().decode(SseEventPayload.self, from: jsonData)
             onEvent(payload)
@@ -148,9 +148,16 @@ extension SseClient: URLSessionDataDelegate {
         }
         completionHandler(.allow)
     }
-
+    
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         print("📥 [SSEClient] RAW CHUNK:", String(data: data, encoding: .utf8) ?? "nil")
         handleChunk(data)
+    }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error = error {
+            print("❌ [SSEClient] connection terminated:", error.localizedDescription)
+            onError(error)
+        }
     }
 }

--- a/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
+++ b/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
@@ -281,6 +281,13 @@ private extension TabBarViewController {
                 name: .navigateToWishWell,
                 object: nil
             )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAppWillEnterForeground),
+            name: UIScene.willEnterForegroundNotification,
+            object: nil
+        )
     }
     
     func updateCustomTabBarSelection() {
@@ -408,6 +415,17 @@ private extension TabBarViewController {
             nav.popToRootViewController(animated: false)
         }
         selectedIndex = 2
+    }
+    
+    @objc
+    private func handleAppWillEnterForeground() {
+        guard isParent else { return }
+        
+        print("🔄 포그라운드 복귀 - 동기화 시작")
+        fetchInitialUnreadStatus()
+        
+        globalSseStarted = false
+        startGlobalFeedSSEIfNeeded()
     }
     
     private func handleParentDeepLink(type: String) {

--- a/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
+++ b/Kiero/Kiero/Presentation/Common/Base/TabBarViewController.swift
@@ -277,10 +277,10 @@ private extension TabBarViewController {
         
         NotificationCenter.default.addObserver(
             self,
-                selector: #selector(handleNavigateToWishWell),
-                name: .navigateToWishWell,
-                object: nil
-            )
+            selector: #selector(handleNavigateToWishWell),
+            name: .navigateToWishWell,
+            object: nil
+        )
         
         NotificationCenter.default.addObserver(
             self,
@@ -424,8 +424,8 @@ private extension TabBarViewController {
         print("🔄 포그라운드 복귀 - 동기화 시작")
         fetchInitialUnreadStatus()
         
-        globalSseStarted = false
-        startGlobalFeedSSEIfNeeded()
+        SseStreamManager.shared.pause()
+        SseStreamManager.shared.resume()
     }
     
     private func handleParentDeepLink(type: String) {
@@ -461,7 +461,7 @@ private extension TabBarViewController {
             if let nav = viewControllers?.first as? UINavigationController {
                 nav.popToRootViewController(animated: false)
             }
-
+            
         case "CHILD_MISSION_INCOMPLETE":
             selectedIndex = 1
             if let nav = viewControllers?[1] as? UINavigationController {
@@ -628,7 +628,7 @@ private extension TabBarViewController {
                     LogoutHelper.logoutToPickRole()
                     return
                 }
-
+                
                 guard payload.eventType == "FEED_ITEM_CREATED" else { return }
                 
                 NotificationCenter.default.post(


### PR DESCRIPTION
## 📟 연결된 이슈
closed <!-- #335 -->
<br>

## 🍎 작업 내용
푸시 알림 확인을 위해 백그라운드로 들어갔다가 다시 앱에 진입하면 레드닷이 나타나지 않는 이슈가 있었습니다. 

iOS에서는 앱이 백그라운드로 전환되면 OS가 배터리 절약을 위해 네트워크 연결을 제한한다고 합니다. 이로 인해 SSE 연결이 끊기게 되고, 백그라운드 상태에서 서버가 보낸 이벤트를 수신하지 못하는 문제가 발생합니다.

기존에는 `fetchInitialUnreadStatus()`가 `viewDidLoad` 시점에만 호출되어, 앱이 처음 실행될 때만 미확인 알림 상태를 조회했습니다. 따라서 백그라운드에서 포그라운드로 복귀했을 때 SSE 연결이 끊긴 채로 유지되고, 그 사이 발생한 알림이 반영되지 않는 문제가 있었습니다.
따라서 
- `TabBarViewController`에 `UIScene.willEnterForegroundNotification` 옵저버 등록
- 포그라운드 복귀 시 미확인 알림 존재 여부 API 호출하여 뱃지 상태 동기화
- SSE 연결 상태를 리셋하고 재연결하여 이후 실시간 이벤트 수신 재개
를 통해 포그라운드 복귀시 미확인 알림에 대한 레드닷이 나타나도록 하였습니다. 
<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 
|:---------:|:-------------:|
| 기능1 | <img width="295" height="640" alt="Simulator Screen Recording - iPhone 17 - 2026-06-07 at 00 57 55" src="https://github.com/user-attachments/assets/311c43a5-c5cf-4730-ba5d-81cf540d7795" /> | 
<br>

## 💬 리뷰 코멘트
이렇게 또 하나 알아갑니다.....
pr 한번에 올렸으면 좋았을텐데 푸시 알림 수정하다 발견해서 따로 올립니다. 죄송합니다
