### PR TITLE
[refactor] #333 2차 스프린트 | QA 반영

### DIFF
--- a/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewController.swift
+++ b/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewController.swift
@@ -13,15 +13,12 @@ import Then
 
 final class AuthGateViewController: UIViewController {
 
-    // MARK: - Properties
-
     private let viewModel: AuthGateViewModel
     private var cancellables = Set<AnyCancellable>()
     private var pendingWork: DispatchWorkItem?
     
     private var dimPanelBottomConstraint: Constraint?
     private var pickRoleBottomConstraint: Constraint?
-
 
     private var overlayPrepared = false
 
@@ -35,8 +32,6 @@ final class AuthGateViewController: UIViewController {
         static let pickRoleHiddenOffset: CGFloat = 1000
     }
 
-    // MARK: - UI Components
-
     private let splashView = SplashView()
 
     private let dimPanelView = GradientDimView().then {
@@ -45,16 +40,14 @@ final class AuthGateViewController: UIViewController {
 
     private let pickRoleView = PickRoleView()
 
-    // MARK: - Init
-
     init(viewModel: AuthGateViewModel = AuthGateViewModel()) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
 
-    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
-
-    // MARK: - Life Cycle
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -64,15 +57,11 @@ final class AuthGateViewController: UIViewController {
         viewModel.decideRoute()
     }
 
-    // MARK: - Setup Methods
-
     private func setUI() {
         view.addSubview(splashView)
         splashView.snp.makeConstraints { $0.edges.equalToSuperview() }
         splashView.start()
     }
-
-    // MARK: - Bind
 
     private func bind() {
         viewModel.route
@@ -80,9 +69,11 @@ final class AuthGateViewController: UIViewController {
             .sink { [weak self] route in
                 guard let self else { return }
 
-                if route == .parentOnboarding {
+                switch route {
+                case .parentOnboarding:
                     self.transition(after: 2.0, to: route)
-                } else {
+
+                default:
                     self.transition(after: 0.0, to: route)
                 }
             }
@@ -95,6 +86,7 @@ final class AuthGateViewController: UIViewController {
         let work = DispatchWorkItem { [weak self] in
             self?.handle(by: route)
         }
+
         pendingWork = work
         DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: work)
     }
@@ -107,6 +99,20 @@ final class AuthGateViewController: UIViewController {
             DispatchQueue.main.asyncAfter(deadline: .now() + IntroTiming.splashHold) { [weak self] in
                 self?.showPickRoleOverlaySequence()
             }
+
+        case .parentRequiredTerms(let terms):
+            let vm = ParentLoginViewModel()
+
+            let vc = ParentLoginViewController(
+                viewModel: vm,
+                diContainer: AppDIContainer.shared
+            )
+
+            vc.pendingRequiredTerms = terms
+
+            changeRoot(
+                UINavigationController(rootViewController: vc)
+            )
 
         case .parentOnboarding:
             let vc = AppDIContainer.shared.makeParentOnboardingViewController()
@@ -151,34 +157,41 @@ final class AuthGateViewController: UIViewController {
     private func showPickRoleOverlaySequence() {
         view.layoutIfNeeded()
 
-        UIView.animate(withDuration: IntroTiming.dimDuration,
-                       delay: 0,
-                       options: [.curveEaseOut]) {
+        UIView.animate(
+            withDuration: IntroTiming.dimDuration,
+            delay: 0,
+            options: [.curveEaseOut]
+        ) {
             self.dimPanelView.alpha = 1
             self.dimPanelBottomConstraint?.update(offset: 0)
             self.view.layoutIfNeeded()
         }
 
-        UIView.animate(withDuration: IntroTiming.pickRoleDuration,
-                       delay: IntroTiming.pickRoleDelayAfterDimStart,
-                       options: [.curveEaseOut]) {
+        UIView.animate(
+            withDuration: IntroTiming.pickRoleDuration,
+            delay: IntroTiming.pickRoleDelayAfterDimStart,
+            options: [.curveEaseOut]
+        ) {
             self.pickRoleBottomConstraint?.update(offset: 0)
             self.view.layoutIfNeeded()
         }
     }
 
-    // MARK: - Navigation
-
     private func goLoginFlow(for role: LoginUser) {
         let vc: UIViewController
+
         switch role {
         case .parent:
             let vm = ParentLoginViewModel()
             vc = ParentLoginViewController(viewModel: vm, diContainer: AppDIContainer.shared)
             
         case .child:
-            vc = ChildrenLoginViewController(viewModel: ChildrenLoginViewModel(), diContainer: AppDIContainer.shared)
+            vc = ChildrenLoginViewController(
+                viewModel: ChildrenLoginViewModel(),
+                diContainer: AppDIContainer.shared
+            )
         }
+
         navigationController?.setNavigationBarHidden(false, animated: true)
         navigationController?.pushViewController(vc, animated: true)
     }

--- a/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewModel.swift
+++ b/Kiero/Kiero/Presentation/Common/Auth/AuthGateViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 
 enum AuthGateRoute {
     case pickRole
+    case parentRequiredTerms([RequiredTerm])
     case parentOnboarding
     case parentTab
     case childTab
@@ -21,12 +22,10 @@ final class AuthGateViewModel {
     var route: AnyPublisher<AuthGateRoute, Never> { routeSubject.eraseToAnyPublisher() }
     
     func decideRoute() {
-        
         guard TokenManager.shared.getAccessToken() != nil else {
             routeSubject.send(.pickRole)
             return
         }
-        
         
         let role = (TokenManager.shared.getUserRole() ?? "").lowercased()
         
@@ -49,6 +48,7 @@ final class AuthGateViewModel {
                 let status: ParentWithdrawalStatusDTO = try await BaseService.shared.request(
                     endPoint: .checkParentWithdrawalStatus
                 )
+                
                 await MainActor.run {
                     if status.isParentWithdrawn {
                         LogoutHelper.logoutToPickRole()
@@ -63,10 +63,18 @@ final class AuthGateViewModel {
             }
         }
     }
-
+    
     private func decideParentRoute() {
         Task {
             do {
+                if let requiredTerms = try await checkRequiredTerms() {
+                    await MainActor.run {
+                        TokenManager.shared.saveRequiredTermsIds(requiredTerms.map { $0.termsId })
+                        self.routeSubject.send(.parentRequiredTerms(requiredTerms))
+                    }
+                    return
+                }
+                
                 let children: [ChildrenData] = try await BaseService.shared.request(
                     endPoint: .fetchChildren
                 )
@@ -84,5 +92,21 @@ final class AuthGateViewModel {
                 }
             }
         }
+    }
+    
+    private func checkRequiredTerms() async throws -> [RequiredTerm]? {
+        let agreement: RequiredTermsAgreementStatusData = try await BaseService.shared.request(
+            endPoint: .requiredTermsAgreementStatus
+        )
+        
+        guard agreement.isRequiredTermsAllAgreed == false else {
+            return nil
+        }
+        
+        let terms: [RequiredTerm] = try await BaseService.shared.request(
+            endPoint: .requiredTerms
+        )
+        
+        return terms
     }
 }

--- a/Kiero/Kiero/Presentation/Login/View/ParentLoginViewController.swift
+++ b/Kiero/Kiero/Presentation/Login/View/ParentLoginViewController.swift
@@ -20,6 +20,9 @@ final class ParentLoginViewController: BaseViewController<ParentLoginViewModel> 
     
     private var loadingVC: UIViewController?
     
+    var pendingRequiredTerms: [RequiredTerm]?
+    private var didShowPendingRequiredTerms = false
+    
     // MARK: - UI Components
     
     private let parentNaviBar = NavigationBar(type: .back(title: "부모님으로 시작하기"))
@@ -34,6 +37,17 @@ final class ParentLoginViewController: BaseViewController<ParentLoginViewModel> 
     
     private let kakaoLoginButton = LoginButton(type: .kakao)
     private let appleLoginButton = LoginButton(type: .apple)
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        guard !didShowPendingRequiredTerms,
+              let pendingRequiredTerms
+        else { return }
+        
+        didShowPendingRequiredTerms = true
+        presentRequiredTermsBottomSheet(pendingRequiredTerms)
+    }
     
     override func setStyle() {
         parentImageView.transform = CGAffineTransform(rotationAngle: -(.pi / 180 * 35))

--- a/Kiero/Kiero/Presentation/PickRole/RequiredTermsBottomSheetHostingViewController.swift
+++ b/Kiero/Kiero/Presentation/PickRole/RequiredTermsBottomSheetHostingViewController.swift
@@ -38,49 +38,69 @@ final class RequiredTermsBottomSheetHostingViewController: UIViewController {
     }
     
     private func setUI() {
-        let bottomSafeArea = view.safeAreaInsets.bottom
+        let dimView = UIView()
+        dimView.backgroundColor = UIColor.black.withAlphaComponent(0.6)
+        view.addSubview(dimView)
+        
+        dimView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            dimView.topAnchor.constraint(equalTo: view.topAnchor),
+            dimView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            dimView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            dimView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dimViewTapped))
+        dimView.addGestureRecognizer(tapGesture)
         
         let hostingController = UIHostingController(
-            rootView: ZStack(alignment: .bottom) {
-                Color.black.opacity(0.6)
-                    .ignoresSafeArea()
-                    .onTapGesture { [weak self] in
-                        self?.dismiss(animated: false)
+            rootView: RequiredTermsBottomSheetView(
+                onTermsTap: { [weak self] in
+                    self?.openURL(self?.serviceTermsURL)
+                },
+                onPrivacyTap: { [weak self] in
+                    self?.openURL(self?.privacyPolicyURL)
+                },
+                onConfirm: { [weak self] in
+                    self?.dismiss(animated: false) {
+                        self?.onConfirm()
                     }
-                
-                RequiredTermsBottomSheetView(
-                    onTermsTap: { [weak self] in
-                        self?.openURL(self?.serviceTermsURL)
-                    },
-                    onPrivacyTap: { [weak self] in
-                        self?.openURL(self?.privacyPolicyURL)
-                    },
-                    onConfirm: { [weak self] in
-                        self?.dismiss(animated: false) {
-                            self?.onConfirm()
-                        }
-                    }
-                )
-                
-                Color.kBlack
-                    .frame(height: bottomSafeArea)
-            }
-            .ignoresSafeArea(edges: .bottom)
+                }
+            )
         )
         
         addChild(hostingController)
         view.addSubview(hostingController.view)
         
+        hostingController.view.backgroundColor = UIColor(resource: .kBlack)
+        
+        hostingController.view.layer.cornerRadius = 15
+        hostingController.view.layer.maskedCorners = [
+            .layerMinXMinYCorner,
+            .layerMaxXMinYCorner
+        ]
+        
+        hostingController.view.layer.shadowColor = UIColor(resource: .gray800).cgColor
+        hostingController.view.layer.shadowOffset = CGSize(width: 0, height: -1)
+        hostingController.view.layer.shadowRadius = 4
+        hostingController.view.layer.shadowOpacity = 0.5
+        
+        hostingController.view.layer.masksToBounds = false
+        hostingController.view.clipsToBounds = false
+        
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
             hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
         
-        hostingController.view.backgroundColor = .clear
         hostingController.didMove(toParent: self)
+    }
+    
+    @objc
+    private func dimViewTapped() {
+        dismiss(animated: false)
     }
     
     private func openURL(_ urlString: String?) {


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #333 
<br>

## 🍎 작업 내용
메인 기능
- 약관 동의 바텀시트 위쪽에 부모 탭바와 같은 형태의 shadow 구현하였습니다..!!
- 기존에 `AuthGateView`에서 자동로그인을 담당했었는데..! QA 할 때 기기에 Token이 남아있어서 이슈가 발생했던것으로 추정되어서~ `AuthGateView`에서 토큰이 있지만~ 약관 동의를 하지 않은 경우에도 `ParentOnboardingView`로 가지 않고 `ParentLoginView`로 가게끔 분기 추가하였습니다!

<br>

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 바텀 시트 | <img src="https://github.com/user-attachments/assets/c12a51be-15e9-42ce-ab3b-a3163cbfe1a0" width="250"> |
| 로그아웃 없이 재 진입 | <img src="https://github.com/user-attachments/assets/9c1a6300-0372-45f6-8e09-4a928573086f" width="250"> |
| 시작하기 직전 후 로그아웃 | <img src="https://github.com/user-attachments/assets/158444d1-6d14-4b9b-8304-f8bb59a3ea40" width="250"> |
<br>


## 💬 리뷰 코멘트
리뷰어가 신경써서 봐줄 부분을 알려주세요.
