### PR TITLE
[feat] #354 앱 업데이트 정책 추가

### DIFF
--- a/Kiero/Kiero.xcodeproj/project.pbxproj
+++ b/Kiero/Kiero.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		AEF67B3A2F4C5C46007319A0 /* KingfisherWebP in Frameworks */ = {isa = PBXBuildFile; productRef = AEF67B392F4C5C46007319A0 /* KingfisherWebP */; };
 		AEF67B502F4C6C41007319A0 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = AEF67B4F2F4C6C41007319A0 /* Lottie */; };
 		AEF67B522F4C6C53007319A0 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = AEF67B512F4C6C53007319A0 /* Lottie */; };
+		F6378B57302B6AAC0057DED9 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = F6378B56302B6AAC0057DED9 /* FirebaseRemoteConfig */; };
+		F6378B59302B6ABA0057DED9 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = F6378B58302B6ABA0057DED9 /* FirebaseRemoteConfig */; };
 		F689777E2F18102D004D5783 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = F6B015D52F123F0D007B1EE4 /* KakaoSDK */; };
 		F689777F2F18102D004D5783 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = F6B015D92F123F0D007B1EE4 /* KakaoSDKUser */; };
 		F68977802F18102D004D5783 /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = F6B018512F136542007B1EE4 /* CombineMoya */; };
@@ -95,6 +97,7 @@
 				AEF67B522F4C6C53007319A0 /* Lottie in Frameworks */,
 				2455DCE52F23628F00836E3D /* Then in Frameworks */,
 				2455DCE62F23628F00836E3D /* Moya in Frameworks */,
+				F6378B59302B6ABA0057DED9 /* FirebaseRemoteConfig in Frameworks */,
 				2455DCE72F23628F00836E3D /* KakaoSDKAuth in Frameworks */,
 				AEF67B3A2F4C5C46007319A0 /* KingfisherWebP in Frameworks */,
 			);
@@ -114,6 +117,7 @@
 				249C641A2F0FA1F50016D6B7 /* Moya in Frameworks */,
 				F6B015D82F123F0D007B1EE4 /* KakaoSDKAuth in Frameworks */,
 				AE418AB42FC6CCE8000B043E /* FirebaseMessaging in Frameworks */,
+				F6378B57302B6AAC0057DED9 /* FirebaseRemoteConfig in Frameworks */,
 				AE418AB62FC6CCF0000B043E /* FirebaseCore in Frameworks */,
 				A100000000000000000000C2 /* AmplitudeSwift in Frameworks */,
 				AEF67B382F4C5C20007319A0 /* KingfisherWebP in Frameworks */,
@@ -183,6 +187,7 @@
 				AE418AB72FC6CCFE000B043E /* FirebaseCore */,
 				AE418AB92FC6CD03000B043E /* FirebaseMessaging */,
 				A100000000000000000000B1 /* AmplitudeSwift */,
+				F6378B58302B6ABA0057DED9 /* FirebaseRemoteConfig */,
 			);
 			productName = Kiero;
 			productReference = 2455DCEC2F23628F00836E3D /* Kiero_Child.app */;
@@ -218,6 +223,7 @@
 				AE418AB32FC6CCE8000B043E /* FirebaseMessaging */,
 				AE418AB52FC6CCF0000B043E /* FirebaseCore */,
 				A100000000000000000000C1 /* AmplitudeSwift */,
+				F6378B56302B6AAC0057DED9 /* FirebaseRemoteConfig */,
 			);
 			productName = Kiero;
 			productReference = 24DF50CB2F0A5173007146AC /* Kiero_Parent.app */;
@@ -328,7 +334,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Kiero.Child.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -367,7 +373,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Kiero.Child;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -405,7 +411,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Kiero.Parent.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -442,7 +448,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Kiero.Parent;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -834,6 +840,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AEF67B4E2F4C6C41007319A0 /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
+		};
+		F6378B56302B6AAC0057DED9 /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AEB0F9DF2FC5CC5500964FED /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
+		};
+		F6378B58302B6ABA0057DED9 /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AEB0F9DF2FC5CC5500964FED /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
 		};
 		F6B015D52F123F0D007B1EE4 /* KakaoSDK */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Kiero/Kiero/Application/AppUpdate/AppUpdateAlertPresenter.swift
+++ b/Kiero/Kiero/Application/AppUpdate/AppUpdateAlertPresenter.swift
@@ -2,6 +2,8 @@
 //  AppUpdateAlertPresenter.swift
 //  Kiero
 //
+//  Created by 정윤아 on 9/4/26.
+//
 
 import UIKit
 

