### PR TITLE
[hotfix] #341 약관동의 로직 수정

### DIFF
--- a/Kiero/Kiero/Presentation/Login/View/ParentLoginViewController.swift
+++ b/Kiero/Kiero/Presentation/Login/View/ParentLoginViewController.swift
@@ -17,6 +17,7 @@ final class ParentLoginViewController: BaseViewController<ParentLoginViewModel> 
     
     private let kakaoTap = PassthroughSubject<Void, Never>()
     private let appleTap = PassthroughSubject<Void, Never>()
+    private let requiredTermsConfirmTap = PassthroughSubject<Void, Never>()
     
     private var loadingVC: UIViewController?
     
@@ -107,7 +108,8 @@ final class ParentLoginViewController: BaseViewController<ParentLoginViewModel> 
         let output = viewModel.transform(
             input: .init(
                 kakaoButtonTapped: kakaoTap.eraseToAnyPublisher(),
-                appleButtonTapped: appleTap.eraseToAnyPublisher()
+                appleButtonTapped: appleTap.eraseToAnyPublisher(),
+                requiredTermsConfirmTapped: requiredTermsConfirmTap.eraseToAnyPublisher()
             )
         )
         
@@ -147,7 +149,7 @@ final class ParentLoginViewController: BaseViewController<ParentLoginViewModel> 
             serviceTermsURL: serviceTermsURL,
             privacyPolicyURL: privacyPolicyURL,
             onConfirm: { [weak self] in
-                self?.viewModel?.confirmRequiredTerms()
+                self?.requiredTermsConfirmTap.send(())
             }
         )
         

--- a/Kiero/Kiero/Presentation/Login/View/ParentLoginViewController.swift
+++ b/Kiero/Kiero/Presentation/Login/View/ParentLoginViewController.swift
@@ -139,15 +139,6 @@ final class ParentLoginViewController: BaseViewController<ParentLoginViewModel> 
             .store(in: &cancellables)
     }
     
-    private func navigateToParentOnboarding() {
-        let vm = ParentOnboardingViewModel()
-        let onboardingVC = UINavigationController(rootViewController: ParentOnboardingViewController(viewModel: vm, diContainer: AppDIContainer.shared))
-        
-        if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate {
-            sceneDelegate.changeRootViewController(onboardingVC)
-        }
-    }
-    
     private func presentRequiredTermsBottomSheet(_ terms: [RequiredTerm]) {
         let serviceTermsURL = terms.first { $0.termsType == .serviceTerms }?.url
         let privacyPolicyURL = terms.first { $0.termsType == .privacyPolicy }?.url
@@ -156,7 +147,7 @@ final class ParentLoginViewController: BaseViewController<ParentLoginViewModel> 
             serviceTermsURL: serviceTermsURL,
             privacyPolicyURL: privacyPolicyURL,
             onConfirm: { [weak self] in
-                self?.navigateToParentOnboarding()
+                self?.viewModel?.confirmRequiredTerms()
             }
         )
         

--- a/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
+++ b/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
@@ -209,4 +209,51 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
 
         return false
     }
+    
+    func confirmRequiredTerms() {
+        stateSubject.send(.loading)
+        
+        Task { [weak self] in
+            guard let self else { return }
+            
+            do {
+                let children: ChildListResponse = try await BaseService.shared.request(
+                    endPoint: .fetchChildren
+                )
+                
+                if children.isEmpty {
+                    await MainActor.run {
+                        self.stateSubject.send(.idle)
+                        self.routeSubject.send(.parentOnboarding)
+                    }
+                    return
+                }
+                
+                let termsIds = TokenManager.shared.getRequiredTermsIds()
+                
+                if termsIds.isEmpty == false {
+                    let request = AgreeRequiredTermsRequestDTO(
+                        termsIds: termsIds
+                    )
+                    
+                    let _: EmptyResponse = try await BaseService.shared.request(
+                        endPoint: .agreeRequiredTerms,
+                        body: request
+                    )
+                    
+                    TokenManager.shared.removeRequiredTermsIds()
+                }
+                
+                await MainActor.run {
+                    self.stateSubject.send(.idle)
+                    self.routeSubject.send(.parentTab)
+                }
+            } catch {
+                await MainActor.run {
+                    self.stateSubject.send(.idle)
+                    self.routeSubject.send(.toast("약관 동의 처리에 실패했습니다."))
+                }
+            }
+        }
+    }
 }

--- a/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
+++ b/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
@@ -13,6 +13,7 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
     struct Input {
         let kakaoButtonTapped: AnyPublisher<Void, Never>
         let appleButtonTapped: AnyPublisher<Void, Never>
+        let requiredTermsConfirmTapped: AnyPublisher<Void, Never>
     }
     
     struct Output {
@@ -46,6 +47,12 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
         input.appleButtonTapped
             .sink { [weak self] in
                 self?.requestAppleLogin()
+            }
+            .store(in: &cancellables)
+        
+        input.requiredTermsConfirmTapped
+            .sink { [weak self] in
+                self?.confirmRequiredTerms()
             }
             .store(in: &cancellables)
         


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #341 
<br>

## 🍎 작업 내용
메인 기능

- 필수 약관 동의 플로우 개선
- 자녀 연동 여부에 따라 필수 약관 동의 API 호출 분기 처리
- 불필요한 온보딩 이동 로직 제거


1. 로그인 후 필수 약관 미동의 상태인 경우 기존과 동일하게 약관 동의 BottomSheet 노출
2. BottomSheet의 “확인” 버튼 동작 수정
 - 자녀 조회 API(fetchChildren) 호출
 - 자녀가 없는 경우
ㄴ약관 동의 API 호출 없이 ParentOnboarding으로 이동
- 자녀가 있는 경우
ㄴ필수 약관 동의 API(agreeRequiredTerms) 호출
ㄴ약관 동의 완료 후 ParentTab(TodayStatusView)으로 이동
3. 기존 BottomSheet 확인 시 무조건 온보딩으로 이동하던 로직 제거
4. 사용하지 않는 navigateToParentOnboarding() 제거
<br>

```
로그인
 ↓
필수 약관 미동의 여부 확인
 ↓
RequiredTermsBottomSheet 노출
 ↓
확인 버튼 탭
 ↓
fetchChildren
 ├─ 자녀 없음
 │   └─ ParentOnboarding 이동
 │       (약관 동의 API 호출 X)
 │
 └─ 자녀 있음
     └─ agreeRequiredTerms 호출
         ↓
         ParentTab(TodayStatusView) 이동
```

## 📸 스크린샷
| 기능/화면 | 화면1 |
|:---------:|:-------------:|
| 기능1 | <img src="https://github.com/user-attachments/assets/7a067356-196b-434c-a778-b5b4e1088867" width="250"> |
<br>


## 💬 리뷰 코멘트
리뷰어가 신경써서 봐줄 부분을 알려주세요.
늦어져서 죄송합니다 ㅜㅜ
