### PR TITLE
[fix] #344 자녀 토큰 갱신 시 로그인 풀리는 문제 수정

### DIFF
--- a/Kiero/Kiero/Network/Base/BaseService/BaseService.swift
+++ b/Kiero/Kiero/Network/Base/BaseService/BaseService.swift
@@ -45,7 +45,7 @@ final class BaseService {
                 throw error
                 
             case .child:
-                try await TokenRefresher.shared.refreshAllTokens()
+                try await TokenRefresher.shared.refreshAccessToken()
                 
             case .parent:
                 do {

--- a/Kiero/Kiero/Network/Base/BaseService/TokenRefresher.swift
+++ b/Kiero/Kiero/Network/Base/BaseService/TokenRefresher.swift
@@ -49,7 +49,9 @@ final class TokenRefresher {
         NetworkLogger.shared.responseLog(http, data: data)
         
         guard (200...299).contains(http.statusCode) else {
-            TokenManager.shared.clearAll()
+            if [401, 403].contains(http.statusCode) {
+                TokenManager.shared.clearAll()
+            }
             throw NetworkError.clientError(statusCode: http.statusCode)
         }
         
@@ -94,7 +96,9 @@ final class TokenRefresher {
         NetworkLogger.shared.responseLog(http, data: data)
         
         guard (200...299).contains(http.statusCode) else {
-            TokenManager.shared.clearAll()
+            if [401, 403].contains(http.statusCode) {
+                TokenManager.shared.clearAll()
+            }
             throw NetworkError.clientError(statusCode: http.statusCode)
         }
         
@@ -104,7 +108,6 @@ final class TokenRefresher {
         TokenManager.shared.saveAccessToken(tokenData.accessToken)
         
         guard let newRefresh = extractCookieValue(from: http, cookieName: "refreshToken") else {
-            TokenManager.shared.clearAll()
             throw NetworkError.responseDecodingError
         }
         

--- a/Kiero/Kiero/Network/Login/TokenManager.swift
+++ b/Kiero/Kiero/Network/Login/TokenManager.swift
@@ -88,6 +88,7 @@ final class TokenManager {
     func clearUserInfo() {
         userDefaults.removeObject(forKey: Key.role)
         userDefaults.removeObject(forKey: Key.name)
+        userDefaults.removeObject(forKey: Key.nameKey)
         userDefaults.removeObject(forKey: Key.profile)
     }
 


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #344 
<br>

## 🍎 작업 내용
### 메인 기능                                                                                                     
  - 자녀 토큰 갱신 시 잘못된 엔드포인트(`/tokens/reissue/tokens`) 호출로 서버 500 에러 발생하여 로그인이 풀리는 문제 수정                                                                                                                
  - `refreshAllTokens()` → `refreshAccessToken()` (`/tokens/reissue/access-token`)으로 변경                         
  - `clearUserInfo()`에서 `firstName`이 삭제되지 않아 로그아웃 후에도 나의공간에 이름이 남아있는 문제 수정
                                                                                                                      
  ### 원인
  - 자녀는 access token 만료 시 `.child` 정책에 의해 `refreshAllTokens()`만 호출
  - 해당 엔드포인트(`/tokens/reissue/tokens`)가 자녀 토큰을 지원하지 않아 500 응답 → `clearAll()` → 로그인 풀림
  - `clearUserInfo()`에 `firstName` 키 삭제가 누락되어, 토큰은 삭제되지만 이름은 UserDefaults에 잔존
<br>

## 📸 스크린샷
| Xcode 로그 | 
|:---------:|
| <img width="551" height="489" alt="image" src="https://github.com/user-attachments/assets/193cae9f-a229-4d24-a880-9a8958c90d68" /> | 
<br>

## 💬 리뷰 코멘트
실사용 QA에서 자녀를 맡고있는 해피가 테플에서 잘 되는지 한번 더 확인해주세요~! 현재 accessToken 만료 시간은 1시간이라 그 이후에 로그인이 안 풀리는지 확인하면 됩니다!