### PR TITLE
[feat] 앰플리튜드 이벤트 연결

### DIFF
--- a/Kiero/Kiero.xcodeproj/project.pbxproj
+++ b/Kiero/Kiero.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		249C641A2F0FA1F50016D6B7 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = 249C64192F0FA1F50016D6B7 /* Moya */; };
 		24DF523F2F0A6487007146AC /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 24DF523E2F0A6487007146AC /* SnapKit */; };
 		24DF52422F0A64A0007146AC /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 24DF52412F0A64A0007146AC /* Then */; };
+		A100000000000000000000B2 /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A100000000000000000000B1 /* AmplitudeSwift */; };
+		A100000000000000000000C2 /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A100000000000000000000C1 /* AmplitudeSwift */; };
 		AE418AB42FC6CCE8000B043E /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = AE418AB32FC6CCE8000B043E /* FirebaseMessaging */; };
 		AE418AB62FC6CCF0000B043E /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = AE418AB52FC6CCF0000B043E /* FirebaseCore */; };
 		AE418AB82FC6CCFE000B043E /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = AE418AB72FC6CCFE000B043E /* FirebaseCore */; };
@@ -81,6 +83,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AE418ABA2FC6CD03000B043E /* FirebaseMessaging in Frameworks */,
+				A100000000000000000000B2 /* AmplitudeSwift in Frameworks */,
 				2455DCE02F23628F00836E3D /* Kingfisher in Frameworks */,
 				2455DCE12F23628F00836E3D /* CombineMoya in Frameworks */,
 				AE418AB82FC6CCFE000B043E /* FirebaseCore in Frameworks */,
@@ -110,6 +113,7 @@
 				F6B015D82F123F0D007B1EE4 /* KakaoSDKAuth in Frameworks */,
 				AE418AB42FC6CCE8000B043E /* FirebaseMessaging in Frameworks */,
 				AE418AB62FC6CCF0000B043E /* FirebaseCore in Frameworks */,
+				A100000000000000000000C2 /* AmplitudeSwift in Frameworks */,
 				AEF67B382F4C5C20007319A0 /* KingfisherWebP in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -176,6 +180,7 @@
 				AEF67B512F4C6C53007319A0 /* Lottie */,
 				AE418AB72FC6CCFE000B043E /* FirebaseCore */,
 				AE418AB92FC6CD03000B043E /* FirebaseMessaging */,
+				A100000000000000000000B1 /* AmplitudeSwift */,
 			);
 			productName = Kiero;
 			productReference = 2455DCEC2F23628F00836E3D /* Kiero_Child.app */;
@@ -210,6 +215,7 @@
 				AEF67B4F2F4C6C41007319A0 /* Lottie */,
 				AE418AB32FC6CCE8000B043E /* FirebaseMessaging */,
 				AE418AB52FC6CCF0000B043E /* FirebaseCore */,
+				A100000000000000000000C1 /* AmplitudeSwift */,
 			);
 			productName = Kiero;
 			productReference = 24DF50CB2F0A5173007146AC /* Kiero_Parent.app */;
@@ -248,6 +254,7 @@
 				AEF67B362F4C5C20007319A0 /* XCRemoteSwiftPackageReference "KingfisherWebP" */,
 				AEF67B4E2F4C6C41007319A0 /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				AEB0F9DF2FC5CC5500964FED /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				A100000000000000000000A1 /* XCRemoteSwiftPackageReference "Amplitude-Swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 24DF50CC2F0A5173007146AC /* Products */;
@@ -662,6 +669,14 @@
 				minimumVersion = 3.0.0;
 			};
 		};
+		A100000000000000000000A1 /* XCRemoteSwiftPackageReference "Amplitude-Swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/amplitude/Amplitude-Swift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.18.6;
+			};
+		};
 		AEB0F9DF2FC5CC5500964FED /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
@@ -759,6 +774,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 24DF52402F0A64A0007146AC /* XCRemoteSwiftPackageReference "Then" */;
 			productName = Then;
+		};
+		A100000000000000000000B1 /* AmplitudeSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A100000000000000000000A1 /* XCRemoteSwiftPackageReference "Amplitude-Swift" */;
+			productName = AmplitudeSwift;
+		};
+		A100000000000000000000C1 /* AmplitudeSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A100000000000000000000A1 /* XCRemoteSwiftPackageReference "Amplitude-Swift" */;
+			productName = AmplitudeSwift;
 		};
 		AE418AB32FC6CCE8000B043E /* FirebaseMessaging */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Kiero/Kiero.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kiero/Kiero.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5bd77c7b5fa43cdd6be30fc96c4c6728d9a792b8c829433f100f1fed72f42cae",
+  "originHash" : "3e34bdabb00b6c1773181733a094aa4df244090c69ecbff028f7fbda46ef3841",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -17,6 +17,33 @@
       "state" : {
         "revision" : "7be73f6c2b5cd90e40798b06ebd5da8f9f79cf88",
         "version" : "5.11.0"
+      }
+    },
+    {
+      "identity" : "amplitude-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/Amplitude-Swift.git",
+      "state" : {
+        "revision" : "17ca168cfe6bc6400e0fd7d0287fb2c742ed0d21",
+        "version" : "1.18.6"
+      }
+    },
+    {
+      "identity" : "amplitudecore-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/AmplitudeCore-Swift.git",
+      "state" : {
+        "revision" : "bf7afcc808ff9ed66c9e0f99c1d65ba8fca8caa3",
+        "version" : "1.4.9"
+      }
+    },
+    {
+      "identity" : "analytics-connector-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/analytics-connector-ios.git",
+      "state" : {
+        "revision" : "982b4c787285d213653bd2a504d6a86b52227cea",
+        "version" : "1.3.2"
       }
     },
     {

--- a/Kiero/Kiero/Application/AppDelegate.swift
+++ b/Kiero/Kiero/Application/AppDelegate.swift
@@ -41,6 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate,
         }
         
         AmplitudeManager.shared.configure()
+        AmplitudeManager.shared.track(.appOpened)
 
         UNUserNotificationCenter.current().delegate = self
         
@@ -90,7 +91,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate,
     private func handleNotification(_ userInfo: [AnyHashable: Any]) {
         let type = userInfo["type"] as? String
         let targetId = userInfo["targetId"] as? String
-        
+
+        AmplitudeManager.shared.track(.pushClicked, properties: [
+            AnalyticsEventProperty.pushType: type ?? "unknown"
+        ])
+
         Task { @MainActor in
             DeepLinkManager.shared.handle(type: type, targetId: targetId)
         }

--- a/Kiero/Kiero/Application/AppDelegate.swift
+++ b/Kiero/Kiero/Application/AppDelegate.swift
@@ -40,7 +40,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate,
             NSLog("❌ GoogleService-Info.plist를 찾을 수 없음")
         }
         
-        // 앰플리튜드 초기화
         AmplitudeManager.shared.configure()
 
         UNUserNotificationCenter.current().delegate = self

--- a/Kiero/Kiero/Application/AppDelegate.swift
+++ b/Kiero/Kiero/Application/AppDelegate.swift
@@ -8,6 +8,7 @@
 import UIKit
 import UserNotifications
 
+import AmplitudeSwift
 import KakaoSDKCommon
 import FirebaseCore
 import FirebaseMessaging
@@ -39,6 +40,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate,
             NSLog("❌ GoogleService-Info.plist를 찾을 수 없음")
         }
         
+        // 앰플리튜드 초기화
+        AmplitudeManager.shared.configure()
+
         UNUserNotificationCenter.current().delegate = self
         
         application.registerForRemoteNotifications()

--- a/Kiero/Kiero/Application/AppDelegate.swift
+++ b/Kiero/Kiero/Application/AppDelegate.swift
@@ -92,9 +92,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate,
         let type = userInfo["type"] as? String
         let targetId = userInfo["targetId"] as? String
 
