### PR TITLE
[refactor] #348 컬러 선택영역 확장

### DIFF
--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -82,19 +82,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
     
     private let timeSelectionView = TimeSelectionView()
     
-    private let colorSectionTitle = UILabel().then {
-        $0.setTypo(.title3_16_SB, text: "컬러")
-        $0.textColor = .white
-    }
-    
-    private let selectedColorChip = ColorChip().then {
-        $0.isUserInteractionEnabled = false
-    }
-    
-    private let colorArrowButton = UIButton().then {
-        $0.setImage(UIImage(resource: .icRight), for: .normal)
-        $0.tintColor = .white
-    }
+    private let colorSelectionView = ColorSelectionView()
     
     // MARK: - Life Cycle
     
@@ -119,7 +107,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                          daySectionTitle, repeatLabel, repeatSwitch,
                          weekdaySelectionView,
                          timeSectionTitle, timeSelectionView,
-                         colorSectionTitle, selectedColorChip, colorArrowButton)
+                         colorSelectionView)
         
         let weekDates = Date().daysOfWeek
         
@@ -188,19 +176,10 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
             $0.horizontalEdges.equalToSuperview().inset(15)
         }
         
-        colorSectionTitle.snp.makeConstraints {
+        colorSelectionView.snp.makeConstraints {
             $0.top.equalTo(timeSectionTitle.snp.bottom).offset(132)
-            $0.leading.equalToSuperview().inset(15)
-        }
-        
-        selectedColorChip.snp.makeConstraints {
-            $0.centerY.equalTo(colorSectionTitle)
-            $0.trailing.equalTo(colorArrowButton.snp.leading).offset(-10)
-        }
-        
-        colorArrowButton.snp.makeConstraints {
-            $0.centerY.equalTo(colorSectionTitle)
-            $0.trailing.equalToSuperview().inset(10)
+            $0.horizontalEdges.equalToSuperview().inset(15)
+            $0.height.equalTo(44)
         }
     }
     
@@ -352,8 +331,10 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         timeSelectionView.startTimeTapAction = { [weak self] in self?.presentTimePicker(isStart: true) }
         timeSelectionView.endTimeTapAction = { [weak self] in self?.presentTimePicker(isStart: false) }
         titleTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
-        colorArrowButton.addTarget(self, action: #selector(didTapColorPicker), for: .touchUpInside)
         repeatSwitch.addTarget(self, action: #selector(repeatSwitchChanged), for: .valueChanged)
+        colorSelectionView.onTap = { [weak self] in
+            self?.didTapColorPicker()
+        }
         
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tapGesture.cancelsTouchesInView = false
@@ -473,8 +454,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
                 
                 if self.currentSelectedColor == nil {
                     self.currentSelectedColor = color
-                    self.selectedColorChip.isHidden = false
-                    self.selectedColorChip.configure(with: color, isSelected: false)
+                    self.colorSelectionView.configure(with: color)
                 }
             }
             .store(in: &cancellables)
@@ -634,8 +614,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         
         vc.onColorSelected = { [weak self] selectedColor in
             guard let self = self else { return }
-            self.selectedColorChip.isHidden = false
-            self.selectedColorChip.configure(with: selectedColor, isSelected: false)
+            self.colorSelectionView.configure(with: selectedColor)
             self.currentSelectedColor = selectedColor
         }
         
@@ -708,8 +687,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         
         let color = colorReverseMapping[schedule.scheduleColor] ?? UIColor(hex: schedule.colorCode)
         currentSelectedColor = color
-        selectedColorChip.isHidden = false
-        selectedColorChip.configure(with: color, isSelected: false)
+        colorSelectionView.configure(with: color)
     }
     
     private func handleEditConfirm() {

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewController.swift
@@ -179,7 +179,7 @@ class AddScheduleViewController: BaseViewController<AddScheduleViewModel> {
         colorSelectionView.snp.makeConstraints {
             $0.top.equalTo(timeSectionTitle.snp.bottom).offset(132)
             $0.horizontalEdges.equalToSuperview().inset(15)
-            $0.height.equalTo(44)
+            $0.height.equalTo(47)
         }
     }
     

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/ColorSelectionView.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/ColorSelectionView.swift
@@ -1,0 +1,87 @@
+//
+//  ColorSelectionView.swift
+//  Kiero
+//
+//  Created by 신혜연 on 7/9/26.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class ColorSelectionView: UIView {
+    
+    // MARK: - Properties
+    
+    var onTap: (() -> Void)?
+    
+    // MARK: - UI Components
+    
+    private let titleLabel = UILabel().then {
+        $0.setTypo(.title3_16_SB, text: "컬러")
+        $0.textColor = .white
+    }
+    
+    private let colorChip = ColorChip().then {
+        $0.isUserInteractionEnabled = false
+    }
+    
+    private let arrowIcon = UIImageView().then {
+        $0.image = UIImage(resource: .icRight)
+        $0.tintColor = .white
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        
+        setUI()
+        setLayout()
+        addTarget()
+    }
+    
+    required init?(coder: NSCoder) { nil }
+    
+    // MARK: - Setup Methods
+    
+    private func setUI() {
+        addSubviews(titleLabel, colorChip, arrowIcon)
+        colorChip.isHidden = true
+    }
+    
+    private func setLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
+        
+        arrowIcon.snp.makeConstraints {
+            $0.trailing.equalToSuperview()
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(24)
+        }
+        
+        colorChip.snp.makeConstraints {
+            $0.trailing.equalTo(arrowIcon.snp.leading).offset(-10)
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+    private func addTarget() {
+        isUserInteractionEnabled = true
+        let tap = UITapGestureRecognizer(target: self, action: #selector(didTap))
+        addGestureRecognizer(tap)
+    }
+    
+    func configure(with color: UIColor) {
+        colorChip.isHidden = false
+        colorChip.configure(with: color, isSelected: false)
+    }
+    
+    @objc private func didTap() {
+        onTap?()
+    }
+}


### PR DESCRIPTION
## 📟 연결된 이슈
closed #348 
<br>

## 🍎 작업 내용
컬러 선택 영역을 ColorSelectionView로 분리하고 탭 영역을 눌러 진입 가능하도록 수정하였습니다.
<br>

## 📸 스크린샷
마우스가 안보이지만, 각각 빈 영역 > 컬러칩 > 화살표을 누른 화면입니다.
| 기능/화면 | 일정추가 |
|:---------:|:-------------:|
| 컬러선택 | <img src="https://github.com/user-attachments/assets/7f6e930e-a658-4d81-8ebc-a28c10e6af62" width="250"> |
<br>

## 💬 리뷰 코멘트
빠른 리뷰 부탁드려요 .~