--- a/Kiero/Kiero/Application/AppUpdate/AppUpdateAlertPresenter.swift
+++ b/Kiero/Kiero/Application/AppUpdate/AppUpdateAlertPresenter.swift
@@ -1,0 +1,124 @@
+//
+//  AppUpdateAlertPresenter.swift
+//  Kiero
+//
+
+import UIKit
+
+@MainActor
+final class AppUpdateAlertPresenter {
+
+    private weak var window: UIWindow?
+    private var isUpdateAlertPresented = false
+
+    func checkForUpdate(in window: UIWindow?) {
+        guard let window else { return }
+
+        self.window = window
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            let updateType = await AppUpdateManager.shared.checkForUpdate()
+            handleUpdate(updateType)
+        }
+    }
+
+    private func handleUpdate(_ updateType: AppUpdateType) {
+        switch updateType {
+        case .none:
+            break
+
+        case .optional:
+            showOptionalUpdateAlert()
+
+        case .required:
+            showRequiredUpdateAlert()
+        }
+    }
+
+    private func showOptionalUpdateAlert() {
+        guard !isUpdateAlertPresented else { return }
+        guard let viewController = topViewController() else { return }
+
+        isUpdateAlertPresented = true
+
+        let alert = UIAlertController(
+            title: "새로운 업데이트",
+            message: "새로운 버전이 출시되었어요.\n업데이트하시겠어요?",
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "나중에", style: .cancel) { [weak self] _ in
+            self?.isUpdateAlertPresented = false
+        })
+
+        alert.addAction(UIAlertAction(title: "업데이트", style: .default) { [weak self] _ in
+            guard let self else { return }
+
+            isUpdateAlertPresented = false
+            openAppStore(shouldRetryRequiredAlert: false)
+        })
+
+        viewController.present(alert, animated: true)
+    }
+
+    private func showRequiredUpdateAlert() {
+        guard !isUpdateAlertPresented else { return }
+        guard let viewController = topViewController() else { return }
+
+        isUpdateAlertPresented = true
+
+        let alert = UIAlertController(
+            title: "필수 업데이트",
+            message: "서비스 이용을 위해\n최신 버전으로 업데이트해 주세요.",
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "업데이트", style: .default) { [weak self] _ in
+            guard let self else { return }
+
+            isUpdateAlertPresented = false
+            openAppStore(shouldRetryRequiredAlert: true)
+        })
+
+        viewController.present(alert, animated: true)
+    }
+
+    private func openAppStore(shouldRetryRequiredAlert: Bool) {
+        UIApplication.shared.open(Config.appStoreURL, options: [:]) { [weak self] didOpen in
+            guard !didOpen else { return }
+
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+
+#if DEBUG
+                print("❌ [AppUpdateAlertPresenter] App Store 열기 실패")
+#endif
+
+                guard shouldRetryRequiredAlert else { return }
+
+                try? await Task.sleep(nanoseconds: 300_000_000)
+                showRequiredUpdateAlert()
+            }
+        }
+    }
+
+    private func topViewController(from viewController: UIViewController? = nil) -> UIViewController? {
+        let current = viewController ?? window?.rootViewController
+
+        if let navigationController = current as? UINavigationController {
+            return topViewController(from: navigationController.visibleViewController)
+        }
+
+        if let tabBarController = current as? UITabBarController {
+            return topViewController(from: tabBarController.selectedViewController)
+        }
+
+        if let presentedViewController = current?.presentedViewController {
+            return topViewController(from: presentedViewController)
+        }
+
+        return current
+    }
+}