-        AmplitudeManager.shared.track(.pushClicked, properties: [
-            AnalyticsEventProperty.pushType: type ?? "unknown"
-        ])
+        AmplitudeManager.shared.track(.pushClicked(pushType: type ?? "unknown"))
 
         Task { @MainActor in
             DeepLinkManager.shared.handle(type: type, targetId: targetId)

--- a/Kiero/Kiero/ChildInfo.plist
+++ b/Kiero/Kiero/ChildInfo.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>CFBundleDisplayName</key>
 	<string>Kiero</string>
+	<key>AMPLITUDE_API_KEY_DEV</key>
+	<string>$(AMPLITUDE_API_KEY_DEV)</string>
+	<key>AMPLITUDE_API_KEY_PROD</key>
+	<string>$(AMPLITUDE_API_KEY_PROD)</string>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
 	<key>CFBundleURLTypes</key>

--- a/Kiero/Kiero/Network/Analytics/AmplitudeManager.swift
+++ b/Kiero/Kiero/Network/Analytics/AmplitudeManager.swift
@@ -28,20 +28,20 @@ final class AmplitudeManager {
         amplitude = Amplitude(configuration: configuration)
 
         refreshUserId()
-        setUserProperties([.role: AnalyticsIdentity.role])
+        setUserProperties([.role: AnalyticsIdentity.role.rawValue])
     }
 
     // MARK: - Event
 
-    func track(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {
-        var merged = properties ?? [:]
-        merged[AnalyticsEventProperty.role] = AnalyticsIdentity.role
+    func track(_ event: AnalyticsEvent) {
+        var merged = event.properties
+        merged[AnalyticsUserProperty.role.rawValue] = AnalyticsIdentity.role.rawValue
 
 #if DEBUG
-        NSLog("📊 [Amplitude] track %@ %@", event.rawValue, String(describing: merged))
+        NSLog("📊 [Amplitude] track %@ %@", event.name, String(describing: merged))
 #endif
 
-        amplitude?.track(eventType: event.rawValue, eventProperties: merged)
+        amplitude?.track(eventType: event.name, eventProperties: merged)
     }
 
     // MARK: - Identity

--- a/Kiero/Kiero/Network/Analytics/AmplitudeManager.swift
+++ b/Kiero/Kiero/Network/Analytics/AmplitudeManager.swift
@@ -10,12 +10,63 @@ import AmplitudeSwift
 final class AmplitudeManager {
     static let shared = AmplitudeManager()
     private init() {}
-    
+
     private var amplitude: Amplitude?
-    
+
     func configure() {
-        amplitude = Amplitude(
-            configuration: Configuration(apiKey: Config.amplitudeAPIKey)
-        )
+        let configuration = Configuration(apiKey: Config.amplitudeAPIKey)
+
+#if DEBUG
+        configuration.logLevel = .debug
+        configuration.callback = { event, code, message in
+            NSLog("📊 [Amplitude] 전송 %@ | code: %d | %@", event.eventType, code, message)
+        }
+#endif
+
+        amplitude = Amplitude(configuration: configuration)
+
+        refreshUserId()
+        setUserProperties([.role: AnalyticsIdentity.role])
+    }
+
+    // MARK: - Event
+
+    func track(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {
+        var merged = properties ?? [:]
+        merged[AnalyticsEventProperty.role] = AnalyticsIdentity.role
+
+#if DEBUG
+        NSLog("📊 [Amplitude] track %@ %@", event.rawValue, String(describing: merged))
+#endif
+
+        amplitude?.track(eventType: event.rawValue, eventProperties: merged)
+    }
+
+    // MARK: - Identity
+
+    func setUserProperties(_ properties: [AnalyticsUserProperty: Any]) {
+        let mapped = properties.reduce(into: [String: Any]()) { result, pair in
+            result[pair.key.rawValue] = pair.value
+        }
+
+#if DEBUG
+        NSLog("📊 [Amplitude] identify %@", String(describing: mapped))
+#endif
+
+        amplitude?.identify(userProperties: mapped)
+    }
+
+    func refreshUserId() {
+        let userId = AnalyticsIdentity.resolveUserId()
+
+#if DEBUG
+        NSLog("📊 [Amplitude] userId %@", userId ?? "nil")
+#endif
+
+        amplitude?.setUserId(userId: userId)
+    }
+
+    func reset() {
+        amplitude?.reset()
     }
 }

--- a/Kiero/Kiero/Network/Analytics/AmplitudeManager.swift
+++ b/Kiero/Kiero/Network/Analytics/AmplitudeManager.swift
@@ -2,6 +2,8 @@
 //  AmplitudeManager.swift
 //  Kiero
 //
+//  Created by Hyunseo Han on 7/28/26.
+//
 
 import Foundation
 

--- a/Kiero/Kiero/Network/Analytics/AmplitudeManager.swift
+++ b/Kiero/Kiero/Network/Analytics/AmplitudeManager.swift
@@ -1,0 +1,21 @@
+//
+//  AmplitudeManager.swift
+//  Kiero
+//
+
+import Foundation
+
+import AmplitudeSwift
+
+final class AmplitudeManager {
+    static let shared = AmplitudeManager()
+    private init() {}
+    
+    private var amplitude: Amplitude?
+    
+    func configure() {
+        amplitude = Amplitude(
+            configuration: Configuration(apiKey: Config.amplitudeAPIKey)
+        )
+    }
+}

--- a/Kiero/Kiero/Network/Analytics/AnalyticsEvent.swift
+++ b/Kiero/Kiero/Network/Analytics/AnalyticsEvent.swift
@@ -1,0 +1,57 @@
+//
+//  AnalyticsEvent.swift
+//  Kiero
+//
+
+import Foundation
+
+enum AnalyticsEvent: String {
+
+    // MARK: - 공통 / 온보딩
+
+    case appOpened = "app_opened"
+    case roleSelected = "role_selected"
+    case loginCompleted = "login_completed"
+    case termsAgreementCompleted = "terms_agreement_completed"
+    case inviteCodeCreated = "invite_code_created"
+    case childConnectionCompleted = "child_connection_completed"
+    case onboardingCompleted = "onboarding_completed"
+
+    // MARK: - 부모 핵심 행동
+
+    case scheduleCreated = "schedule_created"
+    case missionCreated = "mission_created"
+    case rewardCreated = "reward_created"
+
+    // MARK: - 자녀 핵심 행동
+
+    case scheduleAuthStarted = "schedule_auth_started"
+    case scheduleAuthCompleted = "schedule_auth_completed"
+    case scheduleSkipped = "schedule_skipped"
+    case dailyJourneyCompleted = "daily_journey_completed"
+    case missionCompleted = "mission_completed"
+    case wishPurchased = "wish_purchased"
+
+    // MARK: - 푸시 / 알림
+
+    case pushPermissionResult = "push_permission_result"
+    case pushClicked = "push_clicked"
+}
+
+enum AnalyticsEventProperty {
+    static let role = "role"
+    static let inviteCodeHash = "invite_code_hash"
+}
+
+enum AnalyticsUserProperty: String {
+    case role = "role"
+    case loginMethod = "login_method"
+    case childConnected = "child_connected"
+    case pushEnabled = "push_enabled"
+}
+
+enum AnalyticsLoginMethod: String {
+    case kakao
+    case apple
+    case inviteCode = "invite_code"
+}

--- a/Kiero/Kiero/Network/Analytics/AnalyticsEvent.swift
+++ b/Kiero/Kiero/Network/Analytics/AnalyticsEvent.swift
@@ -41,6 +41,15 @@ enum AnalyticsEvent: String {
 enum AnalyticsEventProperty {
     static let role = "role"
     static let inviteCodeHash = "invite_code_hash"
+    static let pushType = "push_type"
+    static let granted = "granted"
+    static let source = "source"
+    static let loginMethod = "login_method"
+    static let selectedRole = "selected_role"
+    static let count = "count"
+    static let earnedCoin = "earned_coin"
+    static let stoneCount = "stone_count"
+    static let price = "price"
 }
 
 enum AnalyticsUserProperty: String {

--- a/Kiero/Kiero/Network/Analytics/AnalyticsEvent.swift
+++ b/Kiero/Kiero/Network/Analytics/AnalyticsEvent.swift
@@ -7,62 +7,144 @@
 
 import Foundation
 
-enum AnalyticsEvent: String {
+enum AnalyticsEvent {
 
     // MARK: - 공통 / 온보딩
 
-    case appOpened = "app_opened"
-    case roleSelected = "role_selected"
-    case loginCompleted = "login_completed"
-    case termsAgreementCompleted = "terms_agreement_completed"
-    case inviteCodeCreated = "invite_code_created"
-    case childConnectionCompleted = "child_connection_completed"
-    case onboardingCompleted = "onboarding_completed"
+    case appOpened
+    case roleSelected(role: AnalyticsRole, source: RoleSelectSource)
+    case loginCompleted(method: AnalyticsLoginMethod)
+    case termsAgreementCompleted
+    case inviteCodeCreated(codeHash: String, source: InviteCodeSource)
+    case childConnectionCompleted(codeHash: String)
+    case onboardingCompleted
 
     // MARK: - 부모 핵심 행동
 
-    case scheduleCreated = "schedule_created"
-    case missionCreated = "mission_created"
-    case rewardCreated = "reward_created"
+    case scheduleCreated
+    case missionCreated(source: MissionCreateSource, count: Int?)
+    case rewardCreated
 
     // MARK: - 자녀 핵심 행동
 
-    case scheduleAuthStarted = "schedule_auth_started"
-    case scheduleAuthCompleted = "schedule_auth_completed"
-    case scheduleSkipped = "schedule_skipped"
-    case dailyJourneyCompleted = "daily_journey_completed"
-    case missionCompleted = "mission_completed"
-    case wishPurchased = "wish_purchased"
+    case scheduleAuthStarted
+    case scheduleAuthCompleted
+    case scheduleSkipped
+    case dailyJourneyCompleted(earnedCoin: Int, stoneCount: Int)
+    case missionCompleted
+    case wishPurchased(price: Int)
 
     // MARK: - 푸시 / 알림
 
-    case pushPermissionResult = "push_permission_result"
-    case pushClicked = "push_clicked"
+    case pushPermissionResult(granted: Bool, source: PushPromptSource)
+    case pushClicked(pushType: String)
 }
 
-enum AnalyticsEventProperty {
-    static let role = "role"
-    static let inviteCodeHash = "invite_code_hash"
-    static let pushType = "push_type"
-    static let granted = "granted"
-    static let source = "source"
-    static let loginMethod = "login_method"
-    static let selectedRole = "selected_role"
-    static let count = "count"
-    static let earnedCoin = "earned_coin"
-    static let stoneCount = "stone_count"
-    static let price = "price"
+extension AnalyticsEvent {
+
+    var name: String {
+        switch self {
+        case .appOpened: return "app_opened"
+        case .roleSelected: return "role_selected"
+        case .loginCompleted: return "login_completed"
+        case .termsAgreementCompleted: return "terms_agreement_completed"
+        case .inviteCodeCreated: return "invite_code_created"
+        case .childConnectionCompleted: return "child_connection_completed"
+        case .onboardingCompleted: return "onboarding_completed"
+        case .scheduleCreated: return "schedule_created"
+        case .missionCreated: return "mission_created"
+        case .rewardCreated: return "reward_created"
+        case .scheduleAuthStarted: return "schedule_auth_started"
+        case .scheduleAuthCompleted: return "schedule_auth_completed"
+        case .scheduleSkipped: return "schedule_skipped"
+        case .dailyJourneyCompleted: return "daily_journey_completed"
+        case .missionCompleted: return "mission_completed"
+        case .wishPurchased: return "wish_purchased"
+        case .pushPermissionResult: return "push_permission_result"
+        case .pushClicked: return "push_clicked"
+        }
+    }
+
+    var properties: [String: Any] {
+        switch self {
+        case .roleSelected(let role, let source):
+            return ["selected_role": role.rawValue, "source": source.rawValue]
+
+        case .loginCompleted(let method):
+            return ["login_method": method.rawValue]
+
+        case .inviteCodeCreated(let codeHash, let source):
+            return ["invite_code_hash": codeHash, "source": source.rawValue]
+
+        case .childConnectionCompleted(let codeHash):
+            return ["invite_code_hash": codeHash]
+
+        case .missionCreated(let source, let count):
+            var properties: [String: Any] = ["source": source.rawValue]
+            properties["count"] = count
+            return properties
+
+        case .dailyJourneyCompleted(let earnedCoin, let stoneCount):
+            return ["earned_coin": earnedCoin, "stone_count": stoneCount]
+
+        case .wishPurchased(let price):
+            return ["price": price]
+
+        case .pushPermissionResult(let granted, let source):
+            return ["granted": granted, "source": source.rawValue]
+
+        case .pushClicked(let pushType):
+            return ["push_type": pushType]
+
+        case .appOpened, .termsAgreementCompleted, .onboardingCompleted,
+             .scheduleCreated, .rewardCreated, .scheduleAuthStarted,
+             .scheduleAuthCompleted, .scheduleSkipped, .missionCompleted:
+            return [:]
+        }
+    }
 }
 
-enum AnalyticsUserProperty: String {
-    case role = "role"
-    case loginMethod = "login_method"
-    case childConnected = "child_connected"
-    case pushEnabled = "push_enabled"
+// MARK: - Property Value
+
+enum AnalyticsRole: String {
+    case parent
+    case child
 }
 
 enum AnalyticsLoginMethod: String {
     case kakao
     case apple
     case inviteCode = "invite_code"
+}
+
+enum RoleSelectSource: String {
+    case authGate = "auth_gate"
+    case logoutDialog = "logout_dialog"
+}
+
+enum InviteCodeSource: String {
+    case onboarding
+    case reissue
+    case childManage = "child_manage"
+}
+
+enum MissionCreateSource: String {
+    case manual
+    case ai
+}
+
+enum PushPromptSource: String {
+    case dailyJourney = "daily_journey"
+    case todayStatus = "today_status"
+    case mySpace = "my_space"
+    case myPage = "my_page"
+}
+
+// MARK: - User Property
+
+enum AnalyticsUserProperty: String {
+    case role = "role"
+    case loginMethod = "login_method"
+    case childConnected = "child_connected"
+    case pushEnabled = "push_enabled"
 }

--- a/Kiero/Kiero/Network/Analytics/AnalyticsEvent.swift
+++ b/Kiero/Kiero/Network/Analytics/AnalyticsEvent.swift
@@ -2,6 +2,8 @@
 //  AnalyticsEvent.swift
 //  Kiero
 //
+//  Created by Hyunseo Han on 7/28/26.
+//
 
 import Foundation
 

--- a/Kiero/Kiero/Network/Analytics/AnalyticsIdentity.swift
+++ b/Kiero/Kiero/Network/Analytics/AnalyticsIdentity.swift
@@ -13,11 +13,11 @@ enum AnalyticsIdentity {
 
     private static let deviceIdKeychainAccount = "analytics_device_id"
 
-    static var role: String {
+    static var role: AnalyticsRole {
 #if KIERO_PARENT
-        return "parent"
+        return .parent
 #else
-        return "child"
+        return .child
 #endif
     }
 

--- a/Kiero/Kiero/Network/Analytics/AnalyticsIdentity.swift
+++ b/Kiero/Kiero/Network/Analytics/AnalyticsIdentity.swift
@@ -38,6 +38,10 @@ enum AnalyticsIdentity {
         return generated
     }
 
+    static func hashed(_ value: String) -> String {
+        sha256(value.trimmingCharacters(in: .whitespacesAndNewlines).uppercased())
+    }
+
     private static func sha256(_ value: String) -> String {
         SHA256.hash(data: Data(value.utf8))
             .map { String(format: "%02x", $0) }

--- a/Kiero/Kiero/Network/Analytics/AnalyticsIdentity.swift
+++ b/Kiero/Kiero/Network/Analytics/AnalyticsIdentity.swift
@@ -2,6 +2,8 @@
 //  AnalyticsIdentity.swift
 //  Kiero
 //
+//  Created by Hyunseo Han on 7/28/26.
+//
 
 import CryptoKit
 import Foundation

--- a/Kiero/Kiero/Network/Analytics/AnalyticsIdentity.swift
+++ b/Kiero/Kiero/Network/Analytics/AnalyticsIdentity.swift
@@ -1,0 +1,83 @@
+//
+//  AnalyticsIdentity.swift
+//  Kiero
+//
+
+import CryptoKit
+import Foundation
+import Security
+
+enum AnalyticsIdentity {
+
+    private static let deviceIdKeychainAccount = "analytics_device_id"
+
+    static var role: String {
+#if KIERO_PARENT
+        return "parent"
+#else
+        return "child"
+#endif
+    }
+
+    static func resolveUserId() -> String? {
+#if KIERO_PARENT
+        guard let email = TokenManager.shared.getEmail(), !email.isEmpty else { return nil }
+        return sha256(email)
+#else
+        return deviceScopedId()
+#endif
+    }
+
+    private static func deviceScopedId() -> String {
+        if let saved = loadKeychain(account: deviceIdKeychainAccount) {
+            return saved
+        }
+
+        let generated = UUID().uuidString
+        saveKeychain(account: deviceIdKeychainAccount, value: generated)
+        return generated
+    }
+
+    private static func sha256(_ value: String) -> String {
+        SHA256.hash(data: Data(value.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+    }
+
+    // MARK: - Keychain
+
+    private static func saveKeychain(account: String, value: String) {
+        guard let data = value.data(using: .utf8) else { return }
+
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: account
+        ]
+
+        SecItemDelete(query as CFDictionary)
+
+        let attributes: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: account,
+            kSecValueData: data,
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock
+        ]
+
+        SecItemAdd(attributes as CFDictionary, nil)
+    }
+
+    private static func loadKeychain(account: String) -> String? {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: account,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/Kiero/Kiero/Network/Base/Config.swift
+++ b/Kiero/Kiero/Network/Base/Config.swift
@@ -12,6 +12,8 @@ enum Config {
         enum Plist {
             static let BASE_URL = "BASE_URL"
             static let KAKAO_NATIVE_APP_KEY = "KAKAO_NATIVE_APP_KEY"
+            static let AMPLITUDE_API_KEY_DEV = "AMPLITUDE_API_KEY_DEV"
+            static let AMPLITUDE_API_KEY_PROD = "AMPLITUDE_API_KEY_PROD"
         }
     }
     
@@ -45,6 +47,20 @@ extension Config {
         return key
     }()
     
+    /// Debug 빌드는 앰플리튜드 DEV 프로젝트, Release 빌드는 PROD 프로젝트로 전송
+    static let amplitudeAPIKey: String = {
+        #if DEBUG
+        let plistKey = Keys.Plist.AMPLITUDE_API_KEY_DEV
+        #else
+        let plistKey = Keys.Plist.AMPLITUDE_API_KEY_PROD
+        #endif
+
+        guard let key = Config.infoDictionary[plistKey] as? String else {
+            fatalError("\(plistKey) is not set in plist for this configuration")
+        }
+        return key
+    }()
+
     static let sseURL: URL = {
         guard let url = URL(string: baseURL + "/api/v1/subscribe") else {
             fatalError("구성된 SSE_URL이 유효한 URL 형식이 아닙니다: \(baseURL)")

--- a/Kiero/Kiero/Network/Base/Config.swift
+++ b/Kiero/Kiero/Network/Base/Config.swift
@@ -47,7 +47,6 @@ extension Config {
         return key
     }()
     
-    /// Debug 빌드는 앰플리튜드 DEV 프로젝트, Release 빌드는 PROD 프로젝트로 전송
     static let amplitudeAPIKey: String = {
         #if DEBUG
         let plistKey = Keys.Plist.AMPLITUDE_API_KEY_DEV

--- a/Kiero/Kiero/Network/DailyJourney/DailyJourneyService.swift
+++ b/Kiero/Kiero/Network/DailyJourney/DailyJourneyService.swift
@@ -49,6 +49,8 @@ final class DailyJourneyService {
     }
     
     func verifyJourney(scheduleDetailId: Int, image: UIImage) -> AnyPublisher<Void, NetworkError> {
+        AmplitudeManager.shared.track(.scheduleAuthStarted)
+
         return Future<Void, NetworkError> { promise in
             Task {
                 do {
@@ -103,6 +105,8 @@ final class DailyJourneyService {
                         body: requestBody
                     )
                     print("✅ 여정 인증 완료 (scheduleDetailId: \(scheduleDetailId), imageUrl: \(cleanImageUrl))")
+
+                    AmplitudeManager.shared.track(.scheduleAuthCompleted)
 
                     promise(.success(()))
                     

--- a/Kiero/Kiero/Network/Login/TokenManager.swift
+++ b/Kiero/Kiero/Network/Login/TokenManager.swift
@@ -11,9 +11,9 @@ import Security
 final class TokenManager {
     static let shared = TokenManager()
     private init() {}
-
+    
     private let userDefaults = UserDefaults.standard
-
+    
     private enum Key {
         static let access = "access_token"
         static let refresh = "refresh_token"
@@ -22,82 +22,93 @@ final class TokenManager {
         static let profile = "profile_url"
         static let sse = "sse_token"
         static let nameKey = "firstName"
+        static let email = "user_email"
     }
-
+    
     func saveAccessToken(_ access: String) {
         save(key: Key.access, value: access)
     }
-
+    
     func getAccessToken() -> String? {
         load(key: Key.access)
     }
-
+    
     func saveRefreshToken(_ refresh: String) {
         save(key: Key.refresh, value: refresh)
     }
-
+    
     func getRefreshToken() -> String? {
         load(key: Key.refresh)
     }
-
+    
     func saveSseToken(_ sse: String) {
         save(key: Key.sse, value: sse)
     }
-
+    
     func getSseToken() -> String? {
         load(key: Key.sse)
     }
-
+    
     func saveUserRole(_ role: String) {
         userDefaults.set(role, forKey: Key.role)
     }
-
+    
     func getUserRole() -> String? {
         userDefaults.string(forKey: Key.role)
     }
-
+    
     func saveUserName(_ name: String) {
         userDefaults.set(name, forKey: Key.name)
     }
-
+    
     func getUserName() -> String? {
         userDefaults.string(forKey: Key.name)
     }
-
+    
     func saveFirstName(_ name: String) {
         userDefaults.set(name, forKey: Key.nameKey)
     }
-
+    
     func getFirstName() -> String? {
         userDefaults.string(forKey: Key.nameKey)
     }
-
+    
+    func saveEmail(_ email: String) {
+        userDefaults.set(email, forKey: Key.email)
+    }
+    
+    func getEmail() -> String? {
+        userDefaults.string(forKey: Key.email)
+    }
+    
     func saveProfile(_ profile: String) {
         userDefaults.set(profile, forKey: Key.profile)
     }
-
+    
     func getProfile() -> String? {
         userDefaults.string(forKey: Key.profile)
     }
-
+    
     func clearTokens() {
         delete(key: Key.access)
         delete(key: Key.refresh)
     }
-
+    
     func clearUserInfo() {
         userDefaults.removeObject(forKey: Key.role)
         userDefaults.removeObject(forKey: Key.name)
         userDefaults.removeObject(forKey: Key.nameKey)
         userDefaults.removeObject(forKey: Key.profile)
+        userDefaults.removeObject(forKey: Key.email)
     }
-
+    
     func clearAll() {
         clearTokens()
         clearUserInfo()
         SseStreamManager.shared.stop()
+        AmplitudeManager.shared.reset()
     }
-
+    
     var isLoggedIn: Bool {
         getAccessToken() != nil && getRefreshToken() != nil
     }
@@ -105,37 +116,37 @@ final class TokenManager {
     func saveRequiredTermsIds(_ ids: [Int]) {
         userDefaults.set(ids, forKey: "requiredTermsIds")
     }
-
+    
     func getRequiredTermsIds() -> [Int] {
         userDefaults.array(forKey: "requiredTermsIds") as? [Int] ?? []
     }
-
+    
     func removeRequiredTermsIds() {
         userDefaults.removeObject(forKey: "requiredTermsIds")
     }
-
+    
     // MARK: - Keychain Helpers
-
+    
     private func save(key: String, value: String) {
         guard let data = value.data(using: .utf8) else { return }
-
+        
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key
         ]
-
+        
         SecItemDelete(query as CFDictionary)
-
+        
         let attributes: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrAccount: key,
             kSecValueData: data,
             kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock
         ]
-
+        
         SecItemAdd(attributes as CFDictionary, nil)
     }
-
+    
     private func load(key: String) -> String? {
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
@@ -143,14 +154,14 @@ final class TokenManager {
             kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitOne
         ]
-
+        
         var result: AnyObject?
         SecItemCopyMatching(query as CFDictionary, &result)
-
+        
         guard let data = result as? Data else { return nil }
         return String(data: data, encoding: .utf8)
     }
-
+    
     private func delete(key: String) {
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,

--- a/Kiero/Kiero/ParentInfo.plist
+++ b/Kiero/Kiero/ParentInfo.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>CFBundleDisplayName</key>
 	<string>Kiero</string>
+	<key>AMPLITUDE_API_KEY_DEV</key>
+	<string>$(AMPLITUDE_API_KEY_DEV)</string>
+	<key>AMPLITUDE_API_KEY_PROD</key>
+	<string>$(AMPLITUDE_API_KEY_PROD)</string>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
 	<key>CFBundleURLTypes</key>

--- a/Kiero/Kiero/Presentation/CoinMission/CoinMissionViewModel.swift
+++ b/Kiero/Kiero/Presentation/CoinMission/CoinMissionViewModel.swift
@@ -74,6 +74,7 @@ final class CoinMissionViewModel: BaseViewModel, ViewModelType {
                     .eraseToAnyPublisher()
             }
             .sink { [weak self] dto in
+                AmplitudeManager.shared.track(.missionCompleted)
                 self?.applyComplete(dto)
             }
             .store(in: &cancellables)

--- a/Kiero/Kiero/Presentation/Common/Splash/PickRoleView.swift
+++ b/Kiero/Kiero/Presentation/Common/Splash/PickRoleView.swift
@@ -115,6 +115,12 @@ final class PickRoleView: UIView {
 
     @objc private func didTapStart() {
         guard let role = selectedRole else { return }
+
+        AmplitudeManager.shared.track(.roleSelected, properties: [
+            AnalyticsEventProperty.selectedRole: role == .parent ? "parent" : "child",
+            AnalyticsEventProperty.source: "auth_gate"
+        ])
+
         onTapStart?(role)
     }
 

--- a/Kiero/Kiero/Presentation/Common/Splash/PickRoleView.swift
+++ b/Kiero/Kiero/Presentation/Common/Splash/PickRoleView.swift
@@ -116,10 +116,7 @@ final class PickRoleView: UIView {
     @objc private func didTapStart() {
         guard let role = selectedRole else { return }
 
-        AmplitudeManager.shared.track(.roleSelected, properties: [
-            AnalyticsEventProperty.selectedRole: role == .parent ? "parent" : "child",
-            AnalyticsEventProperty.source: "auth_gate"
-        ])
+        AmplitudeManager.shared.track(.roleSelected(role: role == .parent ? .parent : .child, source: .authGate))
 
         onTapStart?(role)
     }

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
@@ -164,6 +164,10 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
             UNUserNotificationCenter.current().requestAuthorization(
                 options: [.alert, .badge, .sound]
             ) { granted, _ in
+                AmplitudeManager.shared.track(.pushPermissionResult, properties: [
+                    AnalyticsEventProperty.granted: granted,
+                    AnalyticsEventProperty.source: "daily_journey"
+                ])
                 guard granted else { return }
                 DispatchQueue.main.async {
                     UIApplication.shared.registerForRemoteNotifications()

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
@@ -164,10 +164,7 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
             UNUserNotificationCenter.current().requestAuthorization(
                 options: [.alert, .badge, .sound]
             ) { granted, _ in
-                AmplitudeManager.shared.track(.pushPermissionResult, properties: [
-                    AnalyticsEventProperty.granted: granted,
-                    AnalyticsEventProperty.source: "daily_journey"
-                ])
+                AmplitudeManager.shared.track(.pushPermissionResult(granted: granted, source: .dailyJourney))
                 AmplitudeManager.shared.setUserProperties([.pushEnabled: granted])
                 guard granted else { return }
                 DispatchQueue.main.async {

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewController.swift
@@ -168,6 +168,7 @@ final class DailyJourneyViewController: BaseViewController<DailyJourneyViewModel
                     AnalyticsEventProperty.granted: granted,
                     AnalyticsEventProperty.source: "daily_journey"
                 ])
+                AmplitudeManager.shared.setUserProperties([.pushEnabled: granted])
                 guard granted else { return }
                 DispatchQueue.main.async {
                     UIApplication.shared.registerForRemoteNotifications()

--- a/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
+++ b/Kiero/Kiero/Presentation/DailyJourney/DailyJourneyViewModel.swift
@@ -132,6 +132,7 @@ final class DailyJourneyViewModel: BaseViewModel, ViewModelType {
                     self.fetchDailyJourney()
                 }
             } receiveValue: { [weak self] _ in
+                AmplitudeManager.shared.track(.scheduleSkipped)
                 self?.fetchDailyJourney()
             }
             .store(in: &cancellables)

--- a/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneViewModel.swift
+++ b/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneViewModel.swift
@@ -75,7 +75,7 @@ final class GiveFireStoneViewModel: BaseViewModel, ViewModelType {
 
                 AmplitudeManager.shared.track(.dailyJourneyCompleted, properties: [
                     AnalyticsEventProperty.earnedCoin: data.earnedCoinAmount,
-                    AnalyticsEventProperty.stoneCount: data.gotStones
+                    AnalyticsEventProperty.stoneCount: data.gotStones.count
                 ])
 
                 self?.resultSubject.send((data.earnedCoinAmount, data.gotStones))

--- a/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneViewModel.swift
+++ b/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneViewModel.swift
@@ -72,7 +72,12 @@ final class GiveFireStoneViewModel: BaseViewModel, ViewModelType {
                 }
             } receiveValue: { [weak self] data in
                 print("✅ [GiveFireStoneVM] 성공! 획득 코인: \(data.earnedCoinAmount), 불조각: \(data.gotStones)")
-                
+
+                AmplitudeManager.shared.track(.dailyJourneyCompleted, properties: [
+                    AnalyticsEventProperty.earnedCoin: data.earnedCoinAmount,
+                    AnalyticsEventProperty.stoneCount: data.gotStones
+                ])
+
                 self?.resultSubject.send((data.earnedCoinAmount, data.gotStones))
             }
             .store(in: &cancellables)

--- a/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneViewModel.swift
+++ b/Kiero/Kiero/Presentation/GiveFireStone/GiveFireStoneViewModel.swift
@@ -73,10 +73,10 @@ final class GiveFireStoneViewModel: BaseViewModel, ViewModelType {
             } receiveValue: { [weak self] data in
                 print("✅ [GiveFireStoneVM] 성공! 획득 코인: \(data.earnedCoinAmount), 불조각: \(data.gotStones)")
 
-                AmplitudeManager.shared.track(.dailyJourneyCompleted, properties: [
-                    AnalyticsEventProperty.earnedCoin: data.earnedCoinAmount,
-                    AnalyticsEventProperty.stoneCount: data.gotStones.count
-                ])
+                AmplitudeManager.shared.track(.dailyJourneyCompleted(
+                    earnedCoin: data.earnedCoinAmount,
+                    stoneCount: data.gotStones.count
+                ))
 
                 self?.resultSubject.send((data.earnedCoinAmount, data.gotStones))
             }

--- a/Kiero/Kiero/Presentation/Login/ViewModel/ChildLoginViewModel.swift
+++ b/Kiero/Kiero/Presentation/Login/ViewModel/ChildLoginViewModel.swift
@@ -74,12 +74,8 @@ final class ChildLoginViewModel: BaseViewModel {
                     .loginMethod: AnalyticsLoginMethod.inviteCode.rawValue,
                     .childConnected: true
                 ])
-                AmplitudeManager.shared.track(.loginCompleted, properties: [
-                    AnalyticsEventProperty.loginMethod: AnalyticsLoginMethod.inviteCode.rawValue
-                ])
-                AmplitudeManager.shared.track(.childConnectionCompleted, properties: [
-                    AnalyticsEventProperty.inviteCodeHash: AnalyticsIdentity.hashed(code)
-                ])
+                AmplitudeManager.shared.track(.loginCompleted(method: .inviteCode))
+                AmplitudeManager.shared.track(.childConnectionCompleted(codeHash: AnalyticsIdentity.hashed(code)))
                 
                 await FCMTokenManager.shared.sendCurrentTokenToServer()
                 

--- a/Kiero/Kiero/Presentation/Login/ViewModel/ChildLoginViewModel.swift
+++ b/Kiero/Kiero/Presentation/Login/ViewModel/ChildLoginViewModel.swift
@@ -74,6 +74,12 @@ final class ChildLoginViewModel: BaseViewModel {
                     .loginMethod: AnalyticsLoginMethod.inviteCode.rawValue,
                     .childConnected: true
                 ])
+                AmplitudeManager.shared.track(.loginCompleted, properties: [
+                    AnalyticsEventProperty.loginMethod: AnalyticsLoginMethod.inviteCode.rawValue
+                ])
+                AmplitudeManager.shared.track(.childConnectionCompleted, properties: [
+                    AnalyticsEventProperty.inviteCodeHash: AnalyticsIdentity.hashed(code)
+                ])
                 
                 await FCMTokenManager.shared.sendCurrentTokenToServer()
                 

--- a/Kiero/Kiero/Presentation/Login/ViewModel/ChildLoginViewModel.swift
+++ b/Kiero/Kiero/Presentation/Login/ViewModel/ChildLoginViewModel.swift
@@ -19,41 +19,41 @@ enum ChildLoginState: Equatable {
 }
 
 final class ChildLoginViewModel: BaseViewModel {
-
+    
     // MARK: - Publisher
-
+    
     private let stateSubject = CurrentValueSubject<ChildLoginState, Never>(.idle)
     private let routeSubject = PassthroughSubject<ChildLoginRoute, Never>()
-
+    
     var state: AnyPublisher<ChildLoginState, Never> {
         stateSubject.eraseToAnyPublisher()
     }
-
+    
     var route: AnyPublisher<ChildLoginRoute, Never> {
         routeSubject.eraseToAnyPublisher()
     }
-
+    
     // MARK: - Public Action
-
+    
     func signup(lastName: String, firstName: String, inviteCode: String) {
         let last = lastName.trimmingCharacters(in: .whitespacesAndNewlines)
         let first = firstName.trimmingCharacters(in: .whitespacesAndNewlines)
         let code = inviteCode.trimmingCharacters(in: .whitespacesAndNewlines)
-
+        
         guard !last.isEmpty, !first.isEmpty, !code.isEmpty else { return }
-
+        
         stateSubject.send(.loading)
-
+        
         Task { [weak self] in
             guard let self else { return }
-
+            
             do {
                 let body = ChildSignupRequest(
                     lastName: last,
                     firstName: first,
                     inviteCode: code
                 )
-
+                
                 let data: ChildSignupData = try await BaseService.shared.request(
                     endPoint: .childSignup(
                         lastName: last,
@@ -62,20 +62,26 @@ final class ChildLoginViewModel: BaseViewModel {
                     ),
                     body: body
                 )
-
+                
                 TokenManager.shared.saveAccessToken(data.accessToken)
                 TokenManager.shared.saveRefreshToken(data.refreshToken)
                 TokenManager.shared.saveUserRole(data.role)
                 TokenManager.shared.saveUserName("\(data.lastName)\(data.firstName)")
                 TokenManager.shared.saveFirstName(data.firstName)
                 
+                AmplitudeManager.shared.refreshUserId()
+                AmplitudeManager.shared.setUserProperties([
+                    .loginMethod: AnalyticsLoginMethod.inviteCode.rawValue,
+                    .childConnected: true
+                ])
+                
                 await FCMTokenManager.shared.sendCurrentTokenToServer()
-
+                
                 await MainActor.run {
                     self.stateSubject.send(.idle)
                     self.routeSubject.send(.childOnboarding)
                 }
-
+                
             } catch let error as NetworkError {
                 await MainActor.run {
                     self.stateSubject.send(.failure(error.toastMessage))

--- a/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
+++ b/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
@@ -81,6 +81,12 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
                 }
                 TokenManager.shared.saveUserName(loginData.name)
                 TokenManager.shared.saveUserRole(loginData.role)
+                TokenManager.shared.saveEmail(loginData.email)
+                
+                AmplitudeManager.shared.refreshUserId()
+                AmplitudeManager.shared.setUserProperties([
+                    .loginMethod: AnalyticsLoginMethod.kakao.rawValue
+                ])
                 
                 await FCMTokenManager.shared.sendCurrentTokenToServer()
                 
@@ -91,6 +97,9 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
                 let children: ChildListResponse = try await BaseService.shared.request(
                     endPoint: .fetchChildren
                 )
+                AmplitudeManager.shared.setUserProperties([
+                    .childConnected: !children.isEmpty
+                ])
                 await MainActor.run {
                     self.stateSubject.send(.idle)
                     if children.isEmpty {
@@ -149,6 +158,12 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
                 }
                 TokenManager.shared.saveUserName(loginData.name)
                 TokenManager.shared.saveUserRole(loginData.role)
+                TokenManager.shared.saveEmail(loginData.email)
+                
+                AmplitudeManager.shared.refreshUserId()
+                AmplitudeManager.shared.setUserProperties([
+                    .loginMethod: AnalyticsLoginMethod.apple.rawValue
+                ])
                 
                 await FCMTokenManager.shared.sendCurrentTokenToServer()
                 
@@ -159,6 +174,9 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
                 let children: ChildListResponse = try await BaseService.shared.request(
                     endPoint: .fetchChildren
                 )
+                AmplitudeManager.shared.setUserProperties([
+                    .childConnected: !children.isEmpty
+                ])
                 await MainActor.run {
                     self.stateSubject.send(.idle)
                     if children.isEmpty {
@@ -193,15 +211,15 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
         let agreement: RequiredTermsAgreementStatusData = try await BaseService.shared.request(
             endPoint: .requiredTermsAgreementStatus
         )
-
+        
         guard agreement.isRequiredTermsAllAgreed == false else {
             return nil
         }
-
+        
         let terms: [RequiredTerm] = try await BaseService.shared.request(
             endPoint: .requiredTerms
         )
-
+        
         return terms
     }
     
@@ -213,7 +231,7 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
             }
             return true
         }
-
+        
         return false
     }
     

--- a/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
+++ b/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
@@ -87,9 +87,7 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
                 AmplitudeManager.shared.setUserProperties([
                     .loginMethod: AnalyticsLoginMethod.kakao.rawValue
                 ])
-                AmplitudeManager.shared.track(.loginCompleted, properties: [
-                    AnalyticsEventProperty.loginMethod: AnalyticsLoginMethod.kakao.rawValue
-                ])
+                AmplitudeManager.shared.track(.loginCompleted(method: .kakao))
                 
                 await FCMTokenManager.shared.sendCurrentTokenToServer()
                 
@@ -167,9 +165,7 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
                 AmplitudeManager.shared.setUserProperties([
                     .loginMethod: AnalyticsLoginMethod.apple.rawValue
                 ])
-                AmplitudeManager.shared.track(.loginCompleted, properties: [
-                    AnalyticsEventProperty.loginMethod: AnalyticsLoginMethod.apple.rawValue
-                ])
+                AmplitudeManager.shared.track(.loginCompleted(method: .apple))
                 
                 await FCMTokenManager.shared.sendCurrentTokenToServer()
                 

--- a/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
+++ b/Kiero/Kiero/Presentation/Login/ViewModel/ParentLoginViewModel.swift
@@ -87,6 +87,9 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
                 AmplitudeManager.shared.setUserProperties([
                     .loginMethod: AnalyticsLoginMethod.kakao.rawValue
                 ])
+                AmplitudeManager.shared.track(.loginCompleted, properties: [
+                    AnalyticsEventProperty.loginMethod: AnalyticsLoginMethod.kakao.rawValue
+                ])
                 
                 await FCMTokenManager.shared.sendCurrentTokenToServer()
                 
@@ -163,6 +166,9 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
                 AmplitudeManager.shared.refreshUserId()
                 AmplitudeManager.shared.setUserProperties([
                     .loginMethod: AnalyticsLoginMethod.apple.rawValue
+                ])
+                AmplitudeManager.shared.track(.loginCompleted, properties: [
+                    AnalyticsEventProperty.loginMethod: AnalyticsLoginMethod.apple.rawValue
                 ])
                 
                 await FCMTokenManager.shared.sendCurrentTokenToServer()
@@ -267,8 +273,9 @@ final class ParentLoginViewModel: BaseViewModel, ViewModelType {
                     )
                     
                     TokenManager.shared.removeRequiredTermsIds()
+                    AmplitudeManager.shared.track(.termsAgreementCompleted)
                 }
-                
+
                 await MainActor.run {
                     self.stateSubject.send(.idle)
                     self.routeSubject.send(.parentTab)

--- a/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewModel.swift
+++ b/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewModel.swift
@@ -57,10 +57,7 @@ final class AIMissionViewModel: BaseViewModel {
             .sink { [weak self] completion in
                 self?.isLoading.send(false)
             } receiveValue: { [weak self] response in
-                AmplitudeManager.shared.track(.missionCreated, properties: [
-                    AnalyticsEventProperty.source: "ai",
-                    AnalyticsEventProperty.count: response.count
-                ])
+                AmplitudeManager.shared.track(.missionCreated(source: .ai, count: response.count))
                 let sortedAiIds = response.sorted { $0.name < $1.name }.reversed().map { $0.id }
                 
                 var recentActivity = UserDefaults.standard.array(forKey: "recentActivityIds") as? [Int] ?? []

--- a/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewModel.swift
+++ b/Kiero/Kiero/Presentation/Mission/AIMission/AIMissionViewModel.swift
@@ -57,6 +57,10 @@ final class AIMissionViewModel: BaseViewModel {
             .sink { [weak self] completion in
                 self?.isLoading.send(false)
             } receiveValue: { [weak self] response in
+                AmplitudeManager.shared.track(.missionCreated, properties: [
+                    AnalyticsEventProperty.source: "ai",
+                    AnalyticsEventProperty.count: response.count
+                ])
                 let sortedAiIds = response.sorted { $0.name < $1.name }.reversed().map { $0.id }
                 
                 var recentActivity = UserDefaults.standard.array(forKey: "recentActivityIds") as? [Int] ?? []

--- a/Kiero/Kiero/Presentation/Mission/WriteMission/WriteMissionViewModel.swift
+++ b/Kiero/Kiero/Presentation/Mission/WriteMission/WriteMissionViewModel.swift
@@ -34,6 +34,9 @@ final class WriteMissionViewModel: BaseViewModel {
                 }
             } receiveValue: { [weak self] response in
                 print("🔍 새로 추가된 미션 id: \(response.id)")
+                AmplitudeManager.shared.track(.missionCreated, properties: [
+                    AnalyticsEventProperty.source: "manual"
+                ])
                 var recentActivity = UserDefaults.standard.array(forKey: "recentActivityIds") as? [Int] ?? []
                 recentActivity.append(response.id)
                 UserDefaults.standard.set(recentActivity, forKey: "recentActivityIds")

--- a/Kiero/Kiero/Presentation/Mission/WriteMission/WriteMissionViewModel.swift
+++ b/Kiero/Kiero/Presentation/Mission/WriteMission/WriteMissionViewModel.swift
@@ -34,9 +34,7 @@ final class WriteMissionViewModel: BaseViewModel {
                 }
             } receiveValue: { [weak self] response in
                 print("🔍 새로 추가된 미션 id: \(response.id)")
-                AmplitudeManager.shared.track(.missionCreated, properties: [
-                    AnalyticsEventProperty.source: "manual"
-                ])
+                AmplitudeManager.shared.track(.missionCreated(source: .manual, count: nil))
                 var recentActivity = UserDefaults.standard.array(forKey: "recentActivityIds") as? [Int] ?? []
                 recentActivity.append(response.id)
                 UserDefaults.standard.set(recentActivity, forKey: "recentActivityIds")

--- a/Kiero/Kiero/Presentation/MyPage/ViewModel/ChildManageViewModel.swift
+++ b/Kiero/Kiero/Presentation/MyPage/ViewModel/ChildManageViewModel.swift
@@ -92,10 +92,10 @@ final class ChildManageViewModel: BaseViewModel, ObservableObject {
                     body: req
                 )
                 
-                AmplitudeManager.shared.track(.inviteCodeCreated, properties: [
-                    AnalyticsEventProperty.inviteCodeHash: AnalyticsIdentity.hashed(data.code),
-                    AnalyticsEventProperty.source: "child_manage"
-                ])
+                AmplitudeManager.shared.track(.inviteCodeCreated(
+                    codeHash: AnalyticsIdentity.hashed(data.code),
+                    source: .childManage
+                ))
 
                 await MainActor.run {
                     let expiresAt = Date().addingTimeInterval(self.expiresIn)

--- a/Kiero/Kiero/Presentation/MyPage/ViewModel/ChildManageViewModel.swift
+++ b/Kiero/Kiero/Presentation/MyPage/ViewModel/ChildManageViewModel.swift
@@ -92,6 +92,11 @@ final class ChildManageViewModel: BaseViewModel, ObservableObject {
                     body: req
                 )
                 
+                AmplitudeManager.shared.track(.inviteCodeCreated, properties: [
+                    AnalyticsEventProperty.inviteCodeHash: AnalyticsIdentity.hashed(data.code),
+                    AnalyticsEventProperty.source: "child_manage"
+                ])
+
                 await MainActor.run {
                     let expiresAt = Date().addingTimeInterval(self.expiresIn)
 

--- a/Kiero/Kiero/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Kiero/Kiero/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -76,10 +76,7 @@ final class MyPageViewModel: BaseViewModel, ObservableObject {
                 case .notDetermined:
                     UNUserNotificationCenter.current()
                         .requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
-                            AmplitudeManager.shared.track(.pushPermissionResult, properties: [
-                                AnalyticsEventProperty.granted: granted,
-                                AnalyticsEventProperty.source: "my_page"
-                            ])
+                            AmplitudeManager.shared.track(.pushPermissionResult(granted: granted, source: .myPage))
                             AmplitudeManager.shared.setUserProperties([.pushEnabled: granted])
                             DispatchQueue.main.async {
                                 self.isAlarmOn = granted

--- a/Kiero/Kiero/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Kiero/Kiero/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -40,6 +40,8 @@ final class MyPageViewModel: BaseViewModel, ObservableObject {
     }
     
     private func updateNotificationSettings(enabled: Bool) {
+        AmplitudeManager.shared.setUserProperties([.pushEnabled: enabled])
+
         Task {
             do {
                 let body = NotificationSettingsRequest(pushNotificationEnabled: enabled)
@@ -78,6 +80,7 @@ final class MyPageViewModel: BaseViewModel, ObservableObject {
                                 AnalyticsEventProperty.granted: granted,
                                 AnalyticsEventProperty.source: "my_page"
                             ])
+                            AmplitudeManager.shared.setUserProperties([.pushEnabled: granted])
                             DispatchQueue.main.async {
                                 self.isAlarmOn = granted
                                 if granted {

--- a/Kiero/Kiero/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/Kiero/Kiero/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -74,6 +74,10 @@ final class MyPageViewModel: BaseViewModel, ObservableObject {
                 case .notDetermined:
                     UNUserNotificationCenter.current()
                         .requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+                            AmplitudeManager.shared.track(.pushPermissionResult, properties: [
+                                AnalyticsEventProperty.granted: granted,
+                                AnalyticsEventProperty.source: "my_page"
+                            ])
                             DispatchQueue.main.async {
                                 self.isAlarmOn = granted
                                 if granted {

--- a/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
+++ b/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
@@ -153,10 +153,7 @@ private extension MySpaceView {
                     showNotificationDialog = true
                 case .notDetermined:
                     UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
-                        AmplitudeManager.shared.track(.pushPermissionResult, properties: [
-                            AnalyticsEventProperty.granted: granted,
-                            AnalyticsEventProperty.source: "my_space"
-                        ])
+                        AmplitudeManager.shared.track(.pushPermissionResult(granted: granted, source: .mySpace))
                         AmplitudeManager.shared.setUserProperties([.pushEnabled: granted])
                         DispatchQueue.main.async {
                             isAlarmOn = granted

--- a/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
+++ b/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
@@ -157,6 +157,7 @@ private extension MySpaceView {
                             AnalyticsEventProperty.granted: granted,
                             AnalyticsEventProperty.source: "my_space"
                         ])
+                        AmplitudeManager.shared.setUserProperties([.pushEnabled: granted])
                         DispatchQueue.main.async {
                             isAlarmOn = granted
                             if granted {
@@ -206,6 +207,8 @@ private extension MySpaceView {
     }
     
     func updateNotificationSettings(enabled: Bool) {
+        AmplitudeManager.shared.setUserProperties([.pushEnabled: enabled])
+
         Task {
             do {
                 let body = NotificationSettingsRequest(pushNotificationEnabled: enabled)

--- a/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
+++ b/Kiero/Kiero/Presentation/MySpace/MySpaceView.swift
@@ -153,6 +153,10 @@ private extension MySpaceView {
                     showNotificationDialog = true
                 case .notDetermined:
                     UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, _ in
+                        AmplitudeManager.shared.track(.pushPermissionResult, properties: [
+                            AnalyticsEventProperty.granted: granted,
+                            AnalyticsEventProperty.source: "my_space"
+                        ])
                         DispatchQueue.main.async {
                             isAlarmOn = granted
                             if granted {

--- a/Kiero/Kiero/Presentation/Onboarding/View/ChildOnboardingViewController.swift
+++ b/Kiero/Kiero/Presentation/Onboarding/View/ChildOnboardingViewController.swift
@@ -164,6 +164,8 @@ final class ChildOnboardingViewController: BaseViewController<ChildOnboardingVie
     
     @objc
     private func startButtonDidTap() {
+        AmplitudeManager.shared.track(.onboardingCompleted)
+
         guard let loadingVC = makeLoadingVC?() else { return }
         loadingVC.modalPresentationStyle = .fullScreen
         present(loadingVC, animated: false)

--- a/Kiero/Kiero/Presentation/Onboarding/ViewModel/ParentInviteViewModel.swift
+++ b/Kiero/Kiero/Presentation/Onboarding/ViewModel/ParentInviteViewModel.swift
@@ -83,10 +83,10 @@ final class ParentInviteViewModel: BaseViewModel {
                     body: req
                 )
 
-                AmplitudeManager.shared.track(.inviteCodeCreated, properties: [
-                    AnalyticsEventProperty.inviteCodeHash: AnalyticsIdentity.hashed(data.code),
-                    AnalyticsEventProperty.source: "reissue"
-                ])
+                AmplitudeManager.shared.track(.inviteCodeCreated(
+                    codeHash: AnalyticsIdentity.hashed(data.code),
+                    source: .reissue
+                ))
 
                 await MainActor.run {
                     self.inviteCodeSubject.send(data.code)

--- a/Kiero/Kiero/Presentation/Onboarding/ViewModel/ParentInviteViewModel.swift
+++ b/Kiero/Kiero/Presentation/Onboarding/ViewModel/ParentInviteViewModel.swift
@@ -83,6 +83,11 @@ final class ParentInviteViewModel: BaseViewModel {
                     body: req
                 )
 
+                AmplitudeManager.shared.track(.inviteCodeCreated, properties: [
+                    AnalyticsEventProperty.inviteCodeHash: AnalyticsIdentity.hashed(data.code),
+                    AnalyticsEventProperty.source: "reissue"
+                ])
+
                 await MainActor.run {
                     self.inviteCodeSubject.send(data.code)
                     self.expiresAt = Date().addingTimeInterval(self.expiresIn)
@@ -164,7 +169,9 @@ final class ParentInviteViewModel: BaseViewModel {
                         body: request
                     )
                     TokenManager.shared.removeRequiredTermsIds()
+                    AmplitudeManager.shared.track(.termsAgreementCompleted)
                 }
+                AmplitudeManager.shared.track(.onboardingCompleted)
                 await MainActor.run {
                     self.isStartingSubject.send(false)
                     self.routeSubject.send(.parentTab)

--- a/Kiero/Kiero/Presentation/Onboarding/ViewModel/ParentOnboardingViewModel.swift
+++ b/Kiero/Kiero/Presentation/Onboarding/ViewModel/ParentOnboardingViewModel.swift
@@ -59,10 +59,10 @@ final class ParentOnboardingViewModel: BaseViewModel {
                     body: req
                 )
 
-                AmplitudeManager.shared.track(.inviteCodeCreated, properties: [
-                    AnalyticsEventProperty.inviteCodeHash: AnalyticsIdentity.hashed(data.code),
-                    AnalyticsEventProperty.source: "onboarding"
-                ])
+                AmplitudeManager.shared.track(.inviteCodeCreated(
+                    codeHash: AnalyticsIdentity.hashed(data.code),
+                    source: .onboarding
+                ))
 
                 print("✅ [VM] 2) reissueSseAccessToken() 호출 직전")
 

--- a/Kiero/Kiero/Presentation/Onboarding/ViewModel/ParentOnboardingViewModel.swift
+++ b/Kiero/Kiero/Presentation/Onboarding/ViewModel/ParentOnboardingViewModel.swift
@@ -59,6 +59,11 @@ final class ParentOnboardingViewModel: BaseViewModel {
                     body: req
                 )
 
+                AmplitudeManager.shared.track(.inviteCodeCreated, properties: [
+                    AnalyticsEventProperty.inviteCodeHash: AnalyticsIdentity.hashed(data.code),
+                    AnalyticsEventProperty.source: "onboarding"
+                ])
+
                 print("✅ [VM] 2) reissueSseAccessToken() 호출 직전")
 
                 let sseToken = try await TokenRefresher.shared.reissueSseAccessToken()

--- a/Kiero/Kiero/Presentation/PickRole/PickRoleViewController.swift
+++ b/Kiero/Kiero/Presentation/PickRole/PickRoleViewController.swift
@@ -69,18 +69,12 @@ final class PickRoleViewController: BaseViewController<BaseViewModel> {
     
     override func addTarget() {
         parentButton.onTap = { [weak self] in
-            AmplitudeManager.shared.track(.roleSelected, properties: [
-                AnalyticsEventProperty.selectedRole: "parent",
-                AnalyticsEventProperty.source: "logout_dialog"
-            ])
+            AmplitudeManager.shared.track(.roleSelected(role: .parent, source: .logoutDialog))
             self?.onSelectParent?()
         }
 
         childButton.onTap = { [weak self] in
-            AmplitudeManager.shared.track(.roleSelected, properties: [
-                AnalyticsEventProperty.selectedRole: "child",
-                AnalyticsEventProperty.source: "logout_dialog"
-            ])
+            AmplitudeManager.shared.track(.roleSelected(role: .child, source: .logoutDialog))
             self?.onSelectChild?()
         }
     }

--- a/Kiero/Kiero/Presentation/PickRole/PickRoleViewController.swift
+++ b/Kiero/Kiero/Presentation/PickRole/PickRoleViewController.swift
@@ -69,10 +69,16 @@ final class PickRoleViewController: BaseViewController<BaseViewModel> {
     
     override func addTarget() {
         parentButton.onTap = { [weak self] in
+            AmplitudeManager.shared.track(.roleSelected, properties: [
+                AnalyticsEventProperty.selectedRole: "parent"
+            ])
             self?.onSelectParent?()
         }
-        
+
         childButton.onTap = { [weak self] in
+            AmplitudeManager.shared.track(.roleSelected, properties: [
+                AnalyticsEventProperty.selectedRole: "child"
+            ])
             self?.onSelectChild?()
         }
     }

--- a/Kiero/Kiero/Presentation/PickRole/PickRoleViewController.swift
+++ b/Kiero/Kiero/Presentation/PickRole/PickRoleViewController.swift
@@ -70,14 +70,16 @@ final class PickRoleViewController: BaseViewController<BaseViewModel> {
     override func addTarget() {
         parentButton.onTap = { [weak self] in
             AmplitudeManager.shared.track(.roleSelected, properties: [
-                AnalyticsEventProperty.selectedRole: "parent"
+                AnalyticsEventProperty.selectedRole: "parent",
+                AnalyticsEventProperty.source: "logout_dialog"
             ])
             self?.onSelectParent?()
         }
 
         childButton.onTap = { [weak self] in
             AmplitudeManager.shared.track(.roleSelected, properties: [
-                AnalyticsEventProperty.selectedRole: "child"
+                AnalyticsEventProperty.selectedRole: "child",
+                AnalyticsEventProperty.source: "logout_dialog"
             ])
             self?.onSelectChild?()
         }

--- a/Kiero/Kiero/Presentation/Reward/RewardViewModel.swift
+++ b/Kiero/Kiero/Presentation/Reward/RewardViewModel.swift
@@ -59,6 +59,7 @@ final class RewardViewModel: BaseViewModel, ObservableObject {
                 switch completion {
                 case .finished:
                     print(" 쿠폰 추가 API 성공")
+                    AmplitudeManager.shared.track(.rewardCreated)
                     self?.fetchCoupons(childId: self?.currentChildId)
                     
                 case .failure(let error):

--- a/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewModel.swift
+++ b/Kiero/Kiero/Presentation/Schedule/AddSchedule/AddScheduleViewModel.swift
@@ -48,6 +48,7 @@ final class AddScheduleViewModel: BaseViewModel {
                 }
             } receiveValue: { [weak self] _ in
                 print("✅ [VM] 서버 저장 성공")
+                AmplitudeManager.shared.track(.scheduleCreated)
                 self?.isAddSuccess.send(())
             }
             .store(in: &cancellables)

--- a/Kiero/Kiero/Presentation/TodayStatus/TodayStatusHostingController.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/TodayStatusHostingController.swift
@@ -118,10 +118,7 @@ private extension TodayStatusHostingController {
             UNUserNotificationCenter.current().requestAuthorization(
                 options: [.alert, .badge, .sound]
             ) { [weak self] granted, _ in
-                AmplitudeManager.shared.track(.pushPermissionResult, properties: [
-                    AnalyticsEventProperty.granted: granted,
-                    AnalyticsEventProperty.source: "today_status"
-                ])
+                AmplitudeManager.shared.track(.pushPermissionResult(granted: granted, source: .todayStatus))
                 AmplitudeManager.shared.setUserProperties([.pushEnabled: granted])
                 guard granted else { return }
 

--- a/Kiero/Kiero/Presentation/TodayStatus/TodayStatusHostingController.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/TodayStatusHostingController.swift
@@ -122,6 +122,7 @@ private extension TodayStatusHostingController {
                     AnalyticsEventProperty.granted: granted,
                     AnalyticsEventProperty.source: "today_status"
                 ])
+                AmplitudeManager.shared.setUserProperties([.pushEnabled: granted])
                 guard granted else { return }
 
                 DispatchQueue.main.async {

--- a/Kiero/Kiero/Presentation/TodayStatus/TodayStatusHostingController.swift
+++ b/Kiero/Kiero/Presentation/TodayStatus/TodayStatusHostingController.swift
@@ -118,8 +118,12 @@ private extension TodayStatusHostingController {
             UNUserNotificationCenter.current().requestAuthorization(
                 options: [.alert, .badge, .sound]
             ) { [weak self] granted, _ in
+                AmplitudeManager.shared.track(.pushPermissionResult, properties: [
+                    AnalyticsEventProperty.granted: granted,
+                    AnalyticsEventProperty.source: "today_status"
+                ])
                 guard granted else { return }
-                
+
                 DispatchQueue.main.async {
                     UIApplication.shared.registerForRemoteNotifications()
                     self?.viewModel.updateNotificationSettings(enabled: true)

--- a/Kiero/Kiero/Presentation/WishWell/WishWellViewModel.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellViewModel.swift
@@ -65,6 +65,9 @@ final class WishWellViewModel: BaseViewModel, ViewModelType {
                 guard let self = self else { return Empty().eraseToAnyPublisher()}
                 return self.service.purchaseCoupon(couponId: couponId)
                     .handleEvents(receiveOutput: { [weak self] purchased in
+                        AmplitudeManager.shared.track(.wishPurchased, properties: [
+                            AnalyticsEventProperty.price: purchased.price
+                        ])
                         self?.purchaseCompletedSubject.send(purchased)
                     })
                     .catch { [weak self] err -> Empty<Coupon, Never> in

--- a/Kiero/Kiero/Presentation/WishWell/WishWellViewModel.swift
+++ b/Kiero/Kiero/Presentation/WishWell/WishWellViewModel.swift
@@ -65,9 +65,7 @@ final class WishWellViewModel: BaseViewModel, ViewModelType {
                 guard let self = self else { return Empty().eraseToAnyPublisher()}
                 return self.service.purchaseCoupon(couponId: couponId)
                     .handleEvents(receiveOutput: { [weak self] purchased in
-                        AmplitudeManager.shared.track(.wishPurchased, properties: [
-                            AnalyticsEventProperty.price: purchased.price
-                        ])
+                        AmplitudeManager.shared.track(.wishPurchased(price: purchased.price))
                         self?.purchaseCompletedSubject.send(purchased)
                     })
                     .catch { [weak self] err -> Empty<Coupon, Never> in


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #352
<br>

## 🍎 작업 내용
**앰플리튜드 이벤트 18개 연동** 
  - Amplitude-Swift 1.18.6 SPM 추가, Parent/Child 두 타겟 모두 링크
  - Debug는 DEV(792387), Release는 PROD(839638) 프로젝트로 분기
  - 기획 문서 기준 P0 이벤트 18개 + User Properties 연결

**로컬 세팅 필요**
- Config.xcconfig 파일을 공유해드리겠습니다.

<br>

## 💬 리뷰 코멘트
**자녀 지표 노이즈**
- 앱 특성상 자녀는 기기 변경 시 새 유저로 집계됩니다. 

**SDK 자동 수집 이벤트**
- `session_start` / `session_end` / `$identify`가 18개 외에 추가로 찍힙니다! DAU·리텐션 차트가 세션 데이터를 전제로 해서 유지를 권장한다고 합니다.
<br>

## 📚 참고 문헌
- [Amplitude Swift 사용해보기](https://velog.io/@mskim98/Amplitude-Swift-%EC%82%AC%EC%9A%A9%ED%95%B4%EB%B3%B4%EA%B8%B0)