### PR TITLE
[refactor] #337 2차 스프린트 1차 QA 반영

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -215,7 +215,7 @@ final class DialogBox: UIView {
     }
     
     private let messageLabel = UILabel().then {
-        $0.textColor = .white
+        $0.textColor = .gray100
         $0.numberOfLines = 2
     }
     

--- a/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
+++ b/Kiero/Kiero/Presentation/Common/Components/Dialog/DialogBox.swift
@@ -75,7 +75,7 @@ final class DialogBox: UIView {
             case .deleteSchedule, .deleteReward, .deleteMission:
                 return "삭제하시겠습니까?"
             case .childNotification:
-                return "알림을 받으려면 설정에서 키어로 알림을 허용해줘!"
+                return "알림을 받으려면\n설정에서 키어로 알림을 허용해줘!"
             case .notificationRequest:
                 return "여정의 중요한 알림을 받아볼 수 있어."
             case .childLogout:

--- a/Kiero/Kiero/Presentation/Common/Wrapper/DialogBoxWrapper.swift
+++ b/Kiero/Kiero/Presentation/Common/Wrapper/DialogBoxWrapper.swift
@@ -8,31 +8,52 @@
 import SwiftUI
 import UIKit
 
-struct DialogBoxWrapper: UIViewRepresentable {
+struct DialogBoxView: View {
     var state: DialogBox.State
     @Binding var isPresented: Bool
     var onConfirm: (() -> Void)?
-    
+
+    var body: some View {
+        DialogBoxWrapper(state: state, isPresented: $isPresented, onConfirm: onConfirm)
+            .frame(width: 343)
+    }
+}
+
+private struct DialogBoxWrapper: UIViewRepresentable {
+    var state: DialogBox.State
+    @Binding var isPresented: Bool
+    var onConfirm: (() -> Void)?
+
     func makeUIView(context: Context) -> DialogBox {
         let view = DialogBox()
-        
+
         view.onTapClose = {
             isPresented = false
         }
-        
+
         view.onTapCancel = {
             isPresented = false
         }
-        
+
         view.onTapConfirm = {
             onConfirm?()
             isPresented = false
         }
-        
+
         return view
     }
-    
+
     func updateUIView(_ uiView: DialogBox, context: Context) {
         uiView.configure(state: state)
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: DialogBox, context: Context) -> CGSize? {
+        let width: CGFloat = 343
+        let size = uiView.systemLayoutSizeFitting(
+            CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        return CGSize(width: width, height: size.height)
     }
 }

--- a/Kiero/Kiero/Presentation/MyPage/View/MyPageView.swift
+++ b/Kiero/Kiero/Presentation/MyPage/View/MyPageView.swift
@@ -144,14 +144,13 @@ struct MyPageView: View {
                         viewModel.showNotificationDialog = false
                     }
                 
-                DialogBoxWrapper(
+                DialogBoxView(
                     state: .parentNotification,
                     isPresented: $viewModel.showNotificationDialog,
                     onConfirm: {
                         viewModel.goToNotificationSettings()
                     }
                 )
-                .frame(width: 327, height: 216)
                 .padding(.horizontal, 16)
                 .zIndex(1)
             }
@@ -163,14 +162,13 @@ struct MyPageView: View {
                         showDialog.toggle()
                     }
                 
-                DialogBoxWrapper(
+                DialogBoxView(
                     state: .logout,
                     isPresented: $showDialog,
                     onConfirm: {
                         viewModel.requestLogout()
                     }
                 )
-                .frame(width: 327, height: 216)
                 .padding(.horizontal, 16)
                 .zIndex(1)
             }

--- a/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
+++ b/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
@@ -96,14 +96,13 @@ struct MySpaceView: View {
                         .ignoresSafeArea()
                         .onTapGesture { showNotificationDialog = false }
                     
-                    DialogBoxWrapper(
+                    DialogBoxView(
                         state: .childNotification,
                         isPresented: $showNotificationDialog,
                         onConfirm: {
                             openAppSettings()
                         }
                     )
-                    .frame(width: 327, height: 216)
                     .padding(.horizontal, 16)
                     .zIndex(1)
                 }
@@ -113,14 +112,13 @@ struct MySpaceView: View {
                         .ignoresSafeArea()
                         .onTapGesture { showLogoutDialog = false }
                     
-                    DialogBoxWrapper(
+                    DialogBoxView(
                         state: .childLogout,
                         isPresented: $showLogoutDialog,
                         onConfirm: {
                             performLogout()
                         }
                     )
-                    .frame(width: 327, height: 216)
                     .padding(.horizontal, 16)
                     .zIndex(1)
                 }

--- a/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
+++ b/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import UserNotifications
 
 struct MySpaceView: View {
-    @State private var isAlarmOn = false
+    @State private var isAlarmOn = UserDefaults.standard.bool(forKey: "child_pushNotificationEnabled")
     @State private var showNotificationDialog = false
     @State private var showLogoutDialog = false
     @State private var showTerms = false
@@ -133,6 +133,9 @@ struct MySpaceView: View {
             .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
                 fetchProfile()
             }
+            .onChange(of: isAlarmOn) { _, newValue in
+                UserDefaults.standard.set(newValue, forKey: "child_pushNotificationEnabled")
+            }
         }
     }
 }
@@ -172,10 +175,10 @@ private extension MySpaceView {
         UNUserNotificationCenter.current().getNotificationSettings { settings in
             DispatchQueue.main.async {
                 let osEnabled = settings.authorizationStatus == .authorized
-                    || settings.authorizationStatus == .provisional
-
+                || settings.authorizationStatus == .provisional
+                
                 if isAlarmOn != osEnabled {
-                    isAlarmOn = osEnabled
+                    setAlarmSilently(osEnabled)
                     updateNotificationSettings(enabled: osEnabled)
                 }
             }
@@ -186,10 +189,18 @@ private extension MySpaceView {
         WishWellService().fetchMyInfo()
             .receive(on: DispatchQueue.main)
             .sink { _ in } receiveValue: { info in
-                isAlarmOn = info.pushNotificationEnabled
+                setAlarmSilently(info.pushNotificationEnabled)
                 refreshNotificationStatus()
             }
             .store(in: &StaticCancellables.bag)
+    }
+    
+    func setAlarmSilently(_ value: Bool) {
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            isAlarmOn = value
+        }
     }
     
     func updateNotificationSettings(enabled: Bool) {

--- a/Kiero/Kiero/Presentation/Reward/RewardView.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardView.swift
@@ -79,14 +79,13 @@ struct RewardView: View {
                     .ignoresSafeArea()
                     .onTapGesture { viewModel.showDeleteDialog = false }
                 
-                DialogBoxWrapper(
+                DialogBoxView(
                     state: .deleteReward(title: reward.title, coin: "\(reward.cost)"),
                     isPresented: $viewModel.showDeleteDialog,
                     onConfirm: {
                         viewModel.deleteReward(reward: reward)
                     }
                 )
-                .frame(width: 327, height: 216)
                 .transition(.scale.combined(with: .opacity))
             }
         }


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #337
<br>

## 🍎 작업 내용
- 나의 공간 알림 토글: 탭 전환 시 움찔거림 수정 (UserDefaults 캐시 + 프로그래매틱 애니메이션 비활성화)
- DialogBox 컴포넌트: SwiftUI 래퍼 크기 피그마 기준(343x197)으로 통일, sizeThatFits 적용으로 동적 높이 지원
- DialogBox 메시지 텍스트 색상: white → gray100 (피그마 디자인 반영)
- DialogBoxView 캡슐화: 크기를 컴포넌트 내부에서 관리하도록 변경, 외부에서 frame 지정 불필요
- 알림 설정 DialogBox 문구 수정
<br>

## 📸 스크린샷
| 알림 토글 | DialogBox | 문구 수정 |
|:---------:|:-------------:|:-------------:|
| <img width="200" alt="알람토글" src="https://github.com/user-attachments/assets/998d1cdb-66ee-4891-a68a-e79f965b9523" /> | <img width="200" alt="image" src="https://github.com/user-attachments/assets/70bb4c01-ad41-4719-928c-1c9880246200" /> | <img width="200" alt="image" src="https://github.com/user-attachments/assets/9d1c7478-17ee-473b-a2c8-76990e17a8ee" /> |



<br>

## 💬 리뷰 코멘트
- `DialogBoxWrapper`를 `private`으로 변경하고 `DialogBoxView`로 통일했습니다. 기존에 `DialogBoxWrapper`를 직접 사용하던 곳(MyPageView, RewardView)도 모두 교체했습니다.
- 알림 토글은 `setAlarmSilently(_:)`로 네트워크/OS 콜백 시 애니메이션을 억제하고, 유저 탭 시에만 애니메이션이 동작합니다.