### PR TITLE
[fix] #350 로그아웃시 fcm 알림 비활성화

### DIFF
--- a/Kiero/Kiero/Network/FCM/FCMTokenManager.swift
+++ b/Kiero/Kiero/Network/FCM/FCMTokenManager.swift
@@ -53,4 +53,19 @@ final class FCMTokenManager {
             print("❌ FCM 토큰 서버 전송 실패: \(error)")
         }
     }
+    
+    func disablePushNotificationsForLogout() async {
+        UserDefaults.standard.set(false, forKey: "child_pushNotificationEnabled")
+
+        do {
+            let body = NotificationSettingsRequest(pushNotificationEnabled: false)
+            let _: EmptyResponse = try await BaseService.shared.request(
+                endPoint: .updateNotificationSettings,
+                body: body
+            )
+            print("✅ 로그아웃 전 푸시 알림 비활성화 성공")
+        } catch {
+            print("❌ 로그아웃 전 푸시 알림 비활성화 실패: \(error)")
+        }
+    }
 }

--- a/Kiero/Kiero/Network/MyPage/LogoutService.swift
+++ b/Kiero/Kiero/Network/MyPage/LogoutService.swift
@@ -17,6 +17,8 @@ final class LogoutService {
             Future { promise in
                 Task {
                     do {
+                        await FCMTokenManager.shared.disablePushNotificationsForLogout()
+                        
                         let _: BaseResponse<String?> = try await BaseService.shared.request(endPoint: .logout)
                         
                         TokenManager.shared.clearAll()

--- a/Kiero/Kiero/Network/Schedule/Schedule/ScheduleService.swift
+++ b/Kiero/Kiero/Network/Schedule/Schedule/ScheduleService.swift
@@ -72,6 +72,8 @@ final class ScheduleService: ScheduleServiceType {
         return Future<Void, NetworkError> { promise in
             Task {
                 do {
+                    await FCMTokenManager.shared.disablePushNotificationsForLogout()
+                    
                     let _: EmptyResponse = try await BaseService.shared.request(endPoint: .logout)
                     promise(.success(()))
                 } catch {


### PR DESCRIPTION
## 📟 연결된 이슈
closed <!-- #350 -->
<br>

## 🍎 작업 내용
로그아웃 이후에도 FCM 푸시 알림이 수신될 수 있는 문제를 방지했습니다.
 - FCMTokenManager에 로그아웃 전 푸시 알림 비활성화 메서드 추가
   - 서버 알림 설정 API에 pushNotificationEnabled: false 요청
   - 로컬 자녀 알림 설정 값도 false로 정리

- LogoutService.logout()에서 로그아웃 API 호출 전에 푸시 알림 비활성화 처리 추가
- ScheduleService.logout() 경로에서도 동일하게 푸시 알림 비활성화 처리 추가
- 토큰 삭제(TokenManager.shared.clearAll()) 전에 알림 비활성화 요청이 먼저 실행되도록 순서 보장
<br>

## 📸 스크린샷

<br>

## 💬 리뷰 코멘트
로그아웃 경로가 LogoutService와 ScheduleService 두개라고 생각해서 두군데만 수정 진행했습니다. 혹시 더 있다면 알려주세요. 
추가로 컴퓨터 저장공간 부족으로 실기기 테스트가 불가능합니다... 한번 테스트 부탁드려요....