--- a/Kiero/Kiero/Application/AppUpdate/AppUpdateManager.swift
+++ b/Kiero/Kiero/Application/AppUpdate/AppUpdateManager.swift
@@ -1,0 +1,156 @@
+//
+//  AppUpdateManager.swift
+//  Kiero
+//
+//  Created by 안치욱 on 8/8/26.
+//
+
+import Foundation
+
+import FirebaseRemoteConfig
+
+@MainActor
+final class AppUpdateManager {
+    
+    static let shared = AppUpdateManager()
+    
+    private enum RemoteConfigKey {
+        static let parentMinimumVersion = "parent_minimum_version"
+        static let parentLatestVersion = "parent_latest_version"
+        
+        static let childMinimumVersion = "child_minimum_version"
+        static let childLatestVersion = "child_latest_version"
+    }
+    
+    private let remoteConfig: RemoteConfig
+    
+    private var isChecking = false
+    
+    private init() {
+        remoteConfig = RemoteConfig.remoteConfig()
+        configureRemoteConfig()
+    }
+    
+    // MARK: - Public
+    
+    func checkForUpdate() async -> AppUpdateType {
+        guard !isChecking else {
+            return .none
+        }
+        
+        isChecking = true
+        defer { isChecking = false }
+        
+        do {
+            _ = try await remoteConfig.fetchAndActivate()
+            
+            let versions = remoteVersions()
+            
+            let updateType = determineUpdateType(
+                currentVersion: currentAppVersion,
+                minimumVersion: versions.minimum,
+                latestVersion: versions.latest
+            )
+            
+            print("""
+            
+            ✅ [AppUpdateManager]
+            currentVersion: \(currentAppVersion)
+            minimumVersion: \(versions.minimum)
+            latestVersion: \(versions.latest)
+            updateType: \(updateType)
+            
+            """)
+            
+            return updateType
+            
+        } catch {
+            print("❌ [AppUpdateManager] Remote Config fetch 실패: \(error)")
+            
+            return .none
+        }
+    }
+    
+    // MARK: - Remote Config
+    
+    private func configureRemoteConfig() {
+        let settings = RemoteConfigSettings()
+        
+#if DEBUG
+        settings.minimumFetchInterval = 0
+#else
+        settings.minimumFetchInterval = 60 * 60
+#endif
+        
+        remoteConfig.configSettings = settings
+        
+        remoteConfig.setDefaults([
+            RemoteConfigKey.parentMinimumVersion: "1.0.0" as NSObject,
+            RemoteConfigKey.parentLatestVersion: "1.0.0" as NSObject,
+            RemoteConfigKey.childMinimumVersion: "1.0.0" as NSObject,
+            RemoteConfigKey.childLatestVersion: "1.0.0" as NSObject
+        ])
+    }
+    
+    private func remoteVersions() -> (
+        minimum: String,
+        latest: String
+    ) {
+#if KIERO_PARENT
+        let minimumKey = RemoteConfigKey.parentMinimumVersion
+        let latestKey = RemoteConfigKey.parentLatestVersion
+#elseif KIERO_CHILD
+        let minimumKey = RemoteConfigKey.childMinimumVersion
+        let latestKey = RemoteConfigKey.childLatestVersion
+#else
+        let minimumKey = RemoteConfigKey.parentMinimumVersion
+        let latestKey = RemoteConfigKey.parentLatestVersion
+#endif
+        
+        return (
+            minimum: remoteConfig[minimumKey].stringValue ?? "1.0.0",
+            latest: remoteConfig[latestKey].stringValue ?? "1.0.0"
+        )
+    }
+    
+    // MARK: - Version
+    
+    private var currentAppVersion: String {
+        Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String ?? "0.0.0"
+    }
+    
+    private func determineUpdateType(
+        currentVersion: String,
+        minimumVersion: String,
+        latestVersion: String
+    ) -> AppUpdateType {
+        
+        if isLowerVersion(
+            currentVersion,
+            than: minimumVersion
+        ) {
+            return .required
+        }
+        
+        if isLowerVersion(
+            currentVersion,
+            than: latestVersion
+        ) {
+            return .optional
+        }
+        
+        return .none
+    }
+    
+    private func isLowerVersion(
+        _ lhs: String,
+        than rhs: String
+    ) -> Bool {
+        lhs.compare(
+            rhs,
+            options: .numeric
+        ) == .orderedAscending
+    }
+}

--- a/Kiero/Kiero/Application/AppUpdate/AppUpdateManager.swift
+++ b/Kiero/Kiero/Application/AppUpdate/AppUpdateManager.swift
@@ -11,117 +11,164 @@ import FirebaseRemoteConfig
 
 @MainActor
 final class AppUpdateManager {
-    
+
     static let shared = AppUpdateManager()
-    
+
     private enum RemoteConfigKey {
         static let latestVersion = "ios_latest_version"
         static let minimumVersion = "ios_min_force_version"
+        static let defaultVersion = "1.0.0"
     }
-    
+
     private let remoteConfig: RemoteConfig
-    private var isChecking = false
-    
+    private var updateCheckTask: Task<AppUpdateType, Never>?
+
     private init() {
         remoteConfig = RemoteConfig.remoteConfig()
         configureRemoteConfig()
     }
-    
+
     // MARK: - Public
-    
+
     func checkForUpdate() async -> AppUpdateType {
-        guard !isChecking else { return .none }
-        
-        isChecking = true
-        defer { isChecking = false }
-        
-        do {
-            _ = try await remoteConfig.fetchAndActivate()
-            
-            let minimumVersion = remoteConfig[RemoteConfigKey.minimumVersion].stringValue ?? "1.0.0"
-            let latestVersion = remoteConfig[RemoteConfigKey.latestVersion].stringValue ?? "1.0.0"
-            
-            let updateType = determineUpdateType(
-                currentVersion: currentAppVersion,
-                minimumVersion: minimumVersion,
-                latestVersion: latestVersion
-            )
-            
-            print("""
-            ✅ [AppUpdateManager]
-            bundleId: \(Bundle.main.bundleIdentifier ?? "")
-            currentVersion: \(currentAppVersion)
-            minimumVersion: \(minimumVersion)
-            latestVersion: \(latestVersion)
-            updateType: \(updateType)
-            """)
-            
-            return updateType
-            
-        } catch {
-            print("❌ [AppUpdateManager] Remote Config fetch 실패: \(error)")
-            return .none
+        if let updateCheckTask {
+            return await updateCheckTask.value
         }
+
+        let task = Task { () -> AppUpdateType in
+            do {
+                _ = try await remoteConfig.fetchAndActivate()
+            } catch {
+#if DEBUG
+                print("❌ Remote Config fetch 실패: \(error)")
+#endif
+            }
+
+            return determineUpdateTypeFromActiveConfig()
+        }
+
+        updateCheckTask = task
+
+        let result = await task.value
+        updateCheckTask = nil
+
+        return result
     }
-    
+
     // MARK: - Remote Config
-    
+
     private func configureRemoteConfig() {
         let settings = RemoteConfigSettings()
-        
-#if DEBUG
+
+        // 강제 업데이트 정책이 게시되면 다음 검사에서 바로 반영합니다.
         settings.minimumFetchInterval = 0
-#else
-        settings.minimumFetchInterval = 60 * 60
-#endif
-        
         remoteConfig.configSettings = settings
-        
+
         remoteConfig.setDefaults([
-            RemoteConfigKey.minimumVersion: "1.0.0" as NSObject,
-            RemoteConfigKey.latestVersion: "1.0.0" as NSObject
+            RemoteConfigKey.minimumVersion: RemoteConfigKey.defaultVersion as NSObject,
+            RemoteConfigKey.latestVersion: RemoteConfigKey.defaultVersion as NSObject
         ])
     }
-    
+
+    private func determineUpdateTypeFromActiveConfig() -> AppUpdateType {
+        let minimumVersion = remoteVersion(forKey: RemoteConfigKey.minimumVersion)
+        let latestVersion = remoteVersion(forKey: RemoteConfigKey.latestVersion)
+
+        let updateType = determineUpdateType(
+            currentVersion: currentAppVersion,
+            minimumVersion: minimumVersion,
+            latestVersion: latestVersion
+        )
+
+#if DEBUG
+        print("""
+        ✅ [AppUpdateManager]
+        bundleId: \(Bundle.main.bundleIdentifier ?? "")
+        currentVersion: \(currentAppVersion)
+        minimumVersion: \(minimumVersion)
+        latestVersion: \(latestVersion)
+        updateType: \(updateType)
+        """)
+#endif
+
+        return updateType
+    }
+
+    private func remoteVersion(forKey key: String) -> String {
+        let version = remoteConfig[key].stringValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !version.isEmpty else {
+            return RemoteConfigKey.defaultVersion
+        }
+
+        return version
+    }
+
     // MARK: - Version
-    
+
     private var currentAppVersion: String {
         Bundle.main.object(
             forInfoDictionaryKey: "CFBundleShortVersionString"
         ) as? String ?? "0.0.0"
     }
-    
+
     private func determineUpdateType(
         currentVersion: String,
         minimumVersion: String,
         latestVersion: String
     ) -> AppUpdateType {
-        
-        if isLowerVersion(currentVersion, than: minimumVersion) {
+        guard isValidVersion(currentVersion),
+              isValidVersion(minimumVersion),
+              isValidVersion(latestVersion) else {
+#if DEBUG
+            print("❌ [AppUpdateManager] 잘못된 버전 형식")
+#endif
+            return .none
+        }
+
+        let effectiveMinimumVersion = isLowerVersion(latestVersion, than: minimumVersion)
+            ? latestVersion
+            : minimumVersion
+
+        if isLowerVersion(currentVersion, than: effectiveMinimumVersion) {
             return .required
         }
-        
+
         if isLowerVersion(currentVersion, than: latestVersion) {
             return .optional
         }
-        
+
         return .none
     }
-    
+
+    private func isValidVersion(_ version: String) -> Bool {
+        let components = version.split(
+            separator: ".",
+            omittingEmptySubsequences: false
+        )
+
+        return (1...3).contains(components.count)
+            && components.allSatisfy { component in
+                guard let number = Int(component) else { return false }
+                return number >= 0
+            }
+    }
+
     private func isLowerVersion(_ lhs: String, than rhs: String) -> Bool {
         normalizedVersion(lhs).compare(
             normalizedVersion(rhs),
             options: .numeric
         ) == .orderedAscending
     }
-    
+
     private func normalizedVersion(_ version: String) -> String {
         var components = version.split(separator: ".").map(String.init)
-        
+
         while components.count < 3 {
             components.append("0")
         }
-        
+
         return components.prefix(3).joined(separator: ".")
     }
 }

--- a/Kiero/Kiero/Application/AppUpdate/AppUpdateManager.swift
+++ b/Kiero/Kiero/Application/AppUpdate/AppUpdateManager.swift
@@ -15,15 +15,11 @@ final class AppUpdateManager {
     static let shared = AppUpdateManager()
     
     private enum RemoteConfigKey {
-        static let parentMinimumVersion = "parent_minimum_version"
-        static let parentLatestVersion = "parent_latest_version"
-        
-        static let childMinimumVersion = "child_minimum_version"
-        static let childLatestVersion = "child_latest_version"
+        static let latestVersion = "ios_latest_version"
+        static let minimumVersion = "ios_min_force_version"
     }
     
     private let remoteConfig: RemoteConfig
-    
     private var isChecking = false
     
     private init() {
@@ -34,9 +30,7 @@ final class AppUpdateManager {
     // MARK: - Public
     
     func checkForUpdate() async -> AppUpdateType {
-        guard !isChecking else {
-            return .none
-        }
+        guard !isChecking else { return .none }
         
         isChecking = true
         defer { isChecking = false }
@@ -44,29 +38,28 @@ final class AppUpdateManager {
         do {
             _ = try await remoteConfig.fetchAndActivate()
             
-            let versions = remoteVersions()
+            let minimumVersion = remoteConfig[RemoteConfigKey.minimumVersion].stringValue ?? "1.0.0"
+            let latestVersion = remoteConfig[RemoteConfigKey.latestVersion].stringValue ?? "1.0.0"
             
             let updateType = determineUpdateType(
                 currentVersion: currentAppVersion,
-                minimumVersion: versions.minimum,
-                latestVersion: versions.latest
+                minimumVersion: minimumVersion,
+                latestVersion: latestVersion
             )
             
             print("""
-            
             ✅ [AppUpdateManager]
+            bundleId: \(Bundle.main.bundleIdentifier ?? "")
             currentVersion: \(currentAppVersion)
-            minimumVersion: \(versions.minimum)
-            latestVersion: \(versions.latest)
+            minimumVersion: \(minimumVersion)
+            latestVersion: \(latestVersion)
             updateType: \(updateType)
-            
             """)
             
             return updateType
             
         } catch {
             print("❌ [AppUpdateManager] Remote Config fetch 실패: \(error)")
-            
             return .none
         }
     }
@@ -85,32 +78,9 @@ final class AppUpdateManager {
         remoteConfig.configSettings = settings
         
         remoteConfig.setDefaults([
-            RemoteConfigKey.parentMinimumVersion: "1.0.0" as NSObject,
-            RemoteConfigKey.parentLatestVersion: "1.0.0" as NSObject,
-            RemoteConfigKey.childMinimumVersion: "1.0.0" as NSObject,
-            RemoteConfigKey.childLatestVersion: "1.0.0" as NSObject
+            RemoteConfigKey.minimumVersion: "1.0.0" as NSObject,
+            RemoteConfigKey.latestVersion: "1.0.0" as NSObject
         ])
-    }
-    
-    private func remoteVersions() -> (
-        minimum: String,
-        latest: String
-    ) {
-#if KIERO_PARENT
-        let minimumKey = RemoteConfigKey.parentMinimumVersion
-        let latestKey = RemoteConfigKey.parentLatestVersion
-#elseif KIERO_CHILD
-        let minimumKey = RemoteConfigKey.childMinimumVersion
-        let latestKey = RemoteConfigKey.childLatestVersion
-#else
-        let minimumKey = RemoteConfigKey.parentMinimumVersion
-        let latestKey = RemoteConfigKey.parentLatestVersion
-#endif
-        
-        return (
-            minimum: remoteConfig[minimumKey].stringValue ?? "1.0.0",
-            latest: remoteConfig[latestKey].stringValue ?? "1.0.0"
-        )
     }
     
     // MARK: - Version
@@ -127,30 +97,31 @@ final class AppUpdateManager {
         latestVersion: String
     ) -> AppUpdateType {
         
-        if isLowerVersion(
-            currentVersion,
-            than: minimumVersion
-        ) {
+        if isLowerVersion(currentVersion, than: minimumVersion) {
             return .required
         }
         
-        if isLowerVersion(
-            currentVersion,
-            than: latestVersion
-        ) {
+        if isLowerVersion(currentVersion, than: latestVersion) {
             return .optional
         }
         
         return .none
     }
     
-    private func isLowerVersion(
-        _ lhs: String,
-        than rhs: String
-    ) -> Bool {
-        lhs.compare(
-            rhs,
+    private func isLowerVersion(_ lhs: String, than rhs: String) -> Bool {
+        normalizedVersion(lhs).compare(
+            normalizedVersion(rhs),
             options: .numeric
         ) == .orderedAscending
+    }
+    
+    private func normalizedVersion(_ version: String) -> String {
+        var components = version.split(separator: ".").map(String.init)
+        
+        while components.count < 3 {
+            components.append("0")
+        }
+        
+        return components.prefix(3).joined(separator: ".")
     }
 }

--- a/Kiero/Kiero/Application/AppUpdate/AppUpdateType.swift
+++ b/Kiero/Kiero/Application/AppUpdate/AppUpdateType.swift
@@ -5,8 +5,6 @@
 //  Created by 안치욱 on 8/8/26.
 //
 
-import Foundation
-
 enum AppUpdateType {
     case none
     case optional

--- a/Kiero/Kiero/Application/AppUpdate/AppUpdateType.swift
+++ b/Kiero/Kiero/Application/AppUpdate/AppUpdateType.swift
@@ -1,0 +1,14 @@
+//
+//  AppUpdateType.swift
+//  Kiero
+//
+//  Created by 안치욱 on 8/8/26.
+//
+
+import Foundation
+
+enum AppUpdateType {
+    case none
+    case optional
+    case required
+}

--- a/Kiero/Kiero/Application/SceneDelegate.swift
+++ b/Kiero/Kiero/Application/SceneDelegate.swift
@@ -12,7 +12,7 @@ import KakaoSDKAuth
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
-    private var isUpdateAlertPresented = false
+    private let appUpdateAlertPresenter = AppUpdateAlertPresenter()
     
 #if KIERO_PARENT
     var parentCoordinator: ParentCoordinator?
@@ -67,7 +67,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        checkAppUpdate()
+        appUpdateAlertPresenter.checkForUpdate(in: window)
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
@@ -81,90 +81,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func sceneDidEnterBackground(_ scene: UIScene) {
         SseStreamManager.shared.pause()
-    }
-}
-
-private extension SceneDelegate {
-    
-    func checkAppUpdate() {
-        Task { @MainActor in
-            let updateType = await AppUpdateManager.shared.checkForUpdate()
-            handleUpdate(updateType)
-        }
-    }
-    
-    func handleUpdate(_ updateType: AppUpdateType) {
-        switch updateType {
-        case .none:
-            break
-            
-        case .optional:
-            showOptionalUpdateAlert()
-            
-        case .required:
-            showRequiredUpdateAlert()
-        }
-    }
-    
-    func showOptionalUpdateAlert() {
-        guard !isUpdateAlertPresented else { return }
-        guard let viewController = topViewController() else { return }
-        
-        isUpdateAlertPresented = true
-        
-        let alert = UIAlertController(title: "새로운 업데이트",
-                                      message: "새로운 버전이 출시되었어요.\n업데이트하시겠어요?",
-                                      preferredStyle: .alert)
-        
-        alert.addAction(UIAlertAction(title: "나중에", style: .cancel) { [weak self] _ in
-            self?.isUpdateAlertPresented = false
-        })
-        
-        alert.addAction(UIAlertAction(title: "업데이트", style: .default) { [weak self] _ in
-            self?.isUpdateAlertPresented = false
-            self?.openAppStore()
-        })
-        
-        viewController.present(alert, animated: true)
-    }
-    
-    func showRequiredUpdateAlert() {
-        guard !isUpdateAlertPresented else { return }
-        guard let viewController = topViewController() else { return }
-        
-        isUpdateAlertPresented = true
-        
-        let alert = UIAlertController(title: "필수 업데이트",
-                                      message: "서비스 이용을 위해\n최신 버전으로 업데이트해 주세요.",
-                                      preferredStyle: .alert)
-        
-        alert.addAction(UIAlertAction(title: "업데이트", style: .default) { [weak self] _ in
-            self?.openAppStore()
-        })
-        
-        viewController.present(alert, animated: true)
-    }
-    
-    func openAppStore() {
-        print(Config.appStoreURL)
-        UIApplication.shared.open(Config.appStoreURL)
-    }
-    
-    func topViewController(from viewController: UIViewController? = nil) -> UIViewController? {
-        let current = viewController ?? window?.rootViewController
-        
-        if let navigationController = current as? UINavigationController {
-            return topViewController(from: navigationController.visibleViewController)
-        }
-        
-        if let tabBarController = current as? UITabBarController {
-            return topViewController(from: tabBarController.selectedViewController)
-        }
-        
-        if let presentedViewController = current?.presentedViewController {
-            return topViewController(from: presentedViewController)
-        }
-        
-        return current
     }
 }

--- a/Kiero/Kiero/Application/SceneDelegate.swift
+++ b/Kiero/Kiero/Application/SceneDelegate.swift
@@ -12,6 +12,7 @@ import KakaoSDKAuth
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    private var isUpdateAlertPresented = false
     
 #if KIERO_PARENT
     var parentCoordinator: ParentCoordinator?
@@ -44,7 +45,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
         }
     }
-
     
     func changeRootViewController(_ vc: UIViewController, animated: Bool = true) {
         guard let window = self.window else { return }
@@ -67,8 +67,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+        checkAppUpdate()
     }
 
     func sceneWillResignActive(_ scene: UIScene) {
@@ -82,5 +81,90 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func sceneDidEnterBackground(_ scene: UIScene) {
         SseStreamManager.shared.pause()
+    }
+}
+
+private extension SceneDelegate {
+    
+    func checkAppUpdate() {
+        Task { @MainActor in
+            let updateType = await AppUpdateManager.shared.checkForUpdate()
+            handleUpdate(updateType)
+        }
+    }
+    
+    func handleUpdate(_ updateType: AppUpdateType) {
+        switch updateType {
+        case .none:
+            break
+            
+        case .optional:
+            showOptionalUpdateAlert()
+            
+        case .required:
+            showRequiredUpdateAlert()
+        }
+    }
+    
+    func showOptionalUpdateAlert() {
+        guard !isUpdateAlertPresented else { return }
+        guard let viewController = topViewController() else { return }
+        
+        isUpdateAlertPresented = true
+        
+        let alert = UIAlertController(title: "새로운 업데이트",
+                                      message: "새로운 버전이 출시되었어요.\n업데이트하시겠어요?",
+                                      preferredStyle: .alert)
+        
+        alert.addAction(UIAlertAction(title: "나중에", style: .cancel) { [weak self] _ in
+            self?.isUpdateAlertPresented = false
+        })
+        
+        alert.addAction(UIAlertAction(title: "업데이트", style: .default) { [weak self] _ in
+            self?.isUpdateAlertPresented = false
+            self?.openAppStore()
+        })
+        
+        viewController.present(alert, animated: true)
+    }
+    
+    func showRequiredUpdateAlert() {
+        guard !isUpdateAlertPresented else { return }
+        guard let viewController = topViewController() else { return }
+        
+        isUpdateAlertPresented = true
+        
+        let alert = UIAlertController(title: "필수 업데이트",
+                                      message: "서비스 이용을 위해\n최신 버전으로 업데이트해 주세요.",
+                                      preferredStyle: .alert)
+        
+        alert.addAction(UIAlertAction(title: "업데이트", style: .default) { [weak self] _ in
+            self?.openAppStore()
+        })
+        
+        viewController.present(alert, animated: true)
+    }
+    
+    func openAppStore() {
+        print(Config.appStoreURL)
+        UIApplication.shared.open(Config.appStoreURL)
+    }
+    
+    func topViewController(from viewController: UIViewController? = nil) -> UIViewController? {
+        let current = viewController ?? window?.rootViewController
+        
+        if let navigationController = current as? UINavigationController {
+            return topViewController(from: navigationController.visibleViewController)
+        }
+        
+        if let tabBarController = current as? UITabBarController {
+            return topViewController(from: tabBarController.selectedViewController)
+        }
+        
+        if let presentedViewController = current?.presentedViewController {
+            return topViewController(from: presentedViewController)
+        }
+        
+        return current
     }
 }

--- a/Kiero/Kiero/ChildInfo.plist
+++ b/Kiero/Kiero/ChildInfo.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CHILD_APPSTORE_ID</key>
+	<string>$(CHILD_APPSTORE_ID)</string>
 	<key>CFBundleDisplayName</key>
 	<string>Kiero</string>
 	<key>AMPLITUDE_API_KEY_DEV</key>

--- a/Kiero/Kiero/Network/Base/Config.swift
+++ b/Kiero/Kiero/Network/Base/Config.swift
@@ -14,6 +14,11 @@ enum Config {
             static let KAKAO_NATIVE_APP_KEY = "KAKAO_NATIVE_APP_KEY"
             static let AMPLITUDE_API_KEY_DEV = "AMPLITUDE_API_KEY_DEV"
             static let AMPLITUDE_API_KEY_PROD = "AMPLITUDE_API_KEY_PROD"
+#if KIERO_PARENT
+            static let APPSTORE_ID = "PARENT_APPSTORE_ID"
+#elseif KIERO_CHILD
+            static let APPSTORE_ID = "CHILD_APPSTORE_ID"
+#endif
         }
     }
     
@@ -63,6 +68,14 @@ extension Config {
     static let sseURL: URL = {
         guard let url = URL(string: baseURL + "/api/v1/subscribe") else {
             fatalError("구성된 SSE_URL이 유효한 URL 형식이 아닙니다: \(baseURL)")
+        }
+        return url
+    }()
+    
+    static let appStoreURL: URL = {
+        guard let appStoreID = Config.infoDictionary[Keys.Plist.APPSTORE_ID] as? String,
+              let url = URL(string: "itms-apps://itunes.apple.com/us/app/id\(appStoreID)") else {
+            fatalError("APPSTORE_ID가 유효하지 않습니다.")
         }
         return url
     }()

--- a/Kiero/Kiero/ParentInfo.plist
+++ b/Kiero/Kiero/ParentInfo.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PARENT_APPSTORE_ID</key>
+	<string>$(PARENT_APPSTORE_ID)</string>
 	<key>CFBundleDisplayName</key>
 	<string>Kiero</string>
 	<key>AMPLITUDE_API_KEY_DEV</key>


### PR DESCRIPTION
## 📟 연결된 이슈
- closed #354 
<br>

## 🍎 작업 내용
메인 기능

### ✨ 앱 업데이트 정책 추가

- Firebase Remote Config 기반 앱 업데이트 정책 추가
- 현재 앱 버전과 Remote Config 버전을 비교하여 업데이트 여부 판단
- 선택 업데이트(Optional) / 강제 업데이트(Required) 정책 분기 추가
- 앱 활성화(`sceneDidBecomeActive`) 시 최신 버전 확인 로직 추가
- App Store 이동 기능 추가
- Firebase Remote Config를 통해 코드 수정 없이 업데이트 정책을 변경할 수 있도록 구현했습니다.

### 🔧 Firebase Remote Config 설정

- iOS 전용 Remote Config 파라미터 추가
  - `ios_latest_version`
  - `ios_min_force_version`
- Parent / Child / Dev 앱별 조건(Condition) 구성
- 앱별 최신 버전 및 최소 지원 버전 관리 가능하도록 설정

### 선택 / 강제 업데이트 정책

- **선택 업데이트(Optional)**
  - `ios_min_force_version ≤ 현재 버전 < ios_latest_version`
  - 최신 버전 업데이트를 권장하며, **나중에** 또는 **업데이트**를 선택할 수 있습니다.

- **강제 업데이트(Required)**
  - `현재 버전 < ios_min_force_version`
  - 서비스 이용을 위해 업데이트가 필요하며, **업데이트**만 선택할 수 있습니다.

- **최신 버전**
  - `현재 버전 ≥ ios_latest_version`
  - 업데이트 없이 정상적으로 서비스를 이용할 수 있습니다.


<br>

## 📸 스크린샷
| 기능/화면 | 화면1 | 화면2 |
|:---------:|:-------------:|:-------------:|
| 기능1 | <img src="https://github.com/user-attachments/assets/ea51e577-99c4-4223-8908-1cef859c3692" width="250"> | <img src="https://github.com/user-attachments/assets/2444982a-185d-4a64-8841-e66ce6d4587e" width="250"> |
| 기능1 | <img src="" width="250"> | <img src="" width="250"> |
<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/0ff3b0f5-dadf-4d8f-8b85-326895faa106" />
선택 업데이트 예시

## 업데이트 Firebase에 적용방법
1. Firebase Console 접속!
<img width="243" height="157" alt="image" src="https://github.com/user-attachments/assets/4e44bdb6-1cf4-4428-bb6e-62610bbaa3ad" />

2. 제품검색에 Remote Config 검색
<img width="1736" height="995" alt="image" src="https://github.com/user-attachments/assets/5450b66b-47cc-492d-82e8-92a171c74689" />

3. 매개변수 탭에 보면 여러가지가 있는데 앞에 `ios_` 붙어있는 녀석들만 보면 됩니다!
<img width="1374" height="811" alt="image" src="https://github.com/user-attachments/assets/1cac740b-9470-49c2-98e0-0e827ea1cff2" />
지금 보면 앱? 별로 다 파라미터에 조건을 걸어두었는데요.. 혹시나 나중에 완전히 분리가 되었을 때에 아이랑 부모랑 버전이 달라질 수 있는 경우를 대비해서 분리해두었습니다.

4. 연필모양 편집 아이콘을 누른뒤에 iOS Parent 혹은 iOS Child만 보면 됩니다..!!
<img width="591" height="389" alt="image" src="https://github.com/user-attachments/assets/2a275d41-029d-4eba-b9f2-88492a301a06" />

5. 수정한 뒤 저장 하고 `변경사항 모두 게시`를 누르면 적용됩니다! 

<br>



## 💬 리뷰 코멘트

- App Store 이동 기능 추가 -> 시뮬레이터로는 앱스토어가 안켜지는 이슈가 있어서 링크가 print 되게하여 확인했습니다
- 질문 있으시면 리뷰에 달아주세욥!! 
- 안드랑 매개변수 컨벤션과 아요 안드 분리관련 논의하면서 조금 늦어졌습니다.. ㅎㅎ,,,